### PR TITLE
feat(model): materialize feature vectors + resident in-memory serving store

### DIFF
--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -696,18 +696,90 @@ class DBService:
             return False
 
     async def truncate_fs_tables(self) -> bool:
-        """Wipe the raw-row store (forced re-bootstrap starts from a clean slate)."""
+        """Wipe the raw-row store AND derived vectors (forced re-bootstrap starts clean)."""
         pool = await self._get_pool()
         if pool is None:
             return False
         try:
             async with pool.acquire() as conn:
-                await conn.execute("TRUNCATE fs_player_games, fs_team_games")
-            logger.info("Truncated feature-store tables")
+                await conn.execute(
+                    "TRUNCATE fs_player_games, fs_team_games, "
+                    "fs_player_vectors, fs_team_allowed_vectors, fs_team_own_vectors"
+                )
+            logger.info("Truncated feature-store + vector tables")
             return True
         except Exception as e:
             logger.error(f"Failed to truncate feature-store tables: {e}")
             return False
+
+    async def upsert_feature_vectors(
+        self, player_rows: list[tuple], team_allowed_rows: list[tuple], team_own_rows: list[tuple]
+    ) -> bool:
+        """Upsert the materialized 'as of now' vectors. player_rows tuple order:
+        (player_id, player_name, team_id, position, last_game_date, games_count,
+         eligible, features_json). team rows: (team_id, features_json)."""
+        pool = await self._get_pool()
+        if pool is None:
+            return False
+        try:
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    if player_rows:
+                        await conn.executemany(
+                            """
+                            INSERT INTO fs_player_vectors
+                                (player_id, player_name, team_id, position,
+                                 last_game_date, games_count, eligible, features, updated_at)
+                            VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb, NOW())
+                            ON CONFLICT (player_id) DO UPDATE SET
+                                player_name    = EXCLUDED.player_name,
+                                team_id        = EXCLUDED.team_id,
+                                position       = EXCLUDED.position,
+                                last_game_date = EXCLUDED.last_game_date,
+                                games_count    = EXCLUDED.games_count,
+                                eligible       = EXCLUDED.eligible,
+                                features       = EXCLUDED.features,
+                                updated_at     = NOW()
+                            """,
+                            player_rows,
+                        )
+                    for table, rows in (
+                        ("fs_team_allowed_vectors", team_allowed_rows),
+                        ("fs_team_own_vectors", team_own_rows),
+                    ):
+                        if rows:
+                            await conn.executemany(
+                                f"""
+                                INSERT INTO {table} (team_id, features, updated_at)
+                                VALUES ($1, $2::jsonb, NOW())
+                                ON CONFLICT (team_id) DO UPDATE SET
+                                    features   = EXCLUDED.features,
+                                    updated_at = NOW()
+                                """,
+                                rows,
+                            )
+            logger.info(
+                f"Upserted {len(player_rows)} player + {len(team_allowed_rows)} team feature vectors"
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to upsert feature vectors: {e}")
+            return False
+
+    async def load_feature_vectors(self) -> tuple[list[dict], list[dict], list[dict]]:
+        """(player_vectors, team_allowed_vectors, team_own_vectors) rows for serving."""
+        pool = await self._get_pool()
+        if pool is None:
+            return [], [], []
+        try:
+            async with pool.acquire() as conn:
+                pv = await conn.fetch("SELECT * FROM fs_player_vectors")
+                tav = await conn.fetch("SELECT * FROM fs_team_allowed_vectors")
+                tov = await conn.fetch("SELECT * FROM fs_team_own_vectors")
+                return [dict(r) for r in pv], [dict(r) for r in tav], [dict(r) for r in tov]
+        except Exception as e:
+            logger.error(f"Failed to load feature vectors: {e}")
+            return [], [], []
 
     async def get_model_nightly_run(self, game_date: date) -> Optional[dict]:
         pool = await self._get_pool()

--- a/backend/app/services/model_nightly_service.py
+++ b/backend/app/services/model_nightly_service.py
@@ -1,10 +1,16 @@
 """Nightly model pipeline: fetch last night's games, retro-predict with real
-minutes, persist predicted-vs-actual, and grow the Postgres-backed feature store.
+minutes, persist predicted-vs-actual, grow the feature store, and refresh the
+materialized feature vectors.
 
-The feature store's source of truth is the raw-row tables (fs_player_games /
-fs_team_games); vectors are rebuilt in memory per run via FeatureStore.build().
-Predictions for a night are computed from rows strictly before it, so they are
-leakage-safe by construction. A model_nightly_runs ledger row per date makes the
+Storage layout in Postgres:
+  - fs_player_games / fs_team_games  : raw game rows, the source of truth.
+  - fs_*_vectors                     : the 'as of now' player/team vectors,
+    DERIVED from the raw rows and re-materialized every morning so a live
+    inference path can load ready-to-use vectors without recomputing.
+
+Predictions for a night are computed from rows strictly before it (leakage-safe
+by construction); the vectors written afterwards include that night, so they are
+current for the *next* game. A model_nightly_runs ledger row per date makes the
 9:00-11:00 scheduler retries no-ops after one success.
 
 Manual runs:
@@ -15,7 +21,9 @@ Manual runs:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import math
 from datetime import date, datetime, timedelta
 from typing import Optional
 from zoneinfo import ZoneInfo
@@ -25,8 +33,9 @@ import pandas as pd
 from app.services.db_service import DBService
 from model_stats_inference.research import config as rconfig
 from model_stats_inference.research import data as rdata
+from model_stats_inference.serving import config as sconfig
 from model_stats_inference.serving import nightly
-from model_stats_inference.serving.feature_store import FeatureStore
+from model_stats_inference.serving.feature_store import _PLAYER_META, FeatureStore
 from model_stats_inference.serving.inference import LiveInference
 from model_stats_inference.serving.simulation import EvalRow
 
@@ -84,6 +93,67 @@ def _eval_to_tuple(ev: EvalRow, game_date: date) -> tuple:
     )
 
 
+# --- feature-vector (de)serialization --------------------------------------
+
+def _features_json(series: pd.Series, feature_cols: list[str]) -> str:
+    """One vector row's features as a JSON object (NaN -> null)."""
+    out = {}
+    for c in feature_cols:
+        v = series[c]
+        out[c] = None if v is None or (isinstance(v, float) and math.isnan(v)) else float(v)
+    return json.dumps(out)
+
+
+def _serialize_vectors(store: FeatureStore) -> tuple[list[tuple], list[tuple], list[tuple]]:
+    """FeatureStore vectors -> DB row tuples for upsert_feature_vectors."""
+    pv = store.player_vectors
+    pfeat = [c for c in pv.columns if c not in _PLAYER_META]
+    player_rows = []
+    for _, row in pv.iterrows():
+        games = int(row["games_count"])
+        last = row["last_game_date"]
+        last = pd.Timestamp(last).date() if pd.notna(last) else None
+        player_rows.append((
+            int(row["PLAYER_ID"]), str(row.get("PLAYER_NAME", "")), int(row["TEAM_ID"]),
+            str(row.get("POSITION", "")), last, games,
+            games >= sconfig.MIN_INFERENCE_GAMES, _features_json(row, pfeat),
+        ))
+
+    def team_rows(tv: pd.DataFrame) -> list[tuple]:
+        feat = [c for c in tv.columns if c != "TEAM_ID"]
+        return [(int(row["TEAM_ID"]), _features_json(row, feat)) for _, row in tv.iterrows()]
+
+    return player_rows, team_rows(store.team_allowed_vectors), team_rows(store.team_own_vectors)
+
+
+def _player_vectors_df(records: list[dict]) -> pd.DataFrame:
+    """DB rows -> player_vectors DataFrame (meta cols + expanded features, NaN restored)."""
+    rows = []
+    for r in records:
+        feats = r["features"] if isinstance(r["features"], dict) else json.loads(r["features"])
+        rows.append({
+            "PLAYER_ID": r["player_id"], "PLAYER_NAME": r["player_name"],
+            "TEAM_ID": r["team_id"], "POSITION": r["position"],
+            "last_game_date": pd.Timestamp(r["last_game_date"]) if r["last_game_date"] else pd.NaT,
+            "games_count": r["games_count"], **feats,
+        })
+    df = pd.DataFrame(rows)
+    feat_cols = [c for c in df.columns if c not in _PLAYER_META]
+    df[feat_cols] = df[feat_cols].astype(float)  # None -> NaN
+    return df
+
+
+def _team_vectors_df(records: list[dict]) -> pd.DataFrame:
+    rows = []
+    for r in records:
+        feats = r["features"] if isinstance(r["features"], dict) else json.loads(r["features"])
+        rows.append({"TEAM_ID": r["team_id"], **feats})
+    df = pd.DataFrame(rows)
+    feat_cols = [c for c in df.columns if c != "TEAM_ID"]
+    df[feat_cols] = df[feat_cols].astype(float)
+    return df
+
+
 class ModelNightlyService:
     _instance = None
 
@@ -91,7 +161,12 @@ class ModelNightlyService:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._lock = asyncio.Lock()
+            cls._instance._store_lock = asyncio.Lock()
             cls._instance._db = DBService()
+            # Resident inference store: loaded from the vectors tables on first
+            # use and kept in memory so intra-day predictions never touch the DB.
+            # Invalidated whenever the nightly job refreshes the vectors.
+            cls._instance._inference_store: Optional[FeatureStore] = None
         return cls._instance
 
     # --- morning entry point (called by the scheduler) ----------------------
@@ -126,11 +201,15 @@ class ModelNightlyService:
                 return "already_processed"
 
         # Leakage guard (unconditional, even with --force): once the night's rows
-        # are in the store, a "prediction" for it would see its own outcome.
+        # are in the store, a "prediction" for it would see its own outcome. We
+        # still refresh vectors — this branch is the crash-recovery path (raw rows
+        # committed on a prior run but vectors/ledger not), so vectors may be stale.
         has_date = await db.fs_has_date(game_date)
         if has_date is None:
             return "db_unavailable"
         if has_date:
+            await self._refresh_vectors_through(game_date)
+            self._invalidate_inference_store()
             await db.upsert_model_nightly_run(game_date, "store_already_ingested", 0, 0)
             return "store_already_ingested"
 
@@ -150,8 +229,8 @@ class ModelNightlyService:
             logger.error("Feature-store tables are empty — run --bootstrap first")
             return "store_not_bootstrapped"
 
-        evals, night_players = await asyncio.to_thread(
-            self._predict_sync, player_recs, team_recs, night
+        evals, night_players, vectors = await asyncio.to_thread(
+            self._process_sync, player_recs, team_recs, night
         )
 
         eval_rows = [_eval_to_tuple(ev, game_date) for ev in evals]
@@ -164,6 +243,13 @@ class ModelNightlyService:
         ):
             return "db_write_failed"
 
+        # Post-night vectors (include the night just ingested). If this fails the
+        # raw rows are already committed, so the run is left unmarked; the retry
+        # hits the leakage-guard branch above and refreshes vectors from the DB.
+        if not await db.upsert_feature_vectors(*vectors):
+            return "db_write_failed"
+        self._invalidate_inference_store()
+
         await db.upsert_model_nightly_run(
             game_date, "processed", night.expected_games, len(eval_rows)
         )
@@ -174,12 +260,21 @@ class ModelNightlyService:
         )
         return "processed"
 
