### PR TITLE
feat(draft-report): team draft value leaderboard

### DIFF
--- a/frontend/src/pages/DraftReport.tsx
+++ b/frontend/src/pages/DraftReport.tsx
@@ -1,9 +1,9 @@
-import { useState, useMemo } from 'react'
+import React, { useState, useMemo, useRef } from 'react'
 import { useGetDraftReportQuery, useGetAllPlayersQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import { FF_DRAFT_STEALS_BUSTS } from '../config/featureFlags'
-import { buildScoredPicks, topSteals, topBusts, type ScoredPick, type DraftBadge } from '../utils/draftReport'
+import { buildScoredPicks, buildTeamDiffRanking, topSteals, topBusts, MIN_GP_FOR_RANK, LOW_GP_MIN, type ScoredPick, type DraftBadge } from '../utils/draftReport'
 
 type SortCol = 'pick' | 'diff' | 'valueRank'
 
@@ -37,6 +37,8 @@ function heatColor(p: ScoredPick): string {
 
 export default function DraftReport() {
   const [calcMode, setCalcMode] = useState<'totals' | 'per_game'>('per_game')
+  const [includeLowGp, setIncludeLowGp] = useState(false)
+  const minGp = includeLowGp ? LOW_GP_MIN : MIN_GP_FOR_RANK
   const { data: draftReport, isLoading: draftLoading, error: draftError } = useGetDraftReportQuery()
   // Same pool Player Rankings uses (season, full ESPN universe) — keeps the
   // draft report's value calc consistent with the rest of the app instead of
@@ -47,10 +49,36 @@ export default function DraftReport() {
 
   const scoredPicks = useMemo(() => {
     if (!draftReport || !playersData) return []
-    return buildScoredPicks(draftReport.picks, playersData.players, calcMode)
-  }, [draftReport, playersData, calcMode])
+    return buildScoredPicks(draftReport.picks, playersData.players, calcMode, minGp)
+  }, [draftReport, playersData, calcMode, minGp])
 
   // const teamGrades = useMemo(() => buildTeamGrades(scoredPicks), [scoredPicks])
+  const teamDiffs = useMemo(() => buildTeamDiffRanking(scoredPicks), [scoredPicks])
+  const [diffColWidths, setDiffColWidths] = useState<number[]>([48, 190, 110, 100, 90])
+  const [expandedTeams, setExpandedTeams] = useState<Set<number>>(new Set())
+  const toggleTeam = (id: number) => setExpandedTeams(prev => {
+    const next = new Set(prev)
+    next.has(id) ? next.delete(id) : next.add(id)
+    return next
+  })
+  const diffDragRef = useRef<{ i: number; startX: number; startW: number } | null>(null)
+  const onDiffResizeDown = (i: number) => (e: React.MouseEvent) => {
+    e.preventDefault()
+    diffDragRef.current = { i, startX: e.clientX, startW: diffColWidths[i] }
+    const move = (ev: MouseEvent) => {
+      const d = diffDragRef.current
+      if (!d) return
+      const w = Math.max(40, d.startW + (ev.clientX - d.startX))
+      setDiffColWidths(prev => prev.map((x, idx) => (idx === d.i ? w : x)))
+    }
+    const up = () => {
+      diffDragRef.current = null
+      window.removeEventListener('mousemove', move)
+      window.removeEventListener('mouseup', up)
+    }
+    window.addEventListener('mousemove', move)
+    window.addEventListener('mouseup', up)
+  }
   const steals = useMemo(() => topSteals(scoredPicks), [scoredPicks])
   const busts = useMemo(() => topBusts(scoredPicks), [scoredPicks])
 
@@ -98,23 +126,34 @@ export default function DraftReport() {
       <div className="max-w-screen-2xl mx-auto space-y-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">📝 Draft Report Card</h1>
-          <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
-            {(['totals', 'per_game'] as const).map(m => (
-              <button
-                key={m}
-                onClick={() => setCalcMode(m)}
-                className={`px-3 py-1.5 ${calcMode === m ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
-              >
-                {m === 'totals' ? 'Totals' : 'Per Game'}
-              </button>
-            ))}
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={includeLowGp}
+                onChange={e => setIncludeLowGp(e.target.checked)}
+                className="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+              />
+              Include low-GP players (&lt;{MIN_GP_FOR_RANK} GP)
+            </label>
+            <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
+              {(['totals', 'per_game'] as const).map(m => (
+                <button
+                  key={m}
+                  onClick={() => setCalcMode(m)}
+                  className={`px-3 py-1.5 ${calcMode === m ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                >
+                  {m === 'totals' ? 'Totals' : 'Per Game'}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
         <p className="text-xs text-gray-400 dark:text-gray-500 -mt-4">
           Every pick vs realized season value (8-cat z-score rank). Diff = pick number − value rank: positive means the player returned more than draft slot price.
         </p>
         <p className="text-[11px] text-gray-400 dark:text-gray-500 -mt-4">
-          Value calc: season stats · min 15 GP to qualify · all 8 categories weighted equally.
+          Value calc: season stats · min {minGp} GP to qualify · all 8 categories weighted equally.
         </p>
 
         <section>
@@ -149,6 +188,84 @@ export default function DraftReport() {
             </table>
           </div>
           <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-1">Blue = returned above slot · Red = below slot / INJ / DNP · Gray = about right.</p>
+        </section>
+
+        <section>
+          <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">Team Draft Value — diff vs slot</h2>
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow overflow-x-auto">
+            <table className="text-sm" style={{ tableLayout: 'fixed', width: 'max-content', minWidth: '100%' }}>
+              <colgroup>
+                {diffColWidths.map((w, i) => <col key={i} style={{ width: `${w}px` }} />)}
+              </colgroup>
+              <thead className="bg-gray-50 dark:bg-gray-900">
+                <tr className="border-b border-gray-200 dark:border-gray-700">
+                  {(['#', 'Team', 'Ranked / Picks', 'Total Diff', 'Avg Diff'] as const).map((label, i) => (
+                    <th
+                      key={label}
+                      title={label === 'Ranked / Picks' ? `How many of the team's draft picks earned a value rank — only players with ${minGp}+ GP are ranked, so low-GP / DNP picks are left out` : undefined}
+                      className={`relative px-2 sm:px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 ${i >= 2 ? 'text-right' : 'text-left'}`}
+                    >
+                      {label}
+                      {i < diffColWidths.length - 1 && (
+                        <span
+                          onMouseDown={onDiffResizeDown(i)}
+                          className="absolute top-0 right-0 h-full w-1.5 cursor-col-resize select-none hover:bg-blue-400/60"
+                        />
+                      )}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {teamDiffs.map((t, i) => {
+                  const hasExcluded = t.unranked.length > 0
+                  const open = expandedTeams.has(t.team_id)
+                  return (
+                    <React.Fragment key={t.team_id}>
+                      <tr
+                        onClick={() => hasExcluded && toggleTeam(t.team_id)}
+                        className={`border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 ${hasExcluded ? 'cursor-pointer' : ''}`}
+                      >
+                        <td className="px-2 sm:px-3 py-1.5 sm:py-2 text-gray-400 dark:text-gray-500 font-mono text-xs">{i + 1}</td>
+                        <td className="px-2 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 truncate">{t.team_name}</td>
+                        <td className="px-2 sm:px-3 py-1.5 sm:py-2 text-right text-gray-500 dark:text-gray-400 text-xs font-mono whitespace-nowrap">
+                          {t.n}/{t.total}
+                          <span className="inline-block w-3 text-left text-amber-500 dark:text-amber-400">{hasExcluded ? (open ? '▾' : '▸') : ''}</span>
+                        </td>
+                        <td className={`px-2 sm:px-3 py-1.5 sm:py-2 text-right font-mono text-xs ${t.totalDiff >= 0 ? 'text-blue-600 dark:text-blue-400' : 'text-red-500 dark:text-red-400'}`}>
+                          {t.totalDiff > 0 ? `+${t.totalDiff}` : t.totalDiff}
+                        </td>
+                        <td className={`px-2 sm:px-3 py-1.5 sm:py-2 text-right font-semibold font-mono ${t.avgDiff >= 0 ? 'text-blue-600 dark:text-blue-400' : 'text-red-500 dark:text-red-400'}`}>
+                          {t.avgDiff > 0 ? `+${t.avgDiff.toFixed(1)}` : t.avgDiff.toFixed(1)}
+                        </td>
+                      </tr>
+                      {open && (
+                        <tr className="bg-gray-50 dark:bg-gray-900/40 border-b border-gray-100 dark:border-gray-700">
+                          <td />
+                          <td colSpan={4} className="px-2 sm:px-3 py-2">
+                            <div className="text-[11px] text-gray-400 dark:text-gray-500 mb-1">Not ranked (under {minGp} GP — excluded from diff):</div>
+                            <div className="flex flex-wrap gap-1.5">
+                              {t.unranked.map(u => (
+                                <span key={u.pick} className="inline-flex items-center gap-1 text-xs bg-white dark:bg-gray-800 rounded px-1.5 py-0.5 border border-gray-200 dark:border-gray-700">
+                                  <span className={`text-[9px] font-bold px-1 py-0.5 rounded ${BADGE_STYLES[u.badge]}`}>{u.badge}</span>
+                                  <span className="text-gray-700 dark:text-gray-200">{u.player_name}</span>
+                                  <span className="text-gray-400 dark:text-gray-500">#{u.pick} · {u.gp ?? 0}gp</span>
+                                </span>
+                              ))}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  )
+                })}
+                {teamDiffs.length === 0 && (
+                  <tr><td colSpan={5} className="px-3 py-2 text-xs text-gray-400">No qualifying picks yet.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-1">Sum / avg of (pick − value rank) over ranked picks. Positive = team's picks returned above draft slot. Rows with ▸ expand to show picks left out (under {minGp} GP). Drag column edges to resize.</p>
         </section>
 
         {FF_DRAFT_STEALS_BUSTS && (

--- a/frontend/src/utils/draftReport.ts
+++ b/frontend/src/utils/draftReport.ts
@@ -26,7 +26,25 @@ export interface TeamGrade {
   grade: 'A' | 'B' | 'C' | 'D' | 'F'
 }
 
-const MIN_GP_FOR_RANK = 15
+export interface UnrankedPick {
+  player_name: string
+  badge: DraftBadge
+  gp: number | null
+  pick: number
+}
+
+export interface TeamDiff {
+  team_id: number
+  team_name: string
+  avgDiff: number
+  totalDiff: number
+  n: number
+  total: number
+  unranked: UnrankedPick[]
+}
+
+export const MIN_GP_FOR_RANK = 15
+export const LOW_GP_MIN = 1
 const STEAL_MIN_GP = 50
 const WEIGHTS = Object.fromEntries(CATEGORIES.map(c => [c, 1])) as Record<RankingCategory, number>
 
@@ -38,18 +56,18 @@ function badgeFor(diff: number): DraftBadge {
   return 'Bust'
 }
 
-export function buildScoredPicks(picks: DraftPick[], allPlayers: Player[], calcMode: 'totals' | 'per_game'): ScoredPick[] {
+export function buildScoredPicks(picks: DraftPick[], allPlayers: Player[], calcMode: 'totals' | 'per_game', minGpForRank: number = MIN_GP_FOR_RANK): ScoredPick[] {
   const { available } = partitionByDataAvailability(allPlayers)
   // computePlayerRankings caps its returned pool at 300 (a display-perf limit
   // for the interactive Player Rankings page) — draft report needs every
-  // qualified (GP >= MIN_GP_FOR_RANK) player ranked, not just the top 300, so
+  // qualified (GP >= minGpForRank) player ranked, not just the top 300, so
   // it re-scores anyone the cap dropped against the same referencePool and
   // re-sorts the full qualified set itself.
-  const ranked = computePlayerRankings(available, { calcMode, minGp: MIN_GP_FOR_RANK, minMin: 0, position: null, weights: WEIGHTS })
+  const ranked = computePlayerRankings(available, { calcMode, minGp: minGpForRank, minMin: 0, position: null, weights: WEIGHTS })
   const referencePool = ranked.map(r => r.player)
   const zByName = new Map(ranked.map(r => [r.player.player_name, r.totalZ]))
 
-  const qualified = available.filter(p => p.stats.gp >= MIN_GP_FOR_RANK)
+  const qualified = available.filter(p => p.stats.gp >= minGpForRank)
   const fullyRanked = qualified
     .map(p => ({ player: p, totalZ: zByName.get(p.player_name) ?? scoreAgainstPool(p, referencePool, calcMode, WEIGHTS) }))
     .sort((a, b) => b.totalZ - a.totalZ)
@@ -160,6 +178,35 @@ export function buildTeamGrades(scoredPicks: ScoredPick[]): TeamGrade[] {
       hitRate: t.hitRate,
       grade: gradeForScore(t.score),
     }))
+}
+
+// Signed diff (pick − value rank) averaged per team: positive = the team's
+// picks returned above their draft slot. INJ/DNP picks carry a noisy fallback
+// diff, so only judged picks (real valueRank) count. Sorted best surplus first.
+export function buildTeamDiffRanking(scoredPicks: ScoredPick[]): TeamDiff[] {
+  const byTeam = new Map<number, { team_name: string; diffs: number[]; total: number; unranked: UnrankedPick[] }>()
+  for (const p of scoredPicks) {
+    if (!byTeam.has(p.team_id)) byTeam.set(p.team_id, { team_name: p.team_name, diffs: [], total: 0, unranked: [] })
+    const e = byTeam.get(p.team_id)!
+    e.total++
+    if (p.valueRank !== null && p.diff !== null) e.diffs.push(p.diff)
+    else e.unranked.push({ player_name: p.player_name, badge: p.badge, gp: p.gp, pick: p.pick })
+  }
+  return [...byTeam.entries()]
+    .filter(([, { diffs }]) => diffs.length > 0)
+    .map(([team_id, { team_name, diffs, total, unranked }]) => {
+      const totalDiff = diffs.reduce((s, d) => s + d, 0)
+      return {
+        team_id,
+        team_name,
+        avgDiff: totalDiff / diffs.length,
+        totalDiff,
+        n: diffs.length,
+        total,
+        unranked: unranked.sort((a, b) => a.pick - b.pick),
+      }
+    })
+    .sort((a, b) => b.avgDiff - a.avgDiff)
 }
 
 export function topSteals(scoredPicks: ScoredPick[], limit = 5): ScoredPick[] {


### PR DESCRIPTION
## What
New **Team Draft Value** leaderboard on the Draft Report page: ranks teams by avg signed diff (`pick − value rank`) over their ranked picks.

## Columns
- **# · Team · Ranked / Picks · Total Diff · Avg Diff**
- Positive diff (blue) = team's picks returned above draft slot; negative (red) = below.
- **Ranked / Picks** fraction (e.g. `12/14`) shows how many picks earned a value rank. Rows with a `▸` chevron expand inline to reveal the left-out picks (badge, player, slot, GP).
- Columns are drag-resizable.

## Low-GP toggle
Header checkbox **Include low-GP players (<15 GP)** — default off (excludes players under 15 GP from ranking, as before). When on, drops the threshold to 1 GP. Affects the whole page (board, diff table, steals/busts, All Picks). All threshold texts update dynamically.

## Notes
- 0-GP DNP picks remain unrankable even when low-GP is included.
- Only judged picks feed the diff; Avg Diff normalizes for differing ranked counts across teams.

Verified live (frontend + backend): renders 12 teams, expand/resize/toggle all work, tsc clean, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)