### PR TITLE
feat(nav): reorganize navbar behind VITE_FF_NAV_REORG flag

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router'
+import { Routes, Route, Navigate } from 'react-router'
 import Layout from './components/Layout'
 import GlobalLoadingBar from './components/GlobalLoadingBar'
 import Dashboard from './pages/Dashboard'
@@ -16,7 +16,7 @@ import FeatureStore from './pages/FeatureStore'
 import NotFound from './pages/NotFound'
 import PlayerRankings from './pages/PlayerRankings'
 import Projections from './pages/Projections'
-import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS } from './config/featureFlags'
+import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG } from './config/featureFlags'
 
 function App() {
   return (
@@ -26,7 +26,11 @@ function App() {
         <Route path="/" element={<Layout />}>
           <Route index element={<Dashboard />} />
           <Route path="rankings" element={<Rankings />} />
-          <Route path="shots" element={<Shots />} />
+          {FF_NAV_REORG ? (
+            <Route path="shots" element={<Navigate to="/analytics" replace />} />
+          ) : (
+            <Route path="shots" element={<Shots />} />
+          )}
           <Route path="teams" element={<Teams />} />
           <Route path="team/:teamId" element={<TeamDetail />} />
           <Route path="analytics" element={<Analytics />} />

--- a/frontend/src/components/GlobalLoadingBar.tsx
+++ b/frontend/src/components/GlobalLoadingBar.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from 'react'
 import NProgress from 'nprogress'
 import 'nprogress/nprogress.css'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from '../store/hooks'
 
 NProgress.configure({ showSpinner: false, minimum: 0.2, speed: 300 })
 
 export default function GlobalLoadingBar() {
-  const isFetching = useSelector((state: any) =>
-    Object.values(state.fantasyApi?.queries ?? {}).some((q: any) => q?.status === 'pending')
+  const isFetching = useAppSelector((state) =>
+    Object.values(state.fantasyApi?.queries ?? {}).some((q) => q?.status === 'pending')
   )
 
   useEffect(() => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, Link, useLocation } from 'react-router'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Footer from './Footer'
-import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS } from '../config/featureFlags'
+import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG } from '../config/featureFlags'
 
 const Layout = () => {
   const location = useLocation()
@@ -37,6 +37,10 @@ const Layout = () => {
   ]
 
   const closeMobileMenu = () => setMobileMenuOpen(false)
+
+  if (FF_NAV_REORG) {
+    return <ReorgLayout darkMode={darkMode} setDarkMode={setDarkMode} />
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 flex flex-col">
@@ -120,6 +124,330 @@ const Layout = () => {
                     {item.label}
                   </Link>
                 ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </nav>
+
+      <main className="py-8 flex-1">
+        <Outlet />
+      </main>
+
+      <Footer />
+    </div>
+  )
+}
+
+interface ReorgLayoutProps {
+  darkMode: boolean
+  setDarkMode: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+interface NavLeaf {
+  path: string
+  label: string
+  icon: string
+}
+
+const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
+  const location = useLocation()
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [mobileToolsOpen, setMobileToolsOpen] = useState(false)
+  const [toolsOpen, setToolsOpen] = useState(false)
+  const toolsRef = useRef<HTMLDivElement>(null)
+  const toolsButtonRef = useRef<HTMLButtonElement>(null)
+  const toolsMenuRef = useRef<HTMLDivElement>(null)
+  const [toolsMenuPos, setToolsMenuPos] = useState<{ top: number; right: number } | null>(null)
+
+  const toolsItems: NavLeaf[] = [
+    ...(FF_PROJECTIONS ? [{ path: '/projections', label: 'Projections', icon: '🔭' }] : []),
+    { path: '/estimator', label: 'Estimator', icon: '🔮' },
+    { path: '/trade', label: 'Trade', icon: '🔄' },
+    ...(FF_FEATURE_STORE ? [{ path: '/feature-store', label: 'Feature Store', icon: '🗄️' }] : []),
+  ]
+
+  const isToolsActive = toolsItems.some((item) => item.path === location.pathname)
+
+  const closeMobileMenu = () => {
+    setMobileMenuOpen(false)
+    setMobileToolsOpen(false)
+  }
+
+  useEffect(() => {
+    if (!toolsOpen) return
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        toolsRef.current &&
+        !toolsRef.current.contains(e.target as Node) &&
+        !toolsMenuRef.current?.contains(e.target as Node)
+      ) {
+        setToolsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [toolsOpen])
+
+  useEffect(() => {
+    if (!toolsOpen) return
+    const updatePos = () => {
+      const rect = toolsButtonRef.current?.getBoundingClientRect()
+      if (rect) {
+        setToolsMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right })
+      }
+    }
+    updatePos()
+    window.addEventListener('resize', updatePos)
+    window.addEventListener('scroll', updatePos, true)
+    return () => {
+      window.removeEventListener('resize', updatePos)
+      window.removeEventListener('scroll', updatePos, true)
+    }
+  }, [toolsOpen])
+
+  const handleToolsKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Escape') {
+      setToolsOpen(false)
+      toolsButtonRef.current?.focus()
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setToolsOpen(true)
+      requestAnimationFrame(() => {
+        const firstLink = toolsMenuRef.current?.querySelector('a')
+        ;(firstLink as HTMLAnchorElement | null)?.focus()
+      })
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      setToolsOpen((o) => !o)
+    }
+  }
+
+  const handleToolsMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      setToolsOpen(false)
+      toolsButtonRef.current?.focus()
+    }
+  }
+
+  const desktopItemClass = (active: boolean) =>
+    `inline-flex items-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium whitespace-nowrap transition-all duration-200 ${
+      active
+        ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 shadow-sm'
+        : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
+    }`
+
+  const mobileItemClass = (active: boolean) =>
+    `inline-flex items-center px-4 py-3 rounded-md text-base font-medium transition-all duration-200 ${
+      active
+        ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 shadow-sm'
+        : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
+    }`
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 flex flex-col">
+      <nav className="sticky top-0 z-40 bg-white dark:bg-gray-900 shadow-lg border-b border-gray-200 dark:border-gray-700">
+        <div className="w-full px-3">
+          <div className="flex items-center justify-between h-14 gap-2">
+            <Link
+              to="/"
+              className="text-sm font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent whitespace-nowrap shrink-0"
+            >
+              🏀 Fantasy League
+            </Link>
+
+            {/* Desktop Navigation */}
+            <div className="hidden md:flex items-center gap-0.5 overflow-x-auto">
+              <Link to="/teams" className={desktopItemClass(location.pathname === '/teams')} title="Teams">
+                <span className="text-xl xl:text-sm">👥</span>
+                <span className="hidden xl:inline">Teams</span>
+              </Link>
+              <Link to="/rankings" className={desktopItemClass(location.pathname === '/rankings')} title="League Rankings">
+                <span className="text-xl xl:text-sm">🏆</span>
+                <span className="hidden xl:inline">League Rankings</span>
+              </Link>
+              {FF_PLAYER_RANKINGS && (
+                <Link
+                  to="/player-rankings"
+                  className={desktopItemClass(location.pathname === '/player-rankings')}
+                  title="Player Rankings"
+                >
+                  <span className="text-xl xl:text-sm">📋</span>
+                  <span className="hidden xl:inline">Player Rankings</span>
+                </Link>
+              )}
+              <Link to="/analytics" className={desktopItemClass(location.pathname === '/analytics')} title="Analytics">
+                <span className="text-xl xl:text-sm">📈</span>
+                <span className="hidden xl:inline">Analytics</span>
+              </Link>
+              <Link to="/players" className={desktopItemClass(location.pathname === '/players')} title="Players">
+                <span className="text-xl xl:text-sm">⛹️</span>
+                <span className="hidden xl:inline">Players</span>
+              </Link>
+
+              <div
+                ref={toolsRef}
+                className="relative"
+                onMouseEnter={() => setToolsOpen(true)}
+                onMouseLeave={() => setToolsOpen(false)}
+              >
+                <button
+                  ref={toolsButtonRef}
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-expanded={toolsOpen}
+                  onClick={() => setToolsOpen((o) => !o)}
+                  onKeyDown={handleToolsKeyDown}
+                  className={desktopItemClass(isToolsActive)}
+                  title="Tools"
+                >
+                  <span className="text-xl xl:text-sm">🛠️</span>
+                  <span className="hidden xl:inline">Tools</span>
+                  <span className="hidden xl:inline text-[10px]">▾</span>
+                </button>
+                {toolsOpen && toolsMenuPos && (
+                  <div
+                    ref={toolsMenuRef}
+                    role="menu"
+                    onKeyDown={handleToolsMenuKeyDown}
+                    onMouseEnter={() => setToolsOpen(true)}
+                    onMouseLeave={() => setToolsOpen(false)}
+                    style={{ position: 'fixed', top: toolsMenuPos.top, right: toolsMenuPos.right }}
+                    className="min-w-[10rem] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg py-1 z-50"
+                  >
+                    {toolsItems.map((item) => (
+                      <Link
+                        key={item.path}
+                        role="menuitem"
+                        to={item.path}
+                        onClick={() => setToolsOpen(false)}
+                        className={`flex items-center gap-2 px-3 py-2 text-xs font-medium whitespace-nowrap transition-colors duration-200 ${
+                          location.pathname === item.path
+                            ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300'
+                            : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
+                        }`}
+                      >
+                        <span className="text-sm">{item.icon}</span>
+                        <span>{item.label}</span>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <Link to="/injuries" className={desktopItemClass(location.pathname === '/injuries')} title="Injuries">
+                <span className="text-xl xl:text-sm">🩺</span>
+                <span className="hidden xl:inline">Injuries</span>
+              </Link>
+              <Link to="/nba-teams" className={desktopItemClass(location.pathname === '/nba-teams')} title="NBA">
+                <span className="text-xl xl:text-sm">🏀</span>
+                <span className="hidden xl:inline">NBA</span>
+              </Link>
+
+              <div className="mx-3 h-6 w-0.5 bg-gray-300 dark:bg-gray-500 shrink-0 rounded-full" />
+              <button
+                onClick={() => setDarkMode(d => !d)}
+                className="p-1.5 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors shrink-0"
+                aria-label="Toggle dark mode"
+                title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+              >
+                <span className="text-sm">{darkMode ? '☀️' : '🌙'}</span>
+              </button>
+            </div>
+
+            {/* Mobile: dark toggle + hamburger */}
+            <div className="md:hidden flex items-center gap-1">
+              <button
+                onClick={() => setDarkMode(d => !d)}
+                className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Toggle dark mode"
+              >
+                <span className="text-base">{darkMode ? '☀️' : '🌙'}</span>
+              </button>
+              <button
+                onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+                className="inline-flex items-center justify-center p-2 rounded-md text-gray-600 dark:text-gray-300 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 transition-all"
+                aria-expanded={mobileMenuOpen}
+                aria-label="Toggle navigation menu"
+              >
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="2" stroke="currentColor">
+                  {mobileMenuOpen ? (
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  ) : (
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                  )}
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          {/* Mobile Navigation Menu */}
+          {mobileMenuOpen && (
+            <div className="md:hidden pb-4">
+              <div className="flex flex-col space-y-1">
+                <Link to="/teams" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/teams')}>
+                  <span className="mr-3 text-xl">👥</span>
+                  Teams
+                </Link>
+                <Link to="/rankings" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/rankings')}>
+                  <span className="mr-3 text-xl">🏆</span>
+                  League Rankings
+                </Link>
+                {FF_PLAYER_RANKINGS && (
+                  <Link
+                    to="/player-rankings"
+                    onClick={closeMobileMenu}
+                    className={mobileItemClass(location.pathname === '/player-rankings')}
+                  >
+                    <span className="mr-3 text-xl">📋</span>
+                    Player Rankings
+                  </Link>
+                )}
+                <Link to="/analytics" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/analytics')}>
+                  <span className="mr-3 text-xl">📈</span>
+                  Analytics
+                </Link>
+                <Link to="/players" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/players')}>
+                  <span className="mr-3 text-xl">⛹️</span>
+                  Players
+                </Link>
+
+                <button
+                  type="button"
+                  onClick={() => setMobileToolsOpen((o) => !o)}
+                  aria-expanded={mobileToolsOpen}
+                  className={mobileItemClass(isToolsActive) + ' justify-between w-full'}
+                >
+                  <span className="flex items-center">
+                    <span className="mr-3 text-xl">🛠️</span>
+                    Tools
+                  </span>
+                  <span className={`text-sm transition-transform duration-200 ${mobileToolsOpen ? 'rotate-180' : ''}`}>▾</span>
+                </button>
+                {mobileToolsOpen && (
+                  <div className="flex flex-col space-y-1 pl-6">
+                    {toolsItems.map((item) => (
+                      <Link
+                        key={item.path}
+                        to={item.path}
+                        onClick={closeMobileMenu}
+                        className={mobileItemClass(location.pathname === item.path)}
+                      >
+                        <span className="mr-3 text-xl">{item.icon}</span>
+                        {item.label}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+
+                <Link to="/injuries" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/injuries')}>
+                  <span className="mr-3 text-xl">🩺</span>
+                  Injuries
+                </Link>
+                <Link to="/nba-teams" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/nba-teams')}>
+                  <span className="mr-3 text-xl">🏀</span>
+                  NBA
+                </Link>
               </div>
             </div>
           )}

--- a/frontend/src/components/ShootingStatsSection.tsx
+++ b/frontend/src/components/ShootingStatsSection.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react'
+import { useGetLeagueShotsQuery } from '../store/api/fantasyApi'
+import { Link } from 'react-router'
+import LoadingSpinner from './LoadingSpinner'
+import ErrorMessage from './ErrorMessage'
+import DataDateBadge from './DataDateBadge'
+import type { TeamShotStats } from '../types/api'
+
+const ShootingStatsSection = () => {
+  const [sortBy, setSortBy] = useState<string>('fg_percentage')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+
+  const { data, error, isLoading } = useGetLeagueShotsQuery()
+
+  const handleSort = (column: string) => {
+    if (sortBy === column) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortBy(column)
+      setSortOrder('desc')
+    }
+  }
+
+  const formatPercentage = (value: number) => {
+    return (value * 100).toFixed(4) + '%'
+  }
+
+  let leagueAverageFG = 0
+  let leagueAverageFT = 0
+  if (data?.shots) {
+    leagueAverageFG = data.shots.reduce((acc, curr) => acc + curr.fg_percentage, 0) / data.shots.length
+    leagueAverageFT = data.shots.reduce((acc, curr) => acc + curr.ft_percentage, 0) / data.shots.length
+  }
+
+  const getPercentageColor = (percentage: number, type: 'fg' | 'ft') => {
+    if (type === 'fg') {
+      if (percentage >= leagueAverageFG) return 'text-green-600'
+      if (percentage >= leagueAverageFG - 0.03) return 'text-yellow-600'
+      return 'text-red-600'
+    }
+    if (type === 'ft') {
+      if (percentage >= leagueAverageFT) return 'text-green-600'
+      if (percentage >= leagueAverageFT - 0.03) return 'text-yellow-600'
+      return 'text-red-600'
+    }
+  }
+
+  if (isLoading) return <LoadingSpinner />
+  if (error) return <ErrorMessage message="Failed to load shots data" />
+
+  const rawShots = data?.shots || []
+
+  const shots = [...rawShots].sort((a, b) => {
+    const aValue = a[sortBy as keyof TeamShotStats]
+    const bValue = b[sortBy as keyof TeamShotStats]
+
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return sortOrder === 'asc' ? aValue - bValue : bValue - aValue
+    }
+
+    const aTeamName = a.team.team_name.toLowerCase()
+    const bTeamName = b.team.team_name.toLowerCase()
+    if (aTeamName && bTeamName && aTeamName < bTeamName) return sortOrder === 'asc' ? -1 : 1
+    if (aTeamName && bTeamName && aTeamName > bTeamName) return sortOrder === 'asc' ? 1 : -1
+    return 0
+  })
+
+  const columns = [
+    { key: 'team', label: 'Team', sortable: true },
+    { key: 'fgm', label: 'FGM', sortable: true },
+    { key: 'fga', label: 'FGA', sortable: true },
+    { key: 'fg_percentage', label: 'FG%', sortable: true },
+    { key: 'ftm', label: 'FTM', sortable: true },
+    { key: 'fta', label: 'FTA', sortable: true },
+    { key: 'ft_percentage', label: 'FT%', sortable: true },
+    { key: 'gp', label: 'GP', sortable: true },
+  ]
+
+  return (
+    <div className="card">
+      <div className="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-orange-600 to-red-600 rounded-t-lg">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2">
+          <div>
+            <h2 className="text-2xl font-bold text-white">League Shooting Statistics</h2>
+            <p className="text-orange-100 mt-1">
+              Field goal and free throw shooting stats for all teams. Click column headers to sort.
+            </p>
+          </div>
+          {data?.data_date && <DataDateBadge dataDate={data.data_date} />}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {columns.map((column) => (
+                <th
+                  key={column.key}
+                  className={`table-header ${
+                    column.sortable ? 'cursor-pointer hover:bg-gray-100 transition-colors duration-150' : ''
+                  }`}
+                  onClick={() => column.sortable && handleSort(column.key)}
+                >
+                  <div className="flex items-center">
+                    {column.label}
+                    {column.sortable && sortBy === column.key && (
+                      <span className="ml-1">
+                        {sortOrder === 'asc' ? '↑' : '↓'}
+                      </span>
+                    )}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {shots.map((team: TeamShotStats) => (
+              <tr key={team.team.team_id} className="hover:bg-orange-50 dark:hover:bg-gray-700 transition-colors duration-150 border-b border-gray-100">
+                <td className="table-cell">
+                  <Link
+                    to={`/team/${team.team.team_id}`}
+                    className="text-blue-600 hover:text-blue-800 font-semibold transition-colors duration-150 hover:underline"
+                  >
+                    {team.team.team_name}
+                  </Link>
+                </td>
+                <td className="table-cell font-medium">{team.fgm}</td>
+                <td className="table-cell font-medium">{team.fga}</td>
+                <td className={`table-cell font-medium ${getPercentageColor(team.fg_percentage, 'fg')}`}>
+                  {formatPercentage(team.fg_percentage)}
+                </td>
+                <td className="table-cell font-medium">{team.ftm}</td>
+                <td className="table-cell font-medium">{team.fta}</td>
+                <td className={`table-cell font-medium ${getPercentageColor(team.ft_percentage, 'ft')}`}>
+                  {formatPercentage(team.ft_percentage)}
+                </td>
+                <td className="table-cell font-medium">{team.gp}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export default ShootingStatsSection

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -2,3 +2,4 @@ export const FF_PLAYER_RANKINGS = import.meta.env.VITE_SHOW_PLAYER_RANKINGS === 
 export const FF_MATCHUP_QUALITY = import.meta.env.VITE_FF_MATCHUP_QUALITY === 'true';
 export const FF_FEATURE_STORE = import.meta.env.VITE_FF_FEATURE_STORE === 'true';
 export const FF_PROJECTIONS = import.meta.env.VITE_FF_PROJECTIONS === 'true';
+export const FF_NAV_REORG = import.meta.env.VITE_FF_NAV_REORG === 'true';

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -4,8 +4,18 @@ import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import DataDateBadge from '../components/DataDateBadge'
 import RankingsOverTimeChart from '../components/RankingsOverTimeChart'
+import ShootingStatsSection from '../components/ShootingStatsSection'
 import type { HeatmapData, Team } from '../types/api'
 import { getHeatmapColor, getTextColor } from '../utils/colorUtils'
+import { FF_NAV_REORG } from '../config/featureFlags'
+
+type AnalyticsTab = 'heatmap' | 'rankingsOverTime' | 'shootingStats'
+
+const ANALYTICS_TABS: { key: AnalyticsTab; label: string }[] = [
+  { key: 'heatmap', label: 'Heatmap' },
+  { key: 'rankingsOverTime', label: 'Rankings Over Time' },
+  { key: 'shootingStats', label: 'Shooting Stats' },
+]
 
 interface SortedHeatmapData {
   teams: Team[]
@@ -33,6 +43,7 @@ const Analytics = () => {
     return () => obs.disconnect()
   }, [])
 
+  const [activeTab, setActiveTab] = useState<AnalyticsTab>('heatmap')
   const [sortBy, setSortBy] = useState<string | null>(null)
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [highlightedTeamId, setHighlightedTeamId] = useState<number | null>(null)
@@ -340,25 +351,71 @@ const Analytics = () => {
     )
   }
 
-  return (
-    <div className="space-y-6">
-      <div className="bg-white rounded-lg shadow p-6">
-        <div className="flex flex-wrap items-center justify-between gap-2 mb-6">
-          <h1 className="text-2xl font-bold text-gray-900">League Analytics</h1>
-          <DataDateBadge dataDate={heatmapData?.data_date} />
+  if (!FF_NAV_REORG) {
+    return (
+      <div className="space-y-6">
+        <div className="bg-white rounded-lg shadow p-6">
+          <div className="flex flex-wrap items-center justify-between gap-2 mb-6">
+            <h1 className="text-2xl font-bold text-gray-900">League Analytics</h1>
+            <DataDateBadge dataDate={heatmapData?.data_date} />
+          </div>
+
+          {renderHeatmapTable(
+            heatmapData,
+            "Performance Heatmap",
+            "Visual representation of team performance across different categories. Red indicates below-average performance, white indicates league-average performance, and green indicates above-average performance. Click column headers to sort by team name or category values."
+          )}
+
         </div>
 
-        {renderHeatmapTable(
-          heatmapData,
-          "Performance Heatmap",
-          "Visual representation of team performance across different categories. Red indicates below-average performance, white indicates league-average performance, and green indicates above-average performance. Click column headers to sort by team name or category values."
-        )}
+        <div className="bg-white rounded-lg shadow p-6">
+          <RankingsOverTimeChart />
+        </div>
+      </div>
+    )
+  }
 
+  return (
+    <div>
+      <div className="sticky top-14 z-10 bg-gray-50 dark:bg-gray-900 pt-4 pb-3 mb-6">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">League Analytics</h1>
+          <DataDateBadge dataDate={heatmapData?.data_date} />
+        </div>
+        <div className="flex gap-2 overflow-x-auto">
+          {ANALYTICS_TABS.map(tab => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`px-4 py-2 rounded-md text-sm font-semibold whitespace-nowrap transition-colors ${
+                activeTab === tab.key
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
       </div>
 
-      <div className="bg-white rounded-lg shadow p-6">
-        <RankingsOverTimeChart />
-      </div>
+      {activeTab === 'heatmap' && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+          {renderHeatmapTable(
+            heatmapData,
+            "Performance Heatmap",
+            "Visual representation of team performance across different categories. Red indicates below-average performance, white indicates league-average performance, and green indicates above-average performance. Click column headers to sort by team name or category values."
+          )}
+        </div>
+      )}
+
+      {activeTab === 'rankingsOverTime' && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+          <RankingsOverTimeChart />
+        </div>
+      )}
+
+      {activeTab === 'shootingStats' && <ShootingStatsSection />}
     </div>
   )
 }

--- a/frontend/src/pages/FeatureStore.tsx
+++ b/frontend/src/pages/FeatureStore.tsx
@@ -91,11 +91,11 @@ export default function FeatureStore() {
   const { data: pState } = useGetFeatureStorePlayerStateQuery(playerId as number, { skip: playerId == null });
   const { data: tState } = useGetFeatureStoreTeamStateQuery(teamId as number, { skip: teamId == null });
 
-  const players = list?.players ?? [];
   const visiblePlayers = useMemo(() => {
+    const players = list?.players ?? [];
     const q = playerFilter.toLowerCase();
     return players.filter((p) => !q || p.player_name.toLowerCase().includes(q) || p.team_abbr.toLowerCase().includes(q));
-  }, [players, playerFilter]);
+  }, [list?.players, playerFilter]);
 
   if (isLoading) return <LoadingSpinner />;
   if (error) return <ErrorMessage message="Failed to load the feature store. Is the backend running?" />;

--- a/frontend/src/pages/PlayerRankings.tsx
+++ b/frontend/src/pages/PlayerRankings.tsx
@@ -78,6 +78,7 @@ export default function PlayerRankings() {
     if (players.length > 0) {
       handleCalculate()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [players])
 
   const sortedPlayers = useMemo(() => {

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -327,7 +327,7 @@ const PlayerTable = ({
   const toggleExpand = (name: string) => {
     setExpandedRows(prev => {
       const next = new Set(prev);
-      next.has(name) ? next.delete(name) : next.add(name);
+      if (next.has(name)) next.delete(name); else next.add(name);
       return next;
     });
   };

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -35,7 +35,7 @@ const TeamDetail = () => {
   const toggleExpand = (name: string) => {
     setExpandedRows(prev => {
       const next = new Set(prev)
-      next.has(name) ? next.delete(name) : next.add(name)
+      if (next.has(name)) next.delete(name); else next.add(name)
       return next
     })
   }


### PR DESCRIPTION
## What

Full navbar reorganization, gated behind a new build-time flag `VITE_FF_NAV_REORG`. **Flag OFF (default) = current nav and routes render byte-for-byte unchanged.** Flag ON = the reorg. Nothing is visible to users until the flag is flipped on Render for season start.

## Why

Prep for season start — cleaner grouping and ordering without shipping a live change now. Building it behind a flag lets it merge to `dev` safely and flip on later via env var + redeploy.

## ON-state changes

- **Dashboard** dropped from nav — reachable via the logo (now a `Link` to `/`)
- **Rankings → "League Rankings"** (label only, route unchanged); **Player Rankings** promoted to a flat top-level item (no dropdown) for 1-click access
- **New "Tools" dropdown**: Projections, Estimator, Trade, Feature Store (each still behind its own flag). Real `<button>` + `aria-haspopup`/`aria-expanded`, hover + click open, Escape closes/refocuses, ArrowDown enters menu, click-outside closes. Mobile = collapsible accordion.
- **Shots removed from nav**, merged into **Analytics** as a 3rd sticky sub-tabbed section (Heatmap / Rankings Over Time / Shooting Stats). `/shots` redirects to `/analytics`. Shooting-stats query only fires when its tab is active.

## Implementation notes

- `Layout.tsx`: clean fork — `if (FF_NAV_REORG) return <ReorgLayout/>` after all hooks; OFF path untouched.
- `Analytics.tsx`: `if (!FF_NAV_REORG) return <original/>`; shooting table extracted to `ShootingStatsSection.tsx` (Shots.tsx itself untouched — still renders on the OFF `/shots` route).
- Flag is build-time (Vite bakes `VITE_*`) — same as existing flags. Season start = set `VITE_FF_NAV_REORG=true` on Render + redeploy.

## Also included

Fixed 5 pre-existing lint problems surfaced while verifying (unused-expression ternaries in Players/TeamDetail, `any` in GlobalLoadingBar, unstable `useMemo` dep in FeatureStore, missing-dep on an intentional load-once effect in PlayerRankings). Logic-equivalent, types only.

## Verification

- Build flag-OFF ✓, flag-ON ✓
- Frontend vitest: 75 passed
- Backend pytest: 258 passed
- `eslint .`: 0 problems, `tsc --noEmit`: clean
- Visual (flag ON): desktop dark-mode + mobile 375px verified — nav order, Tools dropdown (4 items, correct order), mobile Tools accordion, Analytics 3 sub-tabs, Shooting Stats table with data, `/shots` redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)