### PR TITLE
feat(model): nightly pipeline — fetch results, retro-predict, eval, grow feature store

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,5 +4,9 @@ SEASON_ID=2026
 LEAGUE_ID=your_espn_league_id
 ENVIRONMENT=development
 DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+# Local dev postgres (docker compose up -d postgres):
+# DATABASE_URL=postgresql://fantasy:fantasy@localhost:5432/fantasy
 SEASON_START=2025-10-22
 INJURY_SCHEDULER_ENABLED=true
+# Morning job: fetch last night's NBA games, score the model, grow the feature store.
+MODEL_NIGHTLY_ENABLED=false

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     cors_origins: str = Field(default="http://localhost:5173", alias="CORS_ORIGINS")
     database_url: Optional[str] = Field(default=None, alias="DATABASE_URL")
     injury_scheduler_enabled: bool = Field(default=True, alias="INJURY_SCHEDULER_ENABLED")
+    model_nightly_enabled: bool = Field(default=False, alias="MODEL_NIGHTLY_ENABLED")
     model_config = SettingsConfigDict(
         env_file=".env",             # Loads .env if it exists
         env_file_encoding="utf-8",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from app.services.data_provider import DataProvider
 from app.services import injury_service
 from app.services import estimator_scheduler
+from app.services import model_nightly_scheduler
 
 # Configure logging
 logging.basicConfig(
@@ -49,6 +50,10 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("Injury scheduler disabled via INJURY_SCHEDULER_ENABLED=false")
     asyncio.create_task(estimator_scheduler.start_scheduler())
+    if settings.model_nightly_enabled:
+        asyncio.create_task(model_nightly_scheduler.start_scheduler())
+    else:
+        logger.info("Model nightly scheduler disabled via MODEL_NIGHTLY_ENABLED=false")
     yield
     # Shutdown
     try:

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -609,6 +609,188 @@ class DBService:
             logger.error(f"Failed to load all injury statuses: {e}")
             return []
 
+    # --- nightly model pipeline (feature-store rows / eval results / runs) ---
+
+    async def fs_counts(self) -> tuple[int, int]:
+        """(player rows, team rows) in the feature-store tables; (0, 0) on failure."""
+        pool = await self._get_pool()
+        if pool is None:
+            return 0, 0
+        try:
+            async with pool.acquire() as conn:
+                p = await conn.fetchval("SELECT COUNT(*) FROM fs_player_games")
+                t = await conn.fetchval("SELECT COUNT(*) FROM fs_team_games")
+                return int(p or 0), int(t or 0)
+        except Exception as e:
+            logger.error(f"Failed to count feature-store rows: {e}")
+            return 0, 0
+
+    async def fs_has_date(self, game_date: date) -> Optional[bool]:
+        """Whether the store already holds the night's rows. None = DB unavailable
+        (the caller must NOT treat that as 'safe to predict')."""
+        pool = await self._get_pool()
+        if pool is None:
+            return None
+        try:
+            async with pool.acquire() as conn:
+                return bool(await conn.fetchval(
+                    "SELECT EXISTS (SELECT 1 FROM fs_player_games WHERE game_date = $1)",
+                    game_date,
+                ))
+        except Exception as e:
+            logger.error(f"Failed to check fs rows for {game_date}: {e}")
+            return None
+
+    async def get_fs_rows_before(self, game_date: date) -> tuple[list[dict], list[dict]]:
+        pool = await self._get_pool()
+        if pool is None:
+            return [], []
+        try:
+            async with pool.acquire() as conn:
+                players = await conn.fetch(
+                    "SELECT * FROM fs_player_games WHERE game_date < $1", game_date
+                )
+                teams = await conn.fetch(
+                    "SELECT * FROM fs_team_games WHERE game_date < $1", game_date
+                )
+                return [dict(r) for r in players], [dict(r) for r in teams]
+        except Exception as e:
+            logger.error(f"Failed to fetch fs rows before {game_date}: {e}")
+            return [], []
+
+    async def insert_fs_rows(self, player_rows: list[tuple], team_rows: list[tuple]) -> bool:
+        """Append raw game rows. Tuple order must match the column lists below.
+        ON CONFLICT DO NOTHING makes re-runs of the same night no-ops."""
+        pool = await self._get_pool()
+        if pool is None:
+            return False
+        player_cols = (
+            "player_id, game_id, season, game_date, player_name, team_id, matchup, position, "
+            "min, pts, reb, oreb, dreb, ast, fg3m, fg3a, stl, blk, tov, fgm, fga, ftm, fta, pf, plus_minus"
+        )
+        team_cols = (
+            "team_id, game_id, season, game_date, team_name, matchup, "
+            "pts, reb, ast, stl, blk, fg3m, fg_pct, fga, fta, tov"
+        )
+        try:
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    if player_rows:
+                        await conn.executemany(
+                            f"INSERT INTO fs_player_games ({player_cols}) VALUES "
+                            f"({', '.join(f'${i + 1}' for i in range(25))}) "
+                            "ON CONFLICT (player_id, game_id) DO NOTHING",
+                            player_rows,
+                        )
+                    if team_rows:
+                        await conn.executemany(
+                            f"INSERT INTO fs_team_games ({team_cols}) VALUES "
+                            f"({', '.join(f'${i + 1}' for i in range(16))}) "
+                            "ON CONFLICT (team_id, game_id) DO NOTHING",
+                            team_rows,
+                        )
+            logger.info(f"Inserted {len(player_rows)} player / {len(team_rows)} team fs rows")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to insert fs rows: {e}")
+            return False
+
+    async def truncate_fs_tables(self) -> bool:
+        """Wipe the raw-row store (forced re-bootstrap starts from a clean slate)."""
+        pool = await self._get_pool()
+        if pool is None:
+            return False
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute("TRUNCATE fs_player_games, fs_team_games")
+            logger.info("Truncated feature-store tables")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to truncate feature-store tables: {e}")
+            return False
+
+    async def get_model_nightly_run(self, game_date: date) -> Optional[dict]:
+        pool = await self._get_pool()
+        if pool is None:
+            return None
+        try:
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    "SELECT * FROM model_nightly_runs WHERE game_date = $1", game_date
+                )
+                return dict(row) if row else None
+        except Exception as e:
+            logger.error(f"Failed to fetch model nightly run for {game_date}: {e}")
+            return None
+
+    async def upsert_model_nightly_run(
+        self, game_date: date, status: str, num_games: int, num_rows: int
+    ) -> bool:
+        pool = await self._get_pool()
+        if pool is None:
+            return False
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO model_nightly_runs (game_date, status, num_games, num_rows, ran_at)
+                    VALUES ($1, $2, $3, $4, NOW())
+                    ON CONFLICT (game_date) DO UPDATE SET
+                        status    = EXCLUDED.status,
+                        num_games = EXCLUDED.num_games,
+                        num_rows  = EXCLUDED.num_rows,
+                        ran_at    = NOW()
+                    """,
+                    game_date, status, num_games, num_rows,
+                )
+            logger.info(f"Marked model nightly run {game_date} as '{status}'")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to upsert model nightly run for {game_date}: {e}")
+            return False
+
+    async def insert_model_eval_rows(self, rows: list[tuple]) -> bool:
+        """Upsert predicted-vs-actual rows. Tuple order must match the columns below."""
+        pool = await self._get_pool()
+        if pool is None:
+            return False
+        stats = ["pts", "reb", "ast", "fg3m", "stl", "blk", "fgm", "fga", "ftm", "fta"]
+        cols = (
+            ["game_id", "player_id", "game_date", "player_name", "team_id",
+             "opponent_team_id", "is_home", "minutes", "eligible", "reason"]
+            + [f"pred_{s}" for s in stats]
+            + [f"actual_{s}" for s in stats]
+        )
+        updates = ",\n".join(f"{c} = EXCLUDED.{c}" for c in cols if c not in ("game_id", "player_id"))
+        try:
+            async with pool.acquire() as conn:
+                await conn.executemany(
+                    f"INSERT INTO model_eval_results ({', '.join(cols)}) VALUES "
+                    f"({', '.join(f'${i + 1}' for i in range(len(cols)))}) "
+                    f"ON CONFLICT (game_id, player_id) DO UPDATE SET {updates}",
+                    rows,
+                )
+            logger.info(f"Upserted {len(rows)} model eval rows")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to insert model eval rows: {e}")
+            return False
+
+    async def get_model_eval_for_date(self, game_date: date) -> list[dict]:
+        pool = await self._get_pool()
+        if pool is None:
+            return []
+        try:
+            async with pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT * FROM model_eval_results WHERE game_date = $1 ORDER BY player_id",
+                    game_date,
+                )
+                return [dict(r) for r in rows]
+        except Exception as e:
+            logger.error(f"Failed to fetch model eval rows for {game_date}: {e}")
+            return []
+
     async def close(self) -> None:
         if self._pool is not None:
             await self._pool.close()

--- a/backend/app/services/model_nightly_scheduler.py
+++ b/backend/app/services/model_nightly_scheduler.py
@@ -1,0 +1,51 @@
+"""Morning scheduler for the nightly model pipeline.
+
+Same retry-window pattern as estimator_scheduler: trigger at each slot between
+9:00 and 11:00 Israel time (NBA games are final by ~8:00 IL). The pipeline's
+model_nightly_runs ledger makes later slots no-ops once a night is processed,
+so the extra slots only matter when nba_api data was late or a run failed.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from app.services.model_nightly_service import ModelNightlyService
+
+logger = logging.getLogger(__name__)
+
+ISRAEL_TZ = ZoneInfo("Asia/Jerusalem")
+SCHEDULE_TIMES = [(9, 0), (9, 30), (10, 0), (10, 30), (11, 0)]
+
+
+def _compute_next_trigger() -> datetime:
+    now = datetime.now(ISRAEL_TZ)
+    for hour, minute in SCHEDULE_TIMES:
+        candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if candidate > now:
+            return candidate
+    tomorrow = (now + timedelta(days=1)).replace(
+        hour=SCHEDULE_TIMES[0][0], minute=SCHEDULE_TIMES[0][1], second=0, microsecond=0
+    )
+    return tomorrow
+
+
+async def start_scheduler():
+    service = ModelNightlyService()
+    logger.info("Model nightly scheduler started")
+    while True:
+        next_trigger = _compute_next_trigger()
+        now = datetime.now(ISRAEL_TZ)
+        sleep_seconds = (next_trigger - now).total_seconds()
+        logger.info(
+            f"Model nightly scheduler sleeping {sleep_seconds:.0f}s until "
+            f"{next_trigger.strftime('%H:%M')} IL"
+        )
+        await asyncio.sleep(sleep_seconds)
+        logger.info("Model nightly scheduler triggered")
+        try:
+            statuses = await service.run_catchup()
+            logger.info(f"Model nightly catch-up finished: {statuses}")
+        except Exception:
+            logger.exception("Model nightly pipeline failed; will retry at next slot")

--- a/backend/app/services/model_nightly_service.py
+++ b/backend/app/services/model_nightly_service.py
@@ -1,0 +1,262 @@
+"""Nightly model pipeline: fetch last night's games, retro-predict with real
+minutes, persist predicted-vs-actual, and grow the Postgres-backed feature store.
+
+The feature store's source of truth is the raw-row tables (fs_player_games /
+fs_team_games); vectors are rebuilt in memory per run via FeatureStore.build().
+Predictions for a night are computed from rows strictly before it, so they are
+leakage-safe by construction. A model_nightly_runs ledger row per date makes the
+9:00-11:00 scheduler retries no-ops after one success.
+
+Manual runs:
+    uv run python -m app.services.model_nightly_service --bootstrap [--until-date YYYY-MM-DD]
+    uv run python -m app.services.model_nightly_service [--date YYYY-MM-DD] [--force]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime, timedelta
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+from app.services.db_service import DBService
+from model_stats_inference.research import config as rconfig
+from model_stats_inference.research import data as rdata
+from model_stats_inference.serving import nightly
+from model_stats_inference.serving.feature_store import FeatureStore
+from model_stats_inference.serving.inference import LiveInference
+from model_stats_inference.serving.simulation import EvalRow
+
+logger = logging.getLogger(__name__)
+
+ISRAEL_TZ = ZoneInfo("Asia/Jerusalem")
+CATCHUP_DAYS = 7
+
+_EVAL_STATS = ["PTS", "REB", "AST", "FG3M", "STL", "BLK", "FGM", "FGA", "FTM", "FTA"]
+
+# Column orders must match DBService.insert_fs_rows.
+_FS_PLAYER_COLS = [
+    "PLAYER_ID", "GAME_ID", "SEASON", "GAME_DATE", "PLAYER_NAME", "TEAM_ID",
+    "MATCHUP", "POSITION", "MIN", "PTS", "REB", "OREB", "DREB", "AST", "FG3M",
+    "FG3A", "STL", "BLK", "TOV", "FGM", "FGA", "FTM", "FTA", "PF", "PLUS_MINUS",
+]
+_FS_TEAM_COLS = [
+    "TEAM_ID", "GAME_ID", "SEASON", "GAME_DATE", "TEAM_NAME", "MATCHUP",
+    "PTS", "REB", "AST", "STL", "BLK", "FG3M", "FG_PCT", "FGA", "FTA", "TOV",
+]
+
+
+def _records_to_frame(records: list[dict]) -> pd.DataFrame:
+    """DB rows (lowercase columns, date game_date) -> pipeline frame (uppercase,
+    Timestamp GAME_DATE)."""
+    df = pd.DataFrame.from_records(records)
+    df.columns = [c.upper() for c in df.columns]
+    df["GAME_DATE"] = pd.to_datetime(df["GAME_DATE"])
+    return df
+
+
+def _frame_to_tuples(df: pd.DataFrame, cols: list[str]) -> list[tuple]:
+    out = []
+    for row in df[cols].itertuples(index=False):
+        vals = []
+        for col, v in zip(cols, row):
+            if col in ("PLAYER_ID", "TEAM_ID"):
+                vals.append(int(v))
+            elif col == "GAME_DATE":
+                vals.append(pd.Timestamp(v).date())
+            elif col in ("GAME_ID", "SEASON", "PLAYER_NAME", "TEAM_NAME", "MATCHUP", "POSITION"):
+                vals.append("" if pd.isna(v) else str(v))
+            else:
+                vals.append(float(v))
+        out.append(tuple(vals))
+    return out
+
+
+def _eval_to_tuple(ev: EvalRow, game_date: date) -> tuple:
+    return (
+        ev.game_id, ev.player_id, game_date, ev.player_name, ev.team_id,
+        ev.opponent_team_id, ev.is_home, ev.real_minutes, ev.eligible, ev.reason,
+        *[ev.predicted.get(s) if ev.eligible else None for s in _EVAL_STATS],
+        *[float(ev.actual.get(s, 0.0)) for s in _EVAL_STATS],
+    )
+
+
+class ModelNightlyService:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._lock = asyncio.Lock()
+            cls._instance._db = DBService()
+        return cls._instance
+
+    # --- morning entry point (called by the scheduler) ----------------------
+
+    async def run_catchup(self) -> dict[str, str]:
+        """Process every unprocessed date in the trailing window, oldest first.
+
+        Stops at the first date that isn't in a terminal state (incomplete data,
+        DB failure): ingesting later days before an earlier day would leave the
+        store with a hole under those predictions.
+        """
+        yesterday = (datetime.now(ISRAEL_TZ) - timedelta(days=1)).date()
+        statuses: dict[str, str] = {}
+        for offset in range(CATCHUP_DAYS - 1, -1, -1):
+            d = yesterday - timedelta(days=offset)
+            status = await self.run_for_date(d)
+            statuses[d.isoformat()] = status
+            if status not in ("processed", "no_games", "already_processed", "store_already_ingested"):
+                logger.warning(f"Model nightly catch-up stopped at {d}: {status}")
+                break
+        return statuses
+
+    async def run_for_date(self, game_date: date, force: bool = False) -> str:
+        async with self._lock:
+            return await self._run_for_date(game_date, force)
+
+    async def _run_for_date(self, game_date: date, force: bool) -> str:
+        db = self._db
+        if not force:
+            run = await db.get_model_nightly_run(game_date)
+            if run is not None:
+                return "already_processed"
+
+        # Leakage guard (unconditional, even with --force): once the night's rows
+        # are in the store, a "prediction" for it would see its own outcome.
+        has_date = await db.fs_has_date(game_date)
+        if has_date is None:
+            return "db_unavailable"
+        if has_date:
+            await db.upsert_model_nightly_run(game_date, "store_already_ingested", 0, 0)
+            return "store_already_ingested"
+
+        night = await asyncio.to_thread(nightly.fetch_night, game_date)
+        if night.expected_games == 0:
+            await db.upsert_model_nightly_run(game_date, "no_games", 0, 0)
+            return "no_games"
+        if not night.complete:
+            logger.info(
+                f"Night {game_date} not complete yet "
+                f"(expected {night.expected_games} games); will retry next slot"
+            )
+            return "incomplete_data"
+
+        player_recs, team_recs = await db.get_fs_rows_before(game_date)
+        if not player_recs or not team_recs:
+            logger.error("Feature-store tables are empty — run --bootstrap first")
+            return "store_not_bootstrapped"
+
+        evals, night_players = await asyncio.to_thread(
+            self._predict_sync, player_recs, team_recs, night
+        )
+
+        eval_rows = [_eval_to_tuple(ev, game_date) for ev in evals]
+        if not await db.insert_model_eval_rows(eval_rows):
+            return "db_write_failed"
+
+        if not await db.insert_fs_rows(
+            _frame_to_tuples(night_players, _FS_PLAYER_COLS),
+            _frame_to_tuples(night.team_games, _FS_TEAM_COLS),
+        ):
+            return "db_write_failed"
+
+        await db.upsert_model_nightly_run(
+            game_date, "processed", night.expected_games, len(eval_rows)
+        )
+        eligible = sum(1 for ev in evals if ev.eligible)
+        logger.info(
+            f"Model nightly {game_date}: {night.expected_games} games, "
+            f"{len(eval_rows)} players evaluated ({eligible} eligible)"
+        )
+        return "processed"
+
+    @staticmethod
+    def _predict_sync(
+        player_recs: list[dict], team_recs: list[dict], night: nightly.NightFetch
+    ) -> tuple[list[EvalRow], pd.DataFrame]:
+        """Heavy pandas/sklearn work, run in a thread: build the pre-night store,
+        score the night, and annotate the night's player rows with positions."""
+        players = _records_to_frame(player_recs).sort_values(["PLAYER_ID", "GAME_DATE"])
+        team_games = _records_to_frame(team_recs)
+        store = FeatureStore.build(
+            players.reset_index(drop=True),
+            rdata.build_team_allowed(team_games),
+            rdata.build_team_own(team_games),
+        )
+        inference = LiveInference(store)
+        evals = nightly.evaluate_night(store, inference, night)
+        night_players = nightly.attach_positions(store, night.player_games)
+        return evals, night_players
+
+    # --- one-time init -------------------------------------------------------
+
+    async def bootstrap(self, force: bool = False, until_date: Optional[date] = None) -> str:
+        """Seed fs_player_games / fs_team_games from nba_api for research SEASONS."""
+        async with self._lock:
+            p_count, t_count = await self._db.fs_counts()
+            if p_count or t_count:
+                if not force:
+                    logger.info(f"Store already bootstrapped ({p_count} player rows); use --force")
+                    return "already_bootstrapped"
+                # A forced re-bootstrap must replace, not append: inserts are
+                # ON CONFLICT DO NOTHING, so leftover rows (e.g. stale players,
+                # dropped seasons) would otherwise survive forever.
+                if not await self._db.truncate_fs_tables():
+                    return "db_write_failed"
+
+            players, team_games = await asyncio.to_thread(
+                nightly.bootstrap_frames, until_date, self._cached_positions()
+            )
+            logger.info(
+                f"Bootstrap fetched {len(players)} player rows / {len(team_games)} team rows "
+                f"for {', '.join(rconfig.SEASONS)}"
+                + (f" (until {until_date})" if until_date else "")
+            )
+            ok = await self._db.insert_fs_rows(
+                _frame_to_tuples(players, _FS_PLAYER_COLS),
+                _frame_to_tuples(team_games, _FS_TEAM_COLS),
+            )
+            return "bootstrapped" if ok else "db_write_failed"
+
+    @staticmethod
+    def _cached_positions() -> Optional[pd.DataFrame]:
+        """PLAYER_ID -> POSITION from the local research cache when present —
+        skips the slow per-team roster crawl. None falls back to fetching."""
+        path = rconfig.DATA_DIR / "players.parquet"
+        if not path.exists():
+            return None
+        df = pd.read_parquet(path, columns=["PLAYER_ID", "POSITION"])
+        return df.dropna().drop_duplicates("PLAYER_ID", keep="last")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the nightly model pipeline manually")
+    parser.add_argument("--date", help="YYYY-MM-DD; default: yesterday (Asia/Jerusalem)")
+    parser.add_argument("--force", action="store_true", help="ignore the runs ledger / bootstrap guard")
+    parser.add_argument("--bootstrap", action="store_true", help="seed the feature-store tables")
+    parser.add_argument("--until-date", help="bootstrap only rows before this date (YYYY-MM-DD)")
+    args = parser.parse_args()
+
+    async def _main() -> str:
+        service = ModelNightlyService()
+        try:
+            if args.bootstrap:
+                until = date.fromisoformat(args.until_date) if args.until_date else None
+                return await service.bootstrap(force=args.force, until_date=until)
+            d = (
+                date.fromisoformat(args.date)
+                if args.date
+                else (datetime.now(ISRAEL_TZ) - timedelta(days=1)).date()
+            )
+            return await service.run_for_date(d, force=args.force)
+        finally:
+            await DBService().close()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+    print(asyncio.run(_main()))

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,6 +1,27 @@
 version: '3.8'
 
 services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: fantasy-postgres