+    async def _refresh_vectors_through(self, game_date: date) -> None:
+        """Rebuild and upsert vectors from all rows up to and including game_date."""
+        player_recs, team_recs = await self._db.get_fs_rows_before(game_date + timedelta(days=1))
+        if not player_recs or not team_recs:
+            return
+        vectors = await asyncio.to_thread(self._vectors_from_records, player_recs, team_recs)
+        await self._db.upsert_feature_vectors(*vectors)
+
     @staticmethod
-    def _predict_sync(
+    def _process_sync(
         player_recs: list[dict], team_recs: list[dict], night: nightly.NightFetch
-    ) -> tuple[list[EvalRow], pd.DataFrame]:
-        """Heavy pandas/sklearn work, run in a thread: build the pre-night store,
-        score the night, and annotate the night's player rows with positions."""
+    ) -> tuple[list[EvalRow], pd.DataFrame, tuple[list, list, list]]:
+        """Heavy pandas/sklearn work in a thread: build the pre-night store, score
+        the night (leakage-safe), then fold the night in to materialize post-night
+        vectors."""
         players = _records_to_frame(player_recs).sort_values(["PLAYER_ID", "GAME_DATE"])
         team_games = _records_to_frame(team_recs)
         store = FeatureStore.build(
@@ -190,12 +285,64 @@ class ModelNightlyService:
         inference = LiveInference(store)
         evals = nightly.evaluate_night(store, inference, night)
         night_players = nightly.attach_positions(store, night.player_games)
-        return evals, night_players
+        # Fold last night in so the stored vectors are current for tonight's games.
+        store.update_with_nightly_results(night_players, night.team_games)
+        return evals, night_players, _serialize_vectors(store)
+
+    @staticmethod
+    def _vectors_from_records(
+        player_recs: list[dict], team_recs: list[dict]
+    ) -> tuple[list, list, list]:
+        players = _records_to_frame(player_recs).sort_values(["PLAYER_ID", "GAME_DATE"])
+        team_games = _records_to_frame(team_recs)
+        store = FeatureStore.build(
+            players.reset_index(drop=True),
+            rdata.build_team_allowed(team_games),
+            rdata.build_team_own(team_games),
+        )
+        return _serialize_vectors(store)
+
+    # --- serving: resident in-memory store (for a future inference tab) -------
+
+    async def get_inference_store(self, refresh: bool = False) -> Optional[FeatureStore]:
+        """Return the resident inference store, loading it from the vectors tables
+        only on first use (or when ``refresh=True``). Held in memory so every
+        prediction during the day is served from RAM without a DB round-trip.
+        Returns None if the vectors have not been materialized yet.
+        """
+        if self._inference_store is not None and not refresh:
+            return self._inference_store
+        async with self._store_lock:
+            if self._inference_store is not None and not refresh:
+                return self._inference_store
+            self._inference_store = await self._load_inference_store()
+            return self._inference_store
+
+    async def _load_inference_store(self) -> Optional[FeatureStore]:
+        pv, tav, tov = await self._db.load_feature_vectors()
+        if not pv:
+            return None
+        return await asyncio.to_thread(
+            lambda: FeatureStore.from_vectors(
+                _player_vectors_df(pv), _team_vectors_df(tav), _team_vectors_df(tov)
+            )
+        )
+
+    def _invalidate_inference_store(self) -> None:
+        """Drop the resident store so the next prediction reloads the fresh vectors.
+
+        Correct when the scheduler and the serving path share this process (the
+        default — the scheduler runs in the FastAPI lifespan). A separate serving
+        process should instead call get_inference_store(refresh=True) after the
+        morning window, since it can't observe this in-process invalidation.
+        """
+        self._inference_store = None
 
     # --- one-time init -------------------------------------------------------
 
     async def bootstrap(self, force: bool = False, until_date: Optional[date] = None) -> str:
-        """Seed fs_player_games / fs_team_games from nba_api for research SEASONS."""
+        """Seed fs_player_games / fs_team_games from nba_api for research SEASONS,
+        then materialize the initial vectors so inference is ready immediately."""
         async with self._lock:
             p_count, t_count = await self._db.fs_counts()
             if p_count or t_count:
@@ -216,11 +363,24 @@ class ModelNightlyService:
                 f"for {', '.join(rconfig.SEASONS)}"
                 + (f" (until {until_date})" if until_date else "")
             )
