### PR TITLE
chore(deps): split test/ml-research deps into uv dependency-groups

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
+# Runtime image already has exactly the deps it needs baked in;
+# `uv run` must not try to reconcile against default-groups as non-root appuser.
+ENV UV_NO_SYNC=1
+
 # Install dependencies as root, then switch to appuser
 COPY pyproject.toml uv.lock ./
 RUN pip install uv && uv sync --frozen --no-group test --no-group ml-research

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # Install dependencies as root, then switch to appuser
 COPY pyproject.toml uv.lock ./
-RUN pip install uv && uv sync --frozen
+RUN pip install uv && uv sync --frozen --no-group test --no-group ml-research
 
 # Copy application code and set ownership
 COPY --chown=appuser:appuser app/ ./app/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,9 +11,6 @@ dependencies = [
     "langchain-openai>=0.2.9",
     "pandas>=2.3.0",
     "pydantic-settings>=2.10.1",
-    "pytest>=8.4.1",
-    "pytest-asyncio>=0.24.0",
-    "pytest-cov>=6.2.1",
     "python-dotenv>=1.1.1",
     "python-multipart>=0.0.22",
     "slowapi>=0.1.9",
@@ -24,11 +21,15 @@ dependencies = [
     "numpy>=1.24.0",
     "nba-api>=1.11.0",
     "scikit-learn>=1.9.0",
-    "matplotlib>=3.11.0",
     "pyarrow>=24.0.0",
-    "shap>=0.52.0",
-    "lightgbm>=4.6.0",
 ]
+
+[dependency-groups]
+test = ["pytest>=8.4.1", "pytest-asyncio>=0.24.0", "pytest-cov>=6.2.1"]
+ml-research = ["shap>=0.52.0", "matplotlib>=3.11.0", "lightgbm>=4.6.0"]
+
+[tool.uv]
+default-groups = ["test"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -499,8 +499,6 @@ dependencies = [
     { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-openai" },
-    { name = "lightgbm" },
-    { name = "matplotlib" },
     { name = "nba-api" },
     { name = "numpy" },
     { name = "pandas" },
@@ -508,15 +506,23 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pyarrow" },
     { name = "pydantic-settings" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "scikit-learn" },
-    { name = "shap" },
     { name = "slowapi" },
     { name = "uvicorn" },
+]
+
+[package.dev-dependencies]
+ml-research = [
+    { name = "lightgbm" },
+    { name = "matplotlib" },
+    { name = "shap" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -526,8 +532,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "langchain", specifier = ">=0.3.27" },
     { name = "langchain-openai", specifier = ">=0.2.9" },
-    { name = "lightgbm", specifier = ">=4.6.0" },
-    { name = "matplotlib", specifier = ">=3.11.0" },
     { name = "nba-api", specifier = ">=1.11.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pandas", specifier = ">=2.3.0" },
@@ -535,15 +539,23 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pyarrow", specifier = ">=24.0.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
-    { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "scikit-learn", specifier = ">=1.9.0" },
-    { name = "shap", specifier = ">=0.52.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "uvicorn", specifier = ">=0.34.3" },
+]
+
+[package.metadata.requires-dev]
+ml-research = [
+    { name = "lightgbm", specifier = ">=4.6.0" },
+    { name = "matplotlib", specifier = ">=3.11.0" },
+    { name = "shap", specifier = ">=0.52.0" },
+]
+test = [
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Resolves Issue 2 from `docs/plans/MODEL_DEPLOYMENT_ISSUES.md` — prod Docker image was installing `pytest`, `shap`, `matplotlib`, `lightgbm` alongside runtime deps, bloating the image on Render's free tier (already slow ~15min cold starts).
- Traced serving code (`model_stats_inference/serving/`) — prod models are sklearn `HistGradientBoostingRegressor`/`Ridge`, not lightgbm; shap/matplotlib only used in `research/`/`training/plots.py`. None needed at serving runtime.
- Split into uv dependency-groups: `test` (pytest, pytest-asyncio, pytest-cov) and `ml-research` (shap, matplotlib, lightgbm). Kept `scikit-learn`/`pyarrow` in main deps — needed to unpickle joblib model artifacts.
- Set `default-groups = ["test"]` so CI's plain `uv sync --frozen` keeps installing pytest without changes to `pr-check.yaml`.
- Dockerfile now runs `uv sync --frozen --no-group test --no-group ml-research` to exclude both from the prod image.

## Test plan
- [x] `uv sync --frozen` (CI-equivalent) installs pytest, excludes ml-research group by default
- [x] `uv run python -m pytest -q` — 262 passed
- [x] `uv sync --frozen --no-group test --no-group ml-research` (Dockerfile-equivalent) drops 19 packages (pytest*, shap, matplotlib, lightgbm + transitive deps)
- [x] `uv run python -c "import app.main"` succeeds with only prod deps installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)