### PR TITLE
fix: preset time-period stats keep ESPN split instead of zeroing on DB gaps

### DIFF
--- a/backend/app/services/player_service.py
+++ b/backend/app/services/player_service.py
@@ -27,6 +27,15 @@ _DB_STAT_COLS = {
 # Custom ranges skip this gate entirely (see build_windowed_players_df) since
 # they have no ESPN split value to protect from being zeroed.
 
+# A known player with zero DB rows in a preset window is ambiguous the same
+# way: fs_player_games can't distinguish "really 0 games" from "our ingest
+# has a gap for this window" (e.g. a night that silently failed to fold in).
+# ESPN's own split value already sitting on the row is safe either way — it
+# agrees with us when we're right (real 0 games -> ESPN reads ~0 too) and
+# self-corrects when we're wrong (gap -> ESPN still has the real number).
+# So presets never force-zero that bucket; only custom ranges do, since they
+# have no ESPN split to fall back to.
+
 # Real calendar "today" is a dead anchor for last_7/15/30 once the season
 # ends (today lands in the offseason, a stretch with zero games league-wide,
 # so ~everyone reads as 0 GP). Anchor to the latest date with actual game
@@ -70,9 +79,9 @@ async def build_windowed_players_df(
     per ESPN (`Pro Team != 'FA'`), independent of whether they've played at
     all this season:
       - known, >=1 game in window -> DB-aggregated totals for the window.
-      - known, 0 games in window  -> zeroed stats, gp=0, has_data=True (a real
-        answer, whether they just didn't play in this window or have been out
-        all season — not missing data).
+      - known, 0 rows in DB window -> ESPN's own split value for this period
+        is kept as-is (covers both a real 0-game stretch and a DB ingest gap
+        — ESPN's number is correct either way, see comment above).
       - unknown (ESPN free agent, no window rows) -> falls back to the ESPN
         split value already on the row.
 
@@ -112,18 +121,14 @@ async def build_windowed_players_df(
 
     merged['has_data'] = True
 
-    # If the DB had zero rows for ANYONE in this window (e.g. pre-season, or
-    # any other edge case the anchor-date resolution doesn't cover), that's a
-    # sign the window itself is empty — not that every matched player had a
-    # blank stretch. Don't overwrite their existing ESPN split value with
-    # zeros in that case; custom ranges have no ESPN fallback to preserve, so
-    # they still zero out as before.
-    skip_zeroing_empty_window = agg_df.empty and not is_custom
-
-    zero_matched = known & ~windowed
-    if zero_matched.any() and not skip_zeroing_empty_window:
-        for espn_col in _DB_STAT_COLS:
-            merged.loc[zero_matched, espn_col] = 0 if espn_col == 'GP' else 0.0
+    # Only custom ranges force-zero known-but-unwindowed players — they have
+    # no ESPN split to fall back to. Presets leave the ESPN value in place
+    # (see the comment above build_windowed_players_df's docstring).
+    if is_custom:
+        zero_matched = ~windowed
+        if zero_matched.any():
+            for espn_col in _DB_STAT_COLS:
+                merged.loc[zero_matched, espn_col] = 0 if espn_col == 'GP' else 0.0
 
     unmatched = ~known
     if unmatched.any():

--- a/backend/tests/services/test_player_service.py
+++ b/backend/tests/services/test_player_service.py
@@ -191,10 +191,13 @@ class TestBuildWindowedPlayersDf:
         assert actual_end == date(2026, 1, 9)
 
     @pytest.mark.asyncio
-    async def test_known_player_zero_games_in_window_is_zeroed_not_no_data(
+    async def test_known_player_zero_games_in_window_keeps_espn_value(
         self, sample_window_players_df
     ):
-        # Player Y is on an ESPN roster (Pro Team != 'FA') but has no rows in this window.
+        """Player Y is on an ESPN roster (Pro Team != 'FA') but has no rows in
+        this window — this is indistinguishable from a DB ingest gap for just
+        this player, so the preset keeps ESPN's own split value instead of
+        forcing a zero (unlike custom ranges, which have no ESPN fallback)."""
         agg_df = pd.DataFrame([{
             'player_id': 1, 'player_name': 'Player X', 'gp': 2,
             'pts': 40.0, 'reb': 10.0, 'ast': 8.0, 'stl': 2.0, 'blk': 1.0,
@@ -209,8 +212,8 @@ class TestBuildWindowedPlayersDf:
         )
 
         row = merged[merged['Name'] == 'Player Y'].iloc[0]
-        assert row['GP'] == 0
-        assert row['PTS'] == 0.0
+        assert row['GP'] == 65
+        assert row['PTS'] == 180.0
         assert bool(row['has_data']) is True
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Why

`build_windowed_players_df` (shared by Players, Player Rankings, Team Detail) force-zeroed any known/rostered player with zero rows in the `fs_player_games` window for preset periods (Season/L7/L15/L30). That query can't distinguish two different situations:

- the player genuinely didn't play in that window, or
- our nightly ingest has a gap for that window (e.g. a night that silently failed to fold in — a real, separate gap this app currently has no alerting for)

Both got zeroed identically, which meant an ingest gap silently displayed as "this player scored 0" instead of surfacing the truth we already had on hand.

## What changed

ESPN's own split value is already sitting on the row before the DB overlay runs. For **preset** periods, a known-but-unwindowed player now keeps that value instead of being zeroed — it's safe in both cases: a real 0-game stretch reads ~0 on ESPN too, and a DB gap still has ESPN's real number. **Custom** ranges are unchanged (still force-zero) since there's no ESPN split for an arbitrary date range to fall back to.

`backend/app/services/player_service.py` — scoped the zeroing block to `is_custom` only; this also makes `skip_zeroing_empty_window` dead code, folded into the same guard.

## Testing

- Updated `test_known_player_zero_games_in_window_is_zeroed_not_no_data` → `test_known_player_zero_games_in_window_keeps_espn_value`, asserting the ESPN value survives instead of being zeroed.
- All other existing tests (custom-range zeroing, unknown-player fallback, season-long-injury) unaffected and still pass.
- Full backend suite: 280/280 passed.
- Verified live against a real preview instance (separate port, running side by side with `main`) — Players page loads and renders correctly with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)