-            ok = await self._db.insert_fs_rows(
+            if not await self._db.insert_fs_rows(
                 _frame_to_tuples(players, _FS_PLAYER_COLS),
                 _frame_to_tuples(team_games, _FS_TEAM_COLS),
-            )
-            return "bootstrapped" if ok else "db_write_failed"
+            ):
+                return "db_write_failed"
+
+            vectors = await asyncio.to_thread(self._vectors_from_frames, players, team_games)
+            if not await self._db.upsert_feature_vectors(*vectors):
+                return "db_write_failed"
+            self._invalidate_inference_store()
+            return "bootstrapped"
+
+    @staticmethod
+    def _vectors_from_frames(players: pd.DataFrame, team_games: pd.DataFrame) -> tuple[list, list, list]:
+        store = FeatureStore.build(
+            players, rdata.build_team_allowed(team_games), rdata.build_team_own(team_games)
+        )
+        return _serialize_vectors(store)
 
     @staticmethod
     def _cached_positions() -> Optional[pd.DataFrame]:

--- a/backend/migrations/create_feature_vector_tables.sql
+++ b/backend/migrations/create_feature_vector_tables.sql
@@ -1,0 +1,31 @@
+-- Materialized feature vectors: the "as of now" state per player/team, rebuilt
+-- and upserted every morning after the nightly ingest. These are DERIVED from
+-- fs_player_games/fs_team_games (the source of truth) — kept here only so a live
+-- inference path can load ready-to-use vectors without recomputing.
+--
+-- Feature values live in a JSONB blob (feature_name -> value) because the set is
+-- large (~150 per player) and config-driven; NaN is stored as JSON null.
+
+CREATE TABLE IF NOT EXISTS fs_player_vectors (
+    player_id      BIGINT PRIMARY KEY,
+    player_name    TEXT   NOT NULL DEFAULT '',
+    team_id        BIGINT NOT NULL,
+    position       TEXT   NOT NULL DEFAULT '',
+    last_game_date DATE,
+    games_count    INT    NOT NULL DEFAULT 0,
+    eligible       BOOLEAN NOT NULL DEFAULT FALSE,   -- games_count >= MIN_INFERENCE_GAMES
+    features       JSONB  NOT NULL,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS fs_team_allowed_vectors (
+    team_id    BIGINT PRIMARY KEY,
+    features   JSONB  NOT NULL,          -- OPP_ALLOWED_* (defense: what opponents produce)
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS fs_team_own_vectors (
+    team_id    BIGINT PRIMARY KEY,
+    features   JSONB  NOT NULL,          -- TEAM_* (own offensive context / pace)
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/model_stats_inference/serving/feature_store.py
+++ b/backend/model_stats_inference/serving/feature_store.py
@@ -80,6 +80,23 @@ class FeatureStore:
         team_own = pd.read_parquet(d / "team_own.parquet")
         return cls.build(players, team_allowed, team_own)
 
+    @classmethod
+    def from_vectors(
+        cls,
+        player_vectors: pd.DataFrame,
+        team_allowed_vectors: pd.DataFrame,
+        team_own_vectors: pd.DataFrame,
+    ) -> "FeatureStore":
+        """Inference-only store built from materialized vectors (no raw rows).
+
+        Sufficient for ``get_player_state`` / ``get_team_state`` and therefore for
+        ``LiveInference`` — but it holds no raw game rows, so it cannot ingest or
+        recompute. Used by a live serving path that loads vectors straight from
+        the DB instead of rebuilding them from history.
+        """
+        empty = pd.DataFrame()
+        return cls(empty, empty, empty, player_vectors, team_allowed_vectors, team_own_vectors)
+
     # --- persistence (DB-ready; parquet now) -------------------------------
 
     def save(self, store_dir: Path | None = None) -> None:

--- a/backend/model_stats_inference/serving/test_nightly.py
+++ b/backend/model_stats_inference/serving/test_nightly.py
@@ -7,7 +7,7 @@ from datetime import date
 import pandas as pd
 
 from model_stats_inference.serving import nightly
-from model_stats_inference.serving.inference import LiveInference
+from model_stats_inference.serving.inference import LiveInference, PredictionRequest
 
 from .conftest import FULL_PID, LOW_PID, TEAM_A, TEAM_B
 
@@ -115,6 +115,24 @@ def test_drop_stale_players_boundary():
     out = nightly.drop_stale_players(df, as_of)
     assert set(out["PLAYER_ID"]) == {1}
     assert len(out) == 2  # active player keeps his old rows too
+
+
+def test_from_vectors_matches_original(store, models_dir):
+    """A store rebuilt from just its vectors must produce identical predictions —
+    this is the DB-vectors serving path (no raw rows, no recompute)."""
+    from model_stats_inference.serving.feature_store import FeatureStore
+
+    original = LiveInference(store, models_dir)
+    lite_store = FeatureStore.from_vectors(
+        store.player_vectors, store.team_allowed_vectors, store.team_own_vectors
+    )
+    lite = LiveInference(lite_store, models_dir)
+
+    req = [PredictionRequest(player_id=FULL_PID, opponent_team_id=TEAM_B,
+                             is_home=True, game_date=NIGHT_DATE, minutes=32.0)]
+    (a,), _ = original.predict_many(req)
+    (b,), _ = lite.predict_many(req)
+    assert {k: v.value for k, v in a.stats.items()} == {k: v.value for k, v in b.stats.items()}
 
 
 def test_attach_positions(store):

--- a/backend/tests/services/test_model_nightly_service.py
+++ b/backend/tests/services/test_model_nightly_service.py
@@ -1,6 +1,8 @@
 """Orchestration tests for ModelNightlyService (fake DB + fake fetch, no network)."""
 
+import json
 from datetime import date
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
@@ -12,6 +14,9 @@ from app.services.model_nightly_service import (
     _FS_TEAM_COLS,
     ModelNightlyService,
     _eval_to_tuple,
+    _player_vectors_df,
+    _serialize_vectors,
+    _team_vectors_df,
 )
 from model_stats_inference.serving.nightly import NightFetch
 from model_stats_inference.serving.simulation import EvalRow
@@ -27,9 +32,11 @@ class FakeDB:
         self.team_recs = [{"team_id": 10}]
         self.eval_insert_ok = True
         self.fs_insert_ok = True
+        self.vec_insert_ok = True
         self.marked = []          # (game_date, status, num_games, num_rows)
         self.eval_rows = None
         self.fs_rows = None
+        self.vectors_written = None
 
     async def get_model_nightly_run(self, d):
         return self.run
@@ -47,6 +54,10 @@ class FakeDB:
     async def insert_fs_rows(self, player_rows, team_rows):
         self.fs_rows = (player_rows, team_rows)
         return self.fs_insert_ok
+
+    async def upsert_feature_vectors(self, player_rows, team_allowed_rows, team_own_rows):
+        self.vectors_written = (player_rows, team_allowed_rows, team_own_rows)
+        return self.vec_insert_ok
 
     async def upsert_model_nightly_run(self, d, status, num_games, num_rows):
         self.marked.append((d, status, num_games, num_rows))
@@ -81,6 +92,9 @@ def _night_players_frame():
                               1) for c in _FS_PLAYER_COLS}])
 
 