+    environment:
+      POSTGRES_USER: fantasy
+      POSTGRES_PASSWORD: fantasy
+      POSTGRES_DB: fantasy
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      # All migrations are CREATE ... IF NOT EXISTS, so auto-applying on first
+      # init is safe. For an existing volume, apply new files manually:
+      # docker compose exec -T postgres psql -U fantasy -d fantasy < migrations/<file>.sql
+      - ./migrations:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fantasy -d fantasy"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   fantasy-backend:
     build: .
     image: fantasy-backend:latest
@@ -9,6 +30,11 @@ services:
       - "8000:8000"
     env_file:
       - .env
+    environment:
+      DATABASE_URL: postgresql://fantasy:fantasy@postgres:5432/fantasy
+    depends_on:
+      postgres:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -16,3 +42,5 @@ services:
       retries: 3
       start_period: 40s
 
+volumes:
+  pgdata:

--- a/backend/migrations/create_model_pipeline_tables.sql
+++ b/backend/migrations/create_model_pipeline_tables.sql
@@ -1,0 +1,108 @@
+-- Nightly model pipeline tables.
+--
+-- fs_player_games / fs_team_games hold the raw game rows that back the
+-- model_stats_inference FeatureStore (source of truth; feature vectors are
+-- recomputed in memory from these rows on every run). Columns are the subset
+-- of the nba_api game-log schemas the feature pipeline actually consumes
+-- (research/config.py BASE_STATS + meta, and the columns
+-- build_team_allowed/build_team_own read from raw team logs).
+
+CREATE TABLE IF NOT EXISTS fs_player_games (
+    player_id   BIGINT NOT NULL,
+    game_id     TEXT   NOT NULL,
+    season      TEXT   NOT NULL,
+    game_date   DATE   NOT NULL,
+    player_name TEXT   NOT NULL DEFAULT '',
+    team_id     BIGINT NOT NULL,
+    matchup     TEXT   NOT NULL DEFAULT '',
+    position    TEXT   NOT NULL DEFAULT '',
+    min         DOUBLE PRECISION NOT NULL,
+    pts         DOUBLE PRECISION NOT NULL,
+    reb         DOUBLE PRECISION NOT NULL,
+    oreb        DOUBLE PRECISION NOT NULL,
+    dreb        DOUBLE PRECISION NOT NULL,
+    ast         DOUBLE PRECISION NOT NULL,
+    fg3m        DOUBLE PRECISION NOT NULL,
+    fg3a        DOUBLE PRECISION NOT NULL,
+    stl         DOUBLE PRECISION NOT NULL,
+    blk         DOUBLE PRECISION NOT NULL,
+    tov         DOUBLE PRECISION NOT NULL,
+    fgm         DOUBLE PRECISION NOT NULL,
+    fga         DOUBLE PRECISION NOT NULL,
+    ftm         DOUBLE PRECISION NOT NULL,
+    fta         DOUBLE PRECISION NOT NULL,
+    pf          DOUBLE PRECISION NOT NULL,
+    plus_minus  DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (player_id, game_id)
+);
+CREATE INDEX IF NOT EXISTS idx_fs_player_games_date ON fs_player_games (game_date);
+
+CREATE TABLE IF NOT EXISTS fs_team_games (
+    team_id   BIGINT NOT NULL,
+    game_id   TEXT   NOT NULL,
+    season    TEXT   NOT NULL,
+    game_date DATE   NOT NULL,
+    team_name TEXT   NOT NULL DEFAULT '',
+    matchup   TEXT   NOT NULL DEFAULT '',
+    pts       DOUBLE PRECISION NOT NULL,
+    reb       DOUBLE PRECISION NOT NULL,
+    ast       DOUBLE PRECISION NOT NULL,
+    stl       DOUBLE PRECISION NOT NULL,
+    blk       DOUBLE PRECISION NOT NULL,
+    fg3m      DOUBLE PRECISION NOT NULL,
+    fg_pct    DOUBLE PRECISION NOT NULL,
+    fga       DOUBLE PRECISION NOT NULL,
+    fta       DOUBLE PRECISION NOT NULL,
+    tov       DOUBLE PRECISION NOT NULL,
+    PRIMARY KEY (team_id, game_id)
+);
+CREATE INDEX IF NOT EXISTS idx_fs_team_games_date ON fs_team_games (game_date);
+
+-- One row per processed night: the idempotency ledger for the morning job.
+CREATE TABLE IF NOT EXISTS model_nightly_runs (
+    game_date DATE PRIMARY KEY,
+    status    TEXT NOT NULL,            -- 'processed' | 'no_games' | 'store_already_ingested'
+    num_games INT  NOT NULL DEFAULT 0,
+    num_rows  INT  NOT NULL DEFAULT 0,
+    ran_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Predicted-vs-actual per player per game. Predictions are retro: computed with
+-- the minutes the player actually played, from feature-store state that excludes
+-- the game itself. pred_* are NULL when the player was ineligible (see reason).
+CREATE TABLE IF NOT EXISTS model_eval_results (
+    game_id          TEXT   NOT NULL,
+    player_id        BIGINT NOT NULL,
+    game_date        DATE   NOT NULL,
+    player_name      TEXT   NOT NULL DEFAULT '',
+    team_id          BIGINT NOT NULL,
+    opponent_team_id BIGINT NOT NULL,
+    is_home          BOOLEAN NOT NULL,
+    minutes          DOUBLE PRECISION NOT NULL,
+    eligible         BOOLEAN NOT NULL,
+    reason           TEXT NOT NULL DEFAULT '',
+    pred_pts    DOUBLE PRECISION,
+    pred_reb    DOUBLE PRECISION,
+    pred_ast    DOUBLE PRECISION,
+    pred_fg3m   DOUBLE PRECISION,
+    pred_stl    DOUBLE PRECISION,
+    pred_blk    DOUBLE PRECISION,
+    pred_fgm    DOUBLE PRECISION,
+    pred_fga    DOUBLE PRECISION,
+    pred_ftm    DOUBLE PRECISION,
+    pred_fta    DOUBLE PRECISION,
+    actual_pts  DOUBLE PRECISION NOT NULL,
+    actual_reb  DOUBLE PRECISION NOT NULL,
+    actual_ast  DOUBLE PRECISION NOT NULL,
+    actual_fg3m DOUBLE PRECISION NOT NULL,
+    actual_stl  DOUBLE PRECISION NOT NULL,
+    actual_blk  DOUBLE PRECISION NOT NULL,
+    actual_fgm  DOUBLE PRECISION NOT NULL,
+    actual_fga  DOUBLE PRECISION NOT NULL,
+    actual_ftm  DOUBLE PRECISION NOT NULL,
+    actual_fta  DOUBLE PRECISION NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (game_id, player_id)
+);
+CREATE INDEX IF NOT EXISTS idx_model_eval_results_game_date ON model_eval_results (game_date);
+CREATE INDEX IF NOT EXISTS idx_model_eval_results_player ON model_eval_results (player_id, game_date);

--- a/backend/model_stats_inference/serving/nightly.py
+++ b/backend/model_stats_inference/serving/nightly.py
@@ -1,0 +1,210 @@
+"""Nightly production ingest: fetch one night's real games and score the model.
+
+Pure synchronous pandas/nba_api code — no DB, no asyncio. The app layer
+(app/services/model_nightly_service.py) orchestrates: it builds a FeatureStore
+from rows *before* the night, calls ``evaluate_night`` (predictions therefore
+use no data from the night itself), persists the results, then ingests the
+night's raw rows.
+
+``fetch_night`` also disambiguates a genuine off-night from nba_api lag via the
+scoreboard: zero scheduled games is a done state, while missing/unfinal logs
+mean "come back later".
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import date
+
+import pandas as pd
+from nba_api.stats.endpoints import playergamelogs, scoreboardv2, teamgamelogs
+
+from ..research import config as rconfig
+from ..research import data as rdata
+from .feature_store import FeatureStore
+from .inference import LiveInference, PredictionRequest
+from .simulation import EvalRow, _actual_line
+
+
+def season_for(d: date) -> str:
+    """NBA season string ("YYYY-YY") the given date belongs to (Aug+ = new season)."""
+    start = d.year if d.month >= 8 else d.year - 1
+    return f"{start}-{str(start + 1)[-2:]}"
+
+
+@dataclass
+class NightFetch:
+    game_date: date
+    player_games: pd.DataFrame   # cleaned player logs (regular season, MIN >= MIN_MINUTES)
+    team_games: pd.DataFrame     # raw team logs (regular season; both teams of each game)
+    expected_games: int          # regular-season games on the scoreboard for the date
+    complete: bool               # all expected games final AND the logs cover them
+
+
+def _fetch_one_day(endpoint_cls, game_date: date) -> pd.DataFrame:
+    ds = game_date.strftime("%m/%d/%Y")
+    df = endpoint_cls(
+        season_nullable=season_for(game_date),
+        season_type_nullable=rconfig.SEASON_TYPE,
+        date_from_nullable=ds,
+        date_to_nullable=ds,
+        timeout=rdata.REQUEST_TIMEOUT,
+    ).get_data_frames()[0]
+    df.insert(0, "SEASON", season_for(game_date))
+    time.sleep(rdata.SLEEP_BETWEEN_CALLS)
+    return rdata._regular_season_only(rdata._to_datetime(df))
+
+
+def _expected_regular_season_games(game_date: date) -> tuple[int, bool]:
+    """(number of regular-season games scheduled on the date, all of them final)."""
+    header = scoreboardv2.ScoreboardV2(
+        game_date=game_date.strftime("%m/%d/%Y"), timeout=rdata.REQUEST_TIMEOUT
+    ).game_header.get_data_frame()
+    time.sleep(rdata.SLEEP_BETWEEN_CALLS)
+    games = header[header["GAME_ID"].astype(str).str.startswith(rdata.REGULAR_SEASON_PREFIX)]
+    all_final = bool((games["GAME_STATUS_ID"].astype(int) == 3).all()) if len(games) else True
+    return len(games), all_final
+
+
+def fetch_night(game_date: date) -> NightFetch:
+    """Fetch one night's player + team logs and judge whether the data is complete."""
+    expected, all_final = _expected_regular_season_games(game_date)
+    if expected == 0:
+        empty = pd.DataFrame()
+        return NightFetch(game_date, empty, empty, 0, complete=True)
+
+    player_games = _fetch_one_day(playergamelogs.PlayerGameLogs, game_date)
+    team_games = _fetch_one_day(teamgamelogs.TeamGameLogs, game_date)
+
+    # Same row filter as the research corpus: DNP / garbage-time rows are neither
+    # targets nor history. (The per-player MIN_PLAYER_GAMES corpus filter does NOT
+    # apply here — MIN_INFERENCE_GAMES gates eligibility at read time instead.)
+    if not player_games.empty:
+        player_games = player_games[
+            player_games["MIN"].notna() & (player_games["MIN"] >= rconfig.MIN_MINUTES)
+        ].reset_index(drop=True)
+
+    complete = all_final and len(team_games) == 2 * expected and not player_games.empty
+    return NightFetch(game_date, player_games, team_games, expected, complete)
+
+
+def evaluate_night(
+    store: FeatureStore, inference: LiveInference, night: NightFetch
+) -> list[EvalRow]:
+    """Score every player of the night against actuals (predictions use the real
+    minutes played and a store that must NOT contain the night's rows)."""
+    opp_map = (
+        rdata.build_team_allowed(night.team_games)
+        .set_index(["GAME_ID", "TEAM_ID"])["OPP_TEAM_ID"]
+        .to_dict()
+    )
+
+    reqs: list[PredictionRequest] = []
+    meta = []  # rows aligned to reqs
+    evals: list[EvalRow] = []
+    for _, row in night.player_games.iterrows():
+        opp = int(opp_map.get((row["GAME_ID"], row["TEAM_ID"]), -1))
+        ev = EvalRow(
+            player_id=int(row["PLAYER_ID"]),
+            player_name=str(row.get("PLAYER_NAME", row["PLAYER_ID"])),
+            team_id=int(row["TEAM_ID"]),
+            opponent_team_id=opp,
+            is_home="vs" in str(row["MATCHUP"]),
+            real_minutes=float(row["MIN"]),
+            eligible=True,
+            game_id=str(row["GAME_ID"]),
+            actual=_actual_line(row),
+        )
+        # predict_many only tolerates per-request player errors; an unknown TEAM
+        # raises out of the whole batch, so filter those requests up front.
+        if opp not in store.team_allowed_vectors.index:
+            ev.eligible = False
+            ev.reason = f"opponent team {opp} not in feature store"
+            evals.append(ev)
+            continue
+        reqs.append(PredictionRequest(
+            player_id=ev.player_id,
+            opponent_team_id=opp,
+            is_home=ev.is_home,
+            game_date=pd.Timestamp(night.game_date),
+            minutes=ev.real_minutes,
+        ))
+        meta.append(ev)
+
+    results, errors = inference.predict_many(reqs)
+    for ev, res, err in zip(meta, results, errors):
+        if err is not None:
+            ev.eligible = False
+            ev.reason = str(err)
+        else:
+            ev.predicted = {k: round(v.value, 2) for k, v in res.stats.items()}
+        evals.append(ev)
+    return evals
+
+
+def attach_positions(store: FeatureStore, player_games: pd.DataFrame) -> pd.DataFrame:
+    """Add each player's last-known POSITION from the store to nightly log rows.
+
+    Nightly game logs carry no POSITION, and ``build_current_state`` takes the
+    per-player last() — un-annotated rows would wipe positions on recompute.
+    Brand-new players get "" (position flags 0) until the next roster refresh.
+    """
+    known = (
+        store.players.dropna(subset=["POSITION"])
+        .groupby("PLAYER_ID")["POSITION"].last()
+        if "POSITION" in store.players.columns
+        else pd.Series(dtype=str)
+    )
+    out = player_games.copy()
+    out["POSITION"] = out["PLAYER_ID"].map(known).fillna("")
+    return out
+
+
+# --- Bootstrap (one-time init of the raw-rows store) ------------------------
+
+# Bootstrap-only memory saver (the nightly path never filters players): rows of
+# players whose most recent game is at least this old (retired / out of the
+# league) are not stored. A comeback player is re-added by the nightly ingest
+# the day he plays (history restarts from zero, so MIN_INFERENCE_GAMES gates
+# him like any newcomer).
+STALE_PLAYER_YEARS = 2
+
+
+def drop_stale_players(players: pd.DataFrame, as_of: date) -> pd.DataFrame:
+    """Remove all rows of players whose newest game is >= STALE_PLAYER_YEARS old."""
+    cutoff = pd.Timestamp(as_of) - pd.DateOffset(years=STALE_PLAYER_YEARS)
+    last = players.groupby("PLAYER_ID")["GAME_DATE"].transform("max")
+    return players[last > cutoff].reset_index(drop=True)
+
+
+def bootstrap_frames(
+    until_date: date | None = None, positions: pd.DataFrame | None = None
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Fetch and clean the full-history frames used to seed the Postgres store.
+
+    Returns (player_games, team_games) for ``research/config.SEASONS``, with the
+    same row filter as the nightly fetch. ``until_date`` (exclusive) trims the
+    frames for mid-season replay testing. ``positions`` (PLAYER_ID -> POSITION)
+    is fetched from team rosters when not supplied.
+    """
+    players = rdata._regular_season_only(rdata._to_datetime(rdata.fetch_player_logs(rconfig.SEASONS)))
+    team_games = rdata._regular_season_only(rdata._to_datetime(rdata.fetch_team_logs(rconfig.SEASONS)))
+
+    players = players[players["MIN"].notna() & (players["MIN"] >= rconfig.MIN_MINUTES)]
+    players = players.sort_values(["PLAYER_ID", "GAME_DATE"]).reset_index(drop=True)
+
+    if positions is None:
+        positions = rdata.fetch_positions(rconfig.SEASONS)
+    players = players.merge(positions, on="PLAYER_ID", how="left")
+    players["POSITION"] = players["POSITION"].fillna("")
+
+    if until_date is not None:
+        cutoff = pd.Timestamp(until_date)
+        players = players[players["GAME_DATE"] < cutoff].reset_index(drop=True)
+        team_games = team_games[team_games["GAME_DATE"] < cutoff].reset_index(drop=True)
+
+    # Staleness is judged as of the snapshot point so --until-date replays
+    # behave exactly like a bootstrap run on that date would have.
+    players = drop_stale_players(players, until_date or date.today())
+    return players, team_games

--- a/backend/model_stats_inference/serving/simulation.py
+++ b/backend/model_stats_inference/serving/simulation.py
@@ -66,6 +66,7 @@ class EvalRow:
     real_minutes: float
     eligible: bool
     reason: str = ""
+    game_id: str = ""
     predicted: dict[str, float] = field(default_factory=dict)
     actual: dict[str, float] = field(default_factory=dict)
 

--- a/backend/model_stats_inference/serving/test_nightly.py
+++ b/backend/model_stats_inference/serving/test_nightly.py
@@ -1,0 +1,127 @@
+"""Tests for the nightly fetch/evaluate helpers (synthetic store, no network)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+
+from model_stats_inference.serving import nightly
+from model_stats_inference.serving.inference import LiveInference
+
+from .conftest import FULL_PID, LOW_PID, TEAM_A, TEAM_B
+
+NIGHT_DATE = date(2024, 12, 31)  # after the synthetic schedule's last game
+NIGHT_GID = "0021409900"
+UNKNOWN_GID = "0021409901"
+UNKNOWN_TEAM_A, UNKNOWN_TEAM_B = 30, 999
+UNKNOWN_PID = 999
+
+
+def test_season_for_boundaries():
+    assert nightly.season_for(date(2025, 11, 1)) == "2025-26"
+    assert nightly.season_for(date(2026, 3, 1)) == "2025-26"
+    assert nightly.season_for(date(2026, 8, 15)) == "2026-27"
+
+
+def _night_player_row(pid, team, game_id, matchup, minutes=30.0):
+    row = {
+        "SEASON": "2024-25", "PLAYER_ID": pid, "PLAYER_NAME": f"Player {pid}",
+        "TEAM_ID": team, "GAME_ID": game_id, "GAME_DATE": pd.Timestamp(NIGHT_DATE),
+        "MATCHUP": matchup, "MIN": minutes,
+        "PTS": 20.0, "REB": 8.0, "AST": 5.0, "FG3M": 2.0, "STL": 1.0, "BLK": 1.0,
+        "FGM": 8.0, "FGA": 15.0, "FTM": 2.0, "FTA": 3.0,
+        "OREB": 2.0, "DREB": 6.0, "TOV": 2.0, "PF": 2.0, "FG3A": 5.0, "PLUS_MINUS": 4.0,
+    }
+    return row
+
+
+def _night_team_row(team, game_id):
+    return {
+        "SEASON": "2024-25", "TEAM_ID": team, "GAME_ID": game_id,
+        "GAME_DATE": pd.Timestamp(NIGHT_DATE), "TEAM_NAME": f"Team {team}",
+        "MATCHUP": "AAA vs. BBB",
+        "PTS": 110.0, "REB": 44.0, "AST": 25.0, "STL": 7.0, "BLK": 5.0,
+        "FG3M": 12.0, "FG_PCT": 0.47, "FGA": 88.0, "FTA": 20.0, "TOV": 14.0,
+    }
+
+
+def _make_night() -> nightly.NightFetch:
+    player_games = pd.DataFrame([
+        _night_player_row(FULL_PID, TEAM_A, NIGHT_GID, "AAA vs. BBB"),      # eligible
+        _night_player_row(LOW_PID, TEAM_B, NIGHT_GID, "BBB @ AAA"),         # <10 games history
+        _night_player_row(UNKNOWN_PID, TEAM_B, NIGHT_GID, "BBB @ AAA"),     # unknown player
+        _night_player_row(2, UNKNOWN_TEAM_A, UNKNOWN_GID, "CCC vs. DDD"),   # opponent not in store
+    ])
+    team_games = pd.DataFrame([
+        _night_team_row(TEAM_A, NIGHT_GID),
+        _night_team_row(TEAM_B, NIGHT_GID),
+        _night_team_row(UNKNOWN_TEAM_A, UNKNOWN_GID),
+        _night_team_row(UNKNOWN_TEAM_B, UNKNOWN_GID),
+    ])
+    return nightly.NightFetch(
+        game_date=NIGHT_DATE, player_games=player_games, team_games=team_games,
+        expected_games=2, complete=True,
+    )
+
+
+def test_evaluate_night(store, models_dir):
+    inference = LiveInference(store, models_dir)
+    evals = {ev.player_id: ev for ev in nightly.evaluate_night(store, inference, _make_night())}
+    assert len(evals) == 4
+
+    full = evals[FULL_PID]
+    assert full.eligible
+    assert full.game_id == NIGHT_GID
+    assert full.is_home
+    assert full.real_minutes == 30.0
+    assert full.predicted["PTS"] >= 0
+    assert full.actual["PTS"] == 20.0
+    assert full.opponent_team_id == TEAM_B
+
+    low = evals[LOW_PID]
+    assert not low.eligible and not low.predicted
+    assert low.actual["PTS"] == 20.0
+
+    unknown_player = evals[UNKNOWN_PID]
+    assert not unknown_player.eligible and not unknown_player.predicted
+
+    # Pre-filtered before predict_many (UnknownTeamError would abort the batch).
+    unknown_team = evals[2]
+    assert not unknown_team.eligible
+    assert "not in feature store" in unknown_team.reason
+    assert unknown_team.opponent_team_id == UNKNOWN_TEAM_B
+
+
+def test_evaluate_night_is_leakage_safe(store, models_dir):
+    """Predictions must come from the pre-night store: evaluating the same night
+    twice against the same store yields identical numbers (store not mutated)."""
+    inference = LiveInference(store, models_dir)
+    first = nightly.evaluate_night(store, inference, _make_night())
+    second = nightly.evaluate_night(store, inference, _make_night())
+    assert [ev.predicted for ev in first] == [ev.predicted for ev in second]
+
+
+def test_drop_stale_players_boundary():
+    as_of = date(2026, 7, 3)
+    df = pd.DataFrame({
+        "PLAYER_ID": [1, 1, 2, 2, 3],
+        "GAME_DATE": pd.to_datetime([
+            "2024-01-05", "2026-01-10",  # active: newest game recent -> ALL rows kept
+            "2023-11-01", "2024-04-01",  # stale: newest game > 2 years old -> dropped
+            "2024-07-03",                # exactly 2 years old -> dropped (>= boundary)
+        ]),
+    })
+    out = nightly.drop_stale_players(df, as_of)
+    assert set(out["PLAYER_ID"]) == {1}
+    assert len(out) == 2  # active player keeps his old rows too
+
+
+def test_attach_positions(store):
+    rows = pd.DataFrame([
+        _night_player_row(FULL_PID, TEAM_A, NIGHT_GID, "AAA vs. BBB"),
+        _night_player_row(UNKNOWN_PID, TEAM_B, NIGHT_GID, "BBB @ AAA"),
+    ])
+    out = nightly.attach_positions(store, rows)
+    assert out.loc[out["PLAYER_ID"] == FULL_PID, "POSITION"].iloc[0] == "G"
+    assert out.loc[out["PLAYER_ID"] == UNKNOWN_PID, "POSITION"].iloc[0] == ""

--- a/backend/tests/services/test_model_nightly_service.py
+++ b/backend/tests/services/test_model_nightly_service.py
@@ -1,0 +1,184 @@
+"""Orchestration tests for ModelNightlyService (fake DB + fake fetch, no network)."""
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from app.services import model_nightly_service as mns
+from app.services.model_nightly_service import (
+    _EVAL_STATS,
+    _FS_PLAYER_COLS,
+    _FS_TEAM_COLS,
+    ModelNightlyService,
+    _eval_to_tuple,
+)
+from model_stats_inference.serving.nightly import NightFetch
+from model_stats_inference.serving.simulation import EvalRow
+
+GAME_DATE = date(2026, 1, 15)
+
+
+class FakeDB:
+    def __init__(self):
+        self.run = None
+        self.has_date = False
+        self.player_recs = [{"player_id": 1}]
+        self.team_recs = [{"team_id": 10}]
+        self.eval_insert_ok = True
+        self.fs_insert_ok = True
+        self.marked = []          # (game_date, status, num_games, num_rows)
+        self.eval_rows = None
+        self.fs_rows = None
+
+    async def get_model_nightly_run(self, d):
+        return self.run
+
+    async def fs_has_date(self, d):
+        return self.has_date
+
+    async def get_fs_rows_before(self, d):
+        return self.player_recs, self.team_recs
+
+    async def insert_model_eval_rows(self, rows):
+        self.eval_rows = rows
+        return self.eval_insert_ok
+
+    async def insert_fs_rows(self, player_rows, team_rows):
+        self.fs_rows = (player_rows, team_rows)
+        return self.fs_insert_ok
+
+    async def upsert_model_nightly_run(self, d, status, num_games, num_rows):
+        self.marked.append((d, status, num_games, num_rows))
+        return True
+
+
+def _night(expected_games=2, complete=True):
+    team_games = pd.DataFrame([{
+        "TEAM_ID": 10, "GAME_ID": "0021409900", "SEASON": "2025-26",
+        "GAME_DATE": pd.Timestamp(GAME_DATE), "TEAM_NAME": "T", "MATCHUP": "A vs. B",
+        "PTS": 110.0, "REB": 44.0, "AST": 25.0, "STL": 7.0, "BLK": 5.0,
+        "FG3M": 12.0, "FG_PCT": 0.47, "FGA": 88.0, "FTA": 20.0, "TOV": 14.0,
+    }])
+    return NightFetch(GAME_DATE, pd.DataFrame(), team_games, expected_games, complete)
+
+
+def _eval_row(eligible=True):
+    return EvalRow(
+        player_id=1, player_name="P", team_id=10, opponent_team_id=20,
+        is_home=True, real_minutes=31.5, eligible=eligible,
+        reason="" if eligible else "insufficient history", game_id="0021409900",
+        predicted={s: 5.0 for s in _EVAL_STATS} if eligible else {},
+        actual={s: 6.0 for s in _EVAL_STATS},
+    )
+
+
+def _night_players_frame():
+    return pd.DataFrame([{c: ("0021409900" if c == "GAME_ID" else
+                              "2025-26" if c == "SEASON" else
+                              pd.Timestamp(GAME_DATE) if c == "GAME_DATE" else
+                              "x" if c in ("PLAYER_NAME", "MATCHUP", "POSITION") else
+                              1) for c in _FS_PLAYER_COLS}])
+
+
+@pytest.fixture
+def service(monkeypatch):
+    ModelNightlyService._instance = None
+    svc = ModelNightlyService()
+    svc._db = FakeDB()
+    monkeypatch.setattr(
+        mns.nightly, "fetch_night", lambda d: pytest.fail("fetch_night should not be called")
+    )
+    yield svc
+    ModelNightlyService._instance = None
+
+
+def _allow_fetch(monkeypatch, night):
+    monkeypatch.setattr(mns.nightly, "fetch_night", lambda d: night)
+
+
+def _allow_predict(monkeypatch, evals):
+    monkeypatch.setattr(
+        ModelNightlyService, "_predict_sync",
+        staticmethod(lambda p, t, n: (evals, _night_players_frame())),
+    )
+
+
+@pytest.mark.asyncio
+async def test_already_processed_skips_fetch(service):
+    service._db.run = {"game_date": GAME_DATE, "status": "processed"}
+    assert await service.run_for_date(GAME_DATE) == "already_processed"
+
+
+@pytest.mark.asyncio
+async def test_leakage_guard_when_rows_already_ingested(service):
+    service._db.has_date = True
+    assert await service.run_for_date(GAME_DATE) == "store_already_ingested"
+    assert service._db.marked == [(GAME_DATE, "store_already_ingested", 0, 0)]
+
+
+@pytest.mark.asyncio
+async def test_leakage_guard_holds_even_with_force(service):
+    service._db.run = {"game_date": GAME_DATE, "status": "processed"}
+    service._db.has_date = True
+    assert await service.run_for_date(GAME_DATE, force=True) == "store_already_ingested"
+
+
+@pytest.mark.asyncio
+async def test_db_unavailable_aborts(service):
+    service._db.has_date = None
+    assert await service.run_for_date(GAME_DATE) == "db_unavailable"
+    assert service._db.marked == []
+
+
+@pytest.mark.asyncio
+async def test_no_games_is_terminal(service, monkeypatch):
+    _allow_fetch(monkeypatch, _night(expected_games=0))
+    assert await service.run_for_date(GAME_DATE) == "no_games"
+    assert service._db.marked == [(GAME_DATE, "no_games", 0, 0)]
+
+
+@pytest.mark.asyncio
+async def test_incomplete_data_left_unmarked_for_retry(service, monkeypatch):
+    _allow_fetch(monkeypatch, _night(complete=False))
+    assert await service.run_for_date(GAME_DATE) == "incomplete_data"
+    assert service._db.marked == []
+
+
+@pytest.mark.asyncio
+async def test_empty_store_requires_bootstrap(service, monkeypatch):
+    _allow_fetch(monkeypatch, _night())
+    service._db.player_recs = []
+    assert await service.run_for_date(GAME_DATE) == "store_not_bootstrapped"
+
+
+@pytest.mark.asyncio
+async def test_failed_eval_write_does_not_mark_run(service, monkeypatch):
+    _allow_fetch(monkeypatch, _night())
+    _allow_predict(monkeypatch, [_eval_row()])
+    service._db.eval_insert_ok = False
+    assert await service.run_for_date(GAME_DATE) == "db_write_failed"
+    assert service._db.marked == []
+    assert service._db.fs_rows is None  # night must not be ingested either
+
+
+@pytest.mark.asyncio
+async def test_happy_path_processes_and_ingests(service, monkeypatch):
+    _allow_fetch(monkeypatch, _night())
+    _allow_predict(monkeypatch, [_eval_row(), _eval_row(eligible=False)])
+    assert await service.run_for_date(GAME_DATE) == "processed"
+    assert service._db.marked == [(GAME_DATE, "processed", 2, 2)]
+    assert len(service._db.eval_rows) == 2
+    player_rows, team_rows = service._db.fs_rows
+    assert len(player_rows) == 1 and len(player_rows[0]) == len(_FS_PLAYER_COLS)
+    assert len(team_rows) == 1 and len(team_rows[0]) == len(_FS_TEAM_COLS)
+
+
+def test_eval_to_tuple_shapes():
+    eligible = _eval_to_tuple(_eval_row(), GAME_DATE)
+    ineligible = _eval_to_tuple(_eval_row(eligible=False), GAME_DATE)
+    assert len(eligible) == 10 + 2 * len(_EVAL_STATS)
+    assert eligible[10:20] == tuple(5.0 for _ in _EVAL_STATS)      # pred_*
+    assert eligible[20:30] == tuple(6.0 for _ in _EVAL_STATS)      # actual_*
+    assert ineligible[10:20] == tuple(None for _ in _EVAL_STATS)   # NULL preds
+    assert ineligible[20:30] == tuple(6.0 for _ in _EVAL_STATS)

--- a/docs/nightly-model-pipeline-plan.md
+++ b/docs/nightly-model-pipeline-plan.md
@@ -1,0 +1,176 @@
+# Nightly Model Pipeline: fetch → retro-predict → persist → update feature store
+
+## Context
+
+The `model_stats_inference` package (PR #100) can predict per-player stat lines, but nothing runs it in production: `FeatureStore` has no live data source and no code fetches nightly games. To be ready for next season, the backend needs a scheduled morning job that:
+
+1. Fetches **only last night's** NBA games (player + team game logs) via nba_api.
+2. Runs model estimations for those games using the **actual minutes played** (retro-prediction, computed from feature-store state that excludes the night being predicted — leakage-safe).
+3. Appends predicted-vs-actual rows to Postgres.
+4. Updates the feature store with the night's data.
+5. All in one callable function, scheduled at 9:00/9:30/10:00/10:30/11:00 Asia/Jerusalem (mirroring `estimator_scheduler.py`), skipping once the night is processed.
+
+## Decisions (settled in design review)
+
+| Decision | Choice |
+|---|---|
+| Store persistence | **Postgres-backed feature store now** (no parquet store dir, no docker volume). |
+| Store shape | **Raw game rows only** in Postgres (`fs_player_games`, `fs_team_games`). Vectors are derived — rebuilt in memory each run via `FeatureStore.build()`. `team_allowed`/`team_own` derived in memory from raw team logs via `rdata.build_team_allowed/build_team_own`. |
+| Bootstrap depth | Same seasons as `research/config.py: SEASONS` (currently 2023-24 → 2025-26; bump each season). Row-level filter only (regular season, `MIN >= MIN_MINUTES`); do **not** apply the research corpus filter `MIN_PLAYER_GAMES=20` — `MIN_INFERENCE_GAMES=10` gates at read time. |
+| Eval output | DB table only (`model_eval_results`). No API route, no UI tab for now. |
+| Retraining | Out of scope. Models stay frozen `models/*.joblib`; retrain manually offline. |
+| Go-live | `MODEL_NIGHTLY_ENABLED` default `false`; flip near opening night. No SEASON_START logic — off-nights just record `no_games`. |
+| Simulation/FeatureStore tabs | Stay behind flags, default off. `SimulationService` (research-cache-based) untouched. |
+| Local DB | Postgres 16 service in `backend/docker-compose.yml`; prod later = change `DATABASE_URL`. |
+| Eval table shape | Wide `pred_*`/`actual_*` columns per target (PTS, REB, AST, FG3M, STL, BLK, FGM, FGA, FTM, FTA). FG%/FT% derivable; error metrics left to SQL. |
+
+## Key design points
+
+- **"Yesterday"**: `(now(Asia/Jerusalem) - 1 day).date()`. NBA `GAME_DATE` is the US/ET calendar date; at 9:00–11:00 IL, all of last night's games carry exactly that date. A catch-up loop covers the last 7 unprocessed dates (oldest first) so downtime never leaves holes.
+- **Idempotency**: `model_nightly_runs` ledger row per date (`processed` / `no_games` / `store_already_ingested`). Leakage guard: if `fs_player_games` already has rows for the date, never predict — mark `store_already_ingested`.
+- **Off-night vs data-lag**: ScoreboardV2 for the date. 0 regular-season games (`GAME_ID` prefix `002`) → `no_games` (done). Games exist but not all final (`GAME_STATUS_ID != 3`) or logs incomplete → return **without marking**, next retry slot tries again.
+- **Leakage-safe build**: each run builds the in-memory store from `fs_player_games`/`fs_team_games` rows `WHERE game_date < target_date` only.
+- **Unknown teams must be pre-filtered** before `predict_many`: it only catches `InsufficientHistoryError`/`UnknownPlayerError` per request (`serving/inference.py:102`); `UnknownTeamError` would abort the whole batch. Ineligible players (< 10 games / unknown) are stored with NULL `pred_*`, real actuals, `eligible=false` + `reason`. Their raw rows are still ingested, so newcomers become eligible over time.
+- **Crash-safe order**: predict → insert eval rows (must succeed) → insert night's raw rows → mark run. Every step retry-safe (`ON CONFLICT DO UPDATE`; re-prediction after a partial failure rebuilds the identical pre-night store, so results are reproducible).
+- **Positions**: nightly logs lack `POSITION` (needed by `build_current_state`). Bootstrap stores it per row (merged from `fetch_positions`, as `load_or_build` does); nightly rows get the player's last known `POSITION` from the store (`""` for brand-new players until the next bootstrap/roster refresh).
+- **Risk (accepted)**: nba_api sometimes blocks datacenter IPs; the nightly fetch runs from wherever the backend runs. Fine for local dev; revisit for cloud deployment.
+
+## Files
+
+### 1. NEW `backend/migrations/create_model_pipeline_tables.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS fs_player_games (
+    player_id BIGINT NOT NULL, game_id TEXT NOT NULL,
+    season TEXT NOT NULL, game_date DATE NOT NULL,
+    player_name TEXT NOT NULL, team_id BIGINT NOT NULL,
+    matchup TEXT NOT NULL, position TEXT NOT NULL DEFAULT '',
+    min DOUBLE PRECISION NOT NULL,
+    -- one column per stat the research cache carries (mirror players.parquet schema exactly;
+    -- enumerate at implementation time from the local cache): fgm, fga, fg3m, fg3a, ftm, fta,
+    -- oreb, dreb, reb, ast, stl, blk, tov, pf, pts, plus_minus, ...
+    PRIMARY KEY (player_id, game_id)
+);
+CREATE INDEX IF NOT EXISTS idx_fs_player_games_date ON fs_player_games (game_date);
+
+CREATE TABLE IF NOT EXISTS fs_team_games (
+    team_id BIGINT NOT NULL, game_id TEXT NOT NULL,
+    season TEXT NOT NULL, game_date DATE NOT NULL,
+    team_name TEXT NOT NULL DEFAULT '', matchup TEXT NOT NULL,
+    -- mirror the raw TeamGameLogs columns build_team_allowed/build_team_own consume
+    PRIMARY KEY (team_id, game_id)
+);
+CREATE INDEX IF NOT EXISTS idx_fs_team_games_date ON fs_team_games (game_date);
+
+CREATE TABLE IF NOT EXISTS model_nightly_runs (
+    game_date DATE PRIMARY KEY,
+    status    TEXT NOT NULL,            -- 'processed' | 'no_games' | 'store_already_ingested'
+    num_games INT  NOT NULL DEFAULT 0,
+    num_rows  INT  NOT NULL DEFAULT 0,
+    ran_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS model_eval_results (
+    game_id TEXT NOT NULL, player_id BIGINT NOT NULL, game_date DATE NOT NULL,
+    player_name TEXT NOT NULL, team_id BIGINT NOT NULL, opponent_team_id BIGINT NOT NULL,
+    is_home BOOLEAN NOT NULL, minutes DOUBLE PRECISION NOT NULL,  -- actual minutes, used as model input
+    eligible BOOLEAN NOT NULL, reason TEXT NOT NULL DEFAULT '',
+    pred_pts DOUBLE PRECISION, pred_reb DOUBLE PRECISION, pred_ast DOUBLE PRECISION,
+    pred_fg3m DOUBLE PRECISION, pred_stl DOUBLE PRECISION, pred_blk DOUBLE PRECISION,
+    pred_fgm DOUBLE PRECISION, pred_fga DOUBLE PRECISION, pred_ftm DOUBLE PRECISION, pred_fta DOUBLE PRECISION,
+    actual_pts DOUBLE PRECISION NOT NULL, actual_reb DOUBLE PRECISION NOT NULL,
+    actual_ast DOUBLE PRECISION NOT NULL, actual_fg3m DOUBLE PRECISION NOT NULL,
+    actual_stl DOUBLE PRECISION NOT NULL, actual_blk DOUBLE PRECISION NOT NULL,
+    actual_fgm DOUBLE PRECISION NOT NULL, actual_fga DOUBLE PRECISION NOT NULL,
+    actual_ftm DOUBLE PRECISION NOT NULL, actual_fta DOUBLE PRECISION NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (game_id, player_id)
+);
+CREATE INDEX IF NOT EXISTS idx_model_eval_results_game_date ON model_eval_results (game_date);
+CREATE INDEX IF NOT EXISTS idx_model_eval_results_player ON model_eval_results (player_id, game_date);
+```
+
+### 2. NEW `backend/model_stats_inference/serving/nightly.py` — pure sync fetch + eval
+
+Reuses `rdata._to_datetime/_regular_season_only/build_team_allowed`, `research/config.MIN_MINUTES`, `EvalRow`/`_actual_line` from `serving/simulation.py`, `LiveInference.predict_many`.
+
+- `season_for(d: date) -> str` — month ≥ 8 → season starts that year (`2026-01-15` → `"2025-26"`).
+- `@dataclass NightFetch`: `game_date, player_games, team_games, expected_games, complete`.
+- `fetch_night(game_date) -> NightFetch`:
+  - `PlayerGameLogs`/`TeamGameLogs` with `season_nullable=season_for(d)`, `date_from_nullable=date_to_nullable=MM/DD/YYYY`, `season_type_nullable="Regular Season"`, plus the sleep/timeout conventions from `rdata` (its `_fetch` loops whole seasons — small `_fetch_one_day` here).
+  - Insert `SEASON` column; `rdata._to_datetime` + `_regular_season_only`; drop player rows with `MIN` null or `< MIN_MINUTES`.
+  - `ScoreboardV2(game_date=...)` → `expected_games` (GAME_ID prefix `002`), `complete` = all final AND `len(team_games) == 2*expected` AND player logs non-empty; `expected == 0 → complete=True`.
+- `evaluate_night(store, inference, night) -> list[EvalRow]` — mirror `SeasonSimulator._evaluate_all` (`simulation.py:338`): opponent map from `build_team_allowed(night.team_games)`, `is_home = "vs" in MATCHUP`, `minutes = float(MIN)`; **pre-filter unknown teams** into ineligible `EvalRow`s; batch the rest through `predict_many`.
+- `attach_positions(store, player_games)` — map `PLAYER_ID` → last known `POSITION` from `store.players`, fallback `""`.
+- Only touch to existing ML code: add `game_id: str = ""` (defaulted) to `EvalRow` in `simulation.py`.
+
+### 3. EDIT `backend/app/services/db_service.py` — following the existing pool/try-except pattern, returning success booleans
+
+- `get_fs_rows_before(game_date) -> (player_records, team_records)` — both fs tables `WHERE game_date < $1`.
+- `fs_has_date(game_date) -> bool` — leakage guard.
+- `insert_fs_rows(player_rows, team_rows) -> bool` — executemany, `ON CONFLICT DO NOTHING`.
+- `get_model_nightly_run(game_date) -> Optional[dict]` / `upsert_model_nightly_run(game_date, status, num_games, num_rows) -> bool`.
+- `insert_model_eval_rows(rows) -> bool` — `ON CONFLICT (game_id, player_id) DO UPDATE`.
+- DataFrame ↔ records conversion lives in the service layer, not DBService.
+
+### 4. NEW `backend/app/services/model_nightly_service.py` — the single orchestrating function
+
+`ModelNightlyService` singleton (`__new__` like `SimulationService`), `asyncio.Lock`, heavy sync work via `asyncio.to_thread`.
+
+- `run_for_date(game_date, force=False) -> str`:
+  1. Ledger row exists (not force) → `"already_processed"`.
+  2. `fs_has_date(d)` → mark `store_already_ingested` → return (leakage guard).
+  3. `night = await to_thread(nightly.fetch_night, d)`.
+  4. `expected_games == 0` → mark `no_games`.
+  5. `not night.complete` → `"incomplete_data"` (NOT marked; next slot retries).
+  6. Read raw rows `< d` from Postgres → `to_thread`: DataFrames → derive `team_allowed`/`team_own` → `FeatureStore.build()`.
+  7. Store empty → `"store_not_bootstrapped"` error status (tells you to run bootstrap).
+  8. `to_thread`: `LiveInference(store)` + `evaluate_night`.
+  9. Map `EvalRow`s → dicts; `insert_model_eval_rows` — failure → `"db_write_failed"` (retry next slot).
+  10. `attach_positions` → `insert_fs_rows(night)`.
+  11. Mark `processed`.
+- `run_catchup()` — last 7 dates ending IL-yesterday, oldest first, each fully completing before the next (each date rebuilds its own pre-date store; a few extra seconds, maximal simplicity).
+- `bootstrap(force=False, until_date=None)` — one-time init: `fetch_player_logs`/`fetch_team_logs`/`fetch_positions` for `research/config.SEASONS` → clean rows (regular season, `MIN >= MIN_MINUTES`, merge `POSITION`) → bulk `insert_fs_rows`. Refuses if fs tables non-empty unless `force`. `until_date` inserts only rows before it (for E2E testing mid-season replay).
+- `__main__` CLI: `python -m app.services.model_nightly_service [--date YYYY-MM-DD] [--force] [--bootstrap] [--until-date YYYY-MM-DD]`.
+
+### 5. NEW `backend/app/services/model_nightly_scheduler.py`
+
+Copy of `estimator_scheduler.py` structure: `ISRAEL_TZ`, `SCHEDULE_TIMES = [(9,0),(9,30),(10,0),(10,30),(11,0)]`, `_compute_next_trigger()`; loop calls `ModelNightlyService().run_catchup()` in try/except with `logger.exception`. Skip-once-processed is automatic via the ledger.
+
+### 6. EDIT `backend/app/config.py` + `backend/app/main.py` + `.env.example`
+
+- Settings: `model_nightly_enabled: bool = False` (alias `MODEL_NIGHTLY_ENABLED`).
+- `main.py` lifespan, after the estimator scheduler line (~51), mirroring injury gating:
+  `if settings.model_nightly_enabled: asyncio.create_task(model_nightly_scheduler.start_scheduler())`.
+
+### 7. EDIT `backend/docker-compose.yml` — local Postgres
+
+```yaml
+  postgres:
+    image: postgres:16-alpine
+    container_name: fantasy-postgres
+    environment: {POSTGRES_USER: fantasy, POSTGRES_PASSWORD: fantasy, POSTGRES_DB: fantasy}
+    ports: ["5432:5432"]
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./migrations:/docker-entrypoint-initdb.d:ro   # all *.sql are CREATE IF NOT EXISTS → safe auto-apply on first init
+    healthcheck: {test: ["CMD-SHELL", "pg_isready -U fantasy -d fantasy"], interval: 5s, timeout: 3s, retries: 10}
+```
+
+`fantasy-backend` gets `depends_on: postgres (service_healthy)` and `DATABASE_URL: postgresql://fantasy:fantasy@postgres:5432/fantasy`. Host-run dev: `DATABASE_URL=postgresql://fantasy:fantasy@localhost:5432/fantasy` in `backend/.env`. Existing volume: `docker compose exec -T postgres psql -U fantasy -d fantasy < migrations/create_model_pipeline_tables.sql`.
+
+### 8. NEW `backend/tests/services/test_model_nightly_service.py`
+
+- `season_for` edge dates (Nov → same season, Mar → prior-year season, Aug → new season).
+- `evaluate_night` on a tiny synthetic store: predictions computed pre-ingest; ineligible player gets reason + actuals; unknown-team row doesn't abort the batch.
+- Idempotency: fake DB + monkeypatched `fetch_night`; second run → `already_processed`; `fs_has_date` true → `store_already_ingested`; failed eval insert → run not marked.
+
+## Verification
+
+1. `cd backend && docker compose up -d postgres`; confirm the 4 tables via `psql -c '\dt'`.
+2. Bootstrap with a mid-season cutoff (offseason-safe E2E — it's July): `DATABASE_URL=... uv run python -m app.services.model_nightly_service --bootstrap --until-date 2026-01-15`.
+3. `... --date 2026-01-15` → `processed` (nba_api serves historical dates).
+4. `SELECT COUNT(*), COUNT(pred_pts) FROM model_eval_results WHERE game_date='2026-01-15'`; sanity-check pred vs actual magnitudes; check `model_nightly_runs`; confirm `fs_player_games` now has 2026-01-15 rows.
+5. Rerun → `already_processed`; delete ledger row, rerun → `store_already_ingested` (leakage guard); eval rows unchanged.
+6. `MODEL_NIGHTLY_ENABLED=true uv run uvicorn app.main:app` → "Model nightly scheduler started" + next-trigger log; flag off → disabled log.
+7. `uv run pytest tests/services/test_model_nightly_service.py`.


### PR DESCRIPTION
## What

Production wiring for the `model_stats_inference` package so the model is ready for next season: a scheduled morning job that, every day of the season:

1. **Fetches only last night's games** via nba_api (`ScoreboardV2` + single-day `PlayerGameLogs`/`TeamGameLogs`), distinguishing off-nights (0 scheduled games → done) from data lag (games not final → retry at the next slot).
2. **Retro-predicts every player's line with the minutes they actually played**, from feature-store state that excludes the night itself (leakage-safe by construction).
3. **Appends predicted-vs-actual rows** to `model_eval_results` (wide `pred_*`/`actual_*` columns per stat) for ongoing model monitoring.
4. **Grows the feature store** with the night's raw rows.

## Design

- **Postgres-backed feature store**: raw rows in `fs_player_games`/`fs_team_games` are the source of truth; player/team vectors are rebuilt in memory per run via the existing `FeatureStore.build()` (no parquet store dir, survives container restarts).
- **Idempotency**: `model_nightly_runs` ledger per date + an unconditional leakage guard (a date whose rows are already in the store is never re-predicted).
- **Scheduler**: 9:00–11:00 Asia/Jerusalem retry slots (same hand-rolled pattern as `estimator_scheduler`), gated by `MODEL_NIGHTLY_ENABLED` (default **false** — flip near opening night). 7-day catch-up window so downtime leaves no holes.
- **Bootstrap CLI**: `python -m app.services.model_nightly_service --bootstrap [--until-date] [--force]` seeds the store from `research/config.SEASONS`; drops players whose newest game is 2+ years old (retired); forced re-bootstrap truncates and rebuilds clean.
- **Local dev**: `postgres:16` service added to docker-compose with auto-applied migrations.
- Only touch to existing ML code: a defaulted `game_id` field on `EvalRow`.

Full design doc: `docs/nightly-model-pipeline-plan.md`.

## Verification

- Replayed real 2025-26 nights E2E against local Postgres (bootstrap cut at a date, then consecutive `--date` runs): 9/10/4/10-game slates, ~190-230 players per night, **PTS MAE 3.6-4.2**; idempotency (`already_processed`), leakage guard (`store_already_ingested`), and off-season (`no_games`) behaviors all verified live.
- 258 tests pass (15 new: synthetic-store evaluation + orchestration/idempotency branches).

## Notes

- nba_api may block datacenter IPs — verify the fetch from the production host before enabling.
- Pre-season checklist: bump `SEASONS`, re-bootstrap `--force`, optionally retrain models, set `MODEL_NIGHTLY_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)