+_DUMMY_VECTORS = ([("pv",)], [("tav",)], [("tov",)])
+
+
 @pytest.fixture
 def service(monkeypatch):
     ModelNightlyService._instance = None
@@ -88,6 +102,11 @@ def service(monkeypatch):
     svc._db = FakeDB()
     monkeypatch.setattr(
         mns.nightly, "fetch_night", lambda d: pytest.fail("fetch_night should not be called")
+    )
+    # Never build a real store from the fake records in unit tests.
+    monkeypatch.setattr(
+        ModelNightlyService, "_vectors_from_records",
+        staticmethod(lambda p, t: ([], [], [])),
     )
     yield svc
     ModelNightlyService._instance = None
@@ -99,8 +118,8 @@ def _allow_fetch(monkeypatch, night):
 
 def _allow_predict(monkeypatch, evals):
     monkeypatch.setattr(
-        ModelNightlyService, "_predict_sync",
-        staticmethod(lambda p, t, n: (evals, _night_players_frame())),
+        ModelNightlyService, "_process_sync",
+        staticmethod(lambda p, t, n: (evals, _night_players_frame(), _DUMMY_VECTORS)),
     )
 
 
@@ -111,10 +130,11 @@ async def test_already_processed_skips_fetch(service):
 
 
 @pytest.mark.asyncio
-async def test_leakage_guard_when_rows_already_ingested(service):
+async def test_leakage_guard_when_rows_already_ingested_refreshes_vectors(service):
     service._db.has_date = True
     assert await service.run_for_date(GAME_DATE) == "store_already_ingested"
     assert service._db.marked == [(GAME_DATE, "store_already_ingested", 0, 0)]
+    assert service._db.vectors_written is not None  # vectors refreshed on recovery
 
 
 @pytest.mark.asyncio
@@ -159,26 +179,80 @@ async def test_failed_eval_write_does_not_mark_run(service, monkeypatch):
     service._db.eval_insert_ok = False
     assert await service.run_for_date(GAME_DATE) == "db_write_failed"
     assert service._db.marked == []
-    assert service._db.fs_rows is None  # night must not be ingested either
+    assert service._db.fs_rows is None
 
 
 @pytest.mark.asyncio
-async def test_happy_path_processes_and_ingests(service, monkeypatch):
+async def test_failed_vector_write_does_not_mark_run(service, monkeypatch):
+    _allow_fetch(monkeypatch, _night())
+    _allow_predict(monkeypatch, [_eval_row()])
+    service._db.vec_insert_ok = False
+    assert await service.run_for_date(GAME_DATE) == "db_write_failed"
+    assert service._db.marked == []  # raw rows written, but run left unmarked to retry
+
+
+@pytest.mark.asyncio
+async def test_happy_path_processes_ingests_and_writes_vectors(service, monkeypatch):
     _allow_fetch(monkeypatch, _night())
     _allow_predict(monkeypatch, [_eval_row(), _eval_row(eligible=False)])
     assert await service.run_for_date(GAME_DATE) == "processed"
     assert service._db.marked == [(GAME_DATE, "processed", 2, 2)]
     assert len(service._db.eval_rows) == 2
     player_rows, team_rows = service._db.fs_rows
-    assert len(player_rows) == 1 and len(player_rows[0]) == len(_FS_PLAYER_COLS)
-    assert len(team_rows) == 1 and len(team_rows[0]) == len(_FS_TEAM_COLS)
+    assert len(player_rows[0]) == len(_FS_PLAYER_COLS)
+    assert len(team_rows[0]) == len(_FS_TEAM_COLS)
+    assert service._db.vectors_written == _DUMMY_VECTORS
+
+
+@pytest.mark.asyncio
+async def test_processing_invalidates_in_memory_store(service, monkeypatch):
+    _allow_fetch(monkeypatch, _night())
+    _allow_predict(monkeypatch, [_eval_row()])
+    service._inference_store = SimpleNamespace()  # pretend a store is cached
+    await service.run_for_date(GAME_DATE)
+    assert service._inference_store is None  # invalidated so next inference reloads fresh
 
 
 def test_eval_to_tuple_shapes():
     eligible = _eval_to_tuple(_eval_row(), GAME_DATE)
     ineligible = _eval_to_tuple(_eval_row(eligible=False), GAME_DATE)
     assert len(eligible) == 10 + 2 * len(_EVAL_STATS)
-    assert eligible[10:20] == tuple(5.0 for _ in _EVAL_STATS)      # pred_*
-    assert eligible[20:30] == tuple(6.0 for _ in _EVAL_STATS)      # actual_*
-    assert ineligible[10:20] == tuple(None for _ in _EVAL_STATS)   # NULL preds
+    assert eligible[10:20] == tuple(5.0 for _ in _EVAL_STATS)
+    assert eligible[20:30] == tuple(6.0 for _ in _EVAL_STATS)
+    assert ineligible[10:20] == tuple(None for _ in _EVAL_STATS)
     assert ineligible[20:30] == tuple(6.0 for _ in _EVAL_STATS)
+
+
+def test_vector_serialize_roundtrip():
+    """Serialize vectors -> (simulate DB read) -> reconstruct; values, NaN, and the
+    eligible flag must survive intact."""
+    pv = pd.DataFrame({
+        "PLAYER_ID": [1, 2], "PLAYER_NAME": ["A", "B"], "TEAM_ID": [10, 20],
+        "POSITION": ["G", "F"],
+        "last_game_date": [pd.Timestamp("2026-01-01"), pd.Timestamp("2026-01-02")],
+        "games_count": [15, 5],
+        "PTS_global_mean": [20.0, float("nan")], "REB_w5_mean": [5.0, 3.0],
+    })
+    tav = pd.DataFrame({"TEAM_ID": [10, 20], "OPP_ALLOWED_PTS_global_mean": [110.0, 108.0]})
+    tov = pd.DataFrame({"TEAM_ID": [10, 20], "TEAM_PTS_global_mean": [112.0, 109.0]})
+    store = SimpleNamespace(player_vectors=pv, team_allowed_vectors=tav, team_own_vectors=tov)
+
+    prows, tarows, torows = _serialize_vectors(store)
+
+    # eligibility computed from games_count vs MIN_INFERENCE_GAMES (10)
+    assert prows[0][6] is True and prows[1][6] is False
+
+    # simulate what DBService.load_feature_vectors returns (lowercase cols, json str)
+    precs = [{"player_id": p[0], "player_name": p[1], "team_id": p[2], "position": p[3],
+              "last_game_date": p[4], "games_count": p[5], "eligible": p[6],
+              "features": p[7]} for p in prows]
+    tacs = [{"team_id": t[0], "features": t[1]} for t in tarows]
+
+    pv2 = _player_vectors_df(precs).set_index("PLAYER_ID")
+    assert pv2.loc[1, "PTS_global_mean"] == 20.0
+    assert pd.isna(pv2.loc[2, "PTS_global_mean"])      # NaN survived the JSON round-trip
+    assert pv2.loc[1, "REB_w5_mean"] == 5.0
+    tav2 = _team_vectors_df(tacs).set_index("TEAM_ID")
+    assert tav2.loc[10, "OPP_ALLOWED_PTS_global_mean"] == 110.0
+    # features JSON is valid and NaN was stored as null
+    assert json.loads(prows[1][7])["PTS_global_mean"] is None

--- a/docs/nightly-model-pipeline-plan.md
+++ b/docs/nightly-model-pipeline-plan.md
@@ -15,7 +15,9 @@ The `model_stats_inference` package (PR #100) can predict per-player stat lines,
 | Decision | Choice |
 |---|---|
 | Store persistence | **Postgres-backed feature store now** (no parquet store dir, no docker volume). |
-| Store shape | **Raw game rows only** in Postgres (`fs_player_games`, `fs_team_games`). Vectors are derived — rebuilt in memory each run via `FeatureStore.build()`. `team_allowed`/`team_own` derived in memory from raw team logs via `rdata.build_team_allowed/build_team_own`. |
+| Store shape | Raw game rows (`fs_player_games`, `fs_team_games`) are the **source of truth**; vectors are derived. **Materialized vectors** are also persisted (`fs_player_vectors`, `fs_team_allowed_vectors`, `fs_team_own_vectors`, features as JSONB) so a live inference path loads ready-to-use vectors without recomputing. The nightly job rebuilds vectors from the raw rows each run and upserts them (post-night, so they're current for tonight's games). |
+| Serving | `ModelNightlyService` holds a **resident in-memory `FeatureStore`** (`get_inference_store`), loaded once from the vector tables and reused for every intra-day prediction (no per-request DB hit). Invalidated whenever the nightly job refreshes vectors; a separate serving process refreshes via `get_inference_store(refresh=True)`. `FeatureStore.from_vectors` builds an inference-only store (no raw rows). |
+| Stale players | Bootstrap-only: players whose newest game is ≥2 years old are dropped (`drop_stale_players`). Forced re-bootstrap truncates raw + vector tables first. |
 | Bootstrap depth | Same seasons as `research/config.py: SEASONS` (currently 2023-24 → 2025-26; bump each season). Row-level filter only (regular season, `MIN >= MIN_MINUTES`); do **not** apply the research corpus filter `MIN_PLAYER_GAMES=20` — `MIN_INFERENCE_GAMES=10` gates at read time. |
 | Eval output | DB table only (`model_eval_results`). No API route, no UI tab for now. |
 | Retraining | Out of scope. Models stay frozen `models/*.joblib`; retrain manually offline. |


### PR DESCRIPTION
Builds on the nightly pipeline (#101, merged) to make a future live-inference tab fast: persist the derived feature vectors and hold them in memory so intra-day predictions never touch the DB.

## What

- **Persisted vectors** — new tables `fs_player_vectors`, `fs_team_allowed_vectors`, `fs_team_own_vectors` (features stored as JSONB, NaN → null). The nightly job rebuilds and upserts them each morning *after* ingesting the night, so they're current for tonight's games. Bootstrap materializes the initial set; a forced re-bootstrap truncates the vector tables too.
- **`FeatureStore.from_vectors`** — an inference-only store built from vectors alone (no raw rows), sufficient for `LiveInference`.
- **Resident in-memory store** — `ModelNightlyService.get_inference_store()` loads the vectors once and keeps them in RAM; every prediction during the day is served from memory with no DB round-trip. Invalidated whenever the nightly job refreshes vectors (same-process); a separate serving process refreshes via `get_inference_store(refresh=True)`.

The raw rows (`fs_player_games`/`fs_team_games`) remain the source of truth; vectors are a rebuildable materialization, so there's no drift risk.

## Measured latency (full 3-season store, local Postgres)

| operation | time |
|---|---|
| load resident store from vectors DB (once) | ~75 ms |
| subsequent `get_inference_store()` (cached in RAM) | ~0 ms |
| single prediction (drag minutes slider) | ~30–70 ms |
| predict a 230-player slate — one batched `predict_many` | ~270 ms (1.1 ms/player) |
| morning job compute (build + predict-all + vectorize, excl. nba_api fetch) | ~730 ms |

Guidance for the tab: **batch predictions in a single `predict_many`** — per-call overhead (~30 ms, 10 sklearn models) dominates, so batching is ~30× faster per player than a per-player loop.

## Verification

- E2E on local Postgres: bootstrap writes 743 player + 30 team vectors; a nightly run updates them post-night; `get_inference_store` loads once (~75 ms) then serves from RAM and predicts correctly off the in-memory vectors.
- 262 tests pass, including a round-trip test proving `from_vectors` inference equals the raw-row store.

## Migration

Apply `backend/migrations/create_feature_vector_tables.sql` (auto-applied on fresh docker-compose init; for an existing DB: `docker compose exec -T postgres psql -U fantasy -d fantasy < migrations/create_feature_vector_tables.sql`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)