### PR TITLE
perf(matchups): ESPN whitelist-calendar schedule redesign

### DIFF
--- a/backend/app/services/nba_matchup_service.py
+++ b/backend/app/services/nba_matchup_service.py
@@ -61,8 +61,8 @@ class NbaMatchupService:
             'pace': None,
             'ts': None,
         }
-        self._schedule_cache: dict = {'data': None, 'date': None, 'ts': None}
-        self._upcoming_cache: dict = {'data': None, 'ts': None}
+        self._events_cache: dict = {'by_day': {}, 'ts': None}
+        self._resolved_date: str | None = None
         self._whitelist_cache: dict = {'dates': None, 'ts': None}
 
     def _def_cache_valid(self) -> bool:
@@ -138,15 +138,11 @@ class NbaMatchupService:
         return 'Average'
 
     async def get_games_today(self, date: str | None = None) -> dict[str, GameInfo]:
-        # Skip cache when a specific date is requested (testing / what-if view)
-        if date is None and (
-            self._schedule_cache['ts'] is not None
-            and datetime.now() - self._schedule_cache['ts'] < timedelta(minutes=5)
-        ):
-            return self._schedule_cache['data']
-
         if date is not None:
-            return self._games_from(await self._scoreboard_events(date))
+            # Explicit/testing date: trusted verbatim, bypasses the whitelist
+            # and the shared events cache entirely.
+            resp = await espn_client.scoreboard_async(self._client, date)
+            return self._games_from(resp.get('events', []))
 
         # Default view = the UPCOMING slate. The date is always pinned (ESPN's
         # dateless scoreboard returns the NEAREST game day — the season finale
@@ -166,31 +162,21 @@ class NbaMatchupService:
                 resolved_date = base + timedelta(days=offset)
                 break
 
-        self._schedule_cache.update({
-            'data': games,
-            'date': resolved_date.isoformat() if resolved_date else None,
-            'ts': datetime.now(),
-        })
+        self._resolved_date = resolved_date.isoformat() if resolved_date else None
         return games
 
     def get_schedule_date(self) -> str | None:
         """ISO date the last default-view (date=None) get_games_today call
         resolved to — None in the offseason, when there's no upcoming slate.
         Lets the UI show which real calendar day 'Upcoming (live)' means."""
-        return self._schedule_cache['date']
+        return self._resolved_date
 
     async def get_upcoming_game_dates(
         self, count: int = 5, lookahead_days: int = 14
     ) -> list[str]:
         """The next ``count`` days that have countable games (ISO dates, today
         included while its slate is still pending), scanning at most
-        ``lookahead_days`` ahead. Offseason -> empty. Cached 5 minutes."""
-        if (
-            self._upcoming_cache['ts'] is not None
-            and datetime.now() - self._upcoming_cache['ts'] < timedelta(minutes=5)
-        ):
-            return self._upcoming_cache['data']
-
+        ``lookahead_days`` ahead. Offseason -> empty."""
         base = datetime.now(ZoneInfo('America/New_York')).date()
         by_day = await self._countable_events_by_day(base, lookahead_days)
         found: list[str] = []
@@ -202,7 +188,6 @@ class NbaMatchupService:
                 if len(found) >= count:
                     break
 
-        self._upcoming_cache.update({'data': found, 'ts': datetime.now()})
         return found
 
     async def _ensure_whitelist(self) -> None:
@@ -229,32 +214,38 @@ class NbaMatchupService:
         self, start: date, lookahead_days: int
     ) -> dict[date, list[dict]]:
         """Countable events for [start, start + lookahead_days], grouped by
-        US/Eastern game date. Fetched via whole-month scoreboard calls (1-2
-        requests, run in parallel) instead of one request per day — ESPN's
-        scoreboard endpoint accepts a "YYYYMM" month in addition to a day."""
+        US/Eastern game date. Candidate days come from the whitelist calendar
+        (one cached request for the whole season) — only those specific days
+        get fetched, never a whole month just to find out which days have
+        games. Empty candidates (offseason) short-circuits with zero
+        day-scoreboard calls. Shared 5-min cache — both get_games_today and
+        get_upcoming_game_dates read/populate the same day-events map, so a
+        page load calling both never double-fetches the overlapping range."""
+        await self._ensure_whitelist()
         end = start + timedelta(days=lookahead_days)
-        months = sorted({start.strftime('%Y%m'), end.strftime('%Y%m')})
-        event_lists = await asyncio.gather(*(self._scoreboard_events(m) for m in months))
+        candidates = sorted(d for d in self._whitelist_cache['dates'] if start <= d <= end)
+        if not candidates:
+            return {}
 
-        by_day: dict[date, list[dict]] = {}
-        for events in event_lists:
-            for event in events:
-                if not is_countable(event):
-                    continue
-                day = event_game_date(event)
-                if start <= day <= end:
-                    by_day.setdefault(day, []).append(event)
-        return by_day
-
-    async def _scoreboard_events(self, dates: str) -> list[dict]:
-        """``dates`` is either a day ("YYYYMMDD") or a whole month ("YYYYMM")."""
-        url = (
-            'https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard'
-            f'?dates={dates}&limit=1000'
+        cache_fresh = (
+            self._events_cache['ts'] is not None
+            and datetime.now() - self._events_cache['ts'] < timedelta(minutes=5)
         )
-        response = await self._client.get(url)
-        response.raise_for_status()
-        return response.json().get('events', [])
+        if not cache_fresh or not set(candidates) <= self._events_cache['by_day'].keys():
+            responses = await asyncio.gather(
+                *(espn_client.scoreboard_async(self._client, d.strftime('%Y%m%d')) for d in candidates)
+            )
+            by_day: dict[date, list[dict]] = {}
+            for resp in responses:
+                for event in resp.get('events', []):
+                    if not is_countable(event):
+                        continue
+                    day = event_game_date(event)
+                    if start <= day <= end:
+                        by_day.setdefault(day, []).append(event)
+            self._events_cache.update({'by_day': by_day, 'ts': datetime.now()})
+
+        return {d: self._events_cache['by_day'].get(d, []) for d in candidates}
 
     @staticmethod
     def _games_from(events: list[dict]) -> dict[str, GameInfo]:

--- a/backend/app/services/nba_matchup_service.py
+++ b/backend/app/services/nba_matchup_service.py
@@ -19,6 +19,7 @@ import httpx
 from app.config import settings
 from app.services.db_service import DBService
 from app.utils.team_abbr_map import TEAM_ID_TO_ABBR, canonical_abbr
+from model_stats_inference.espn import client as espn_client
 from model_stats_inference.espn.games import event_game_date, is_countable, is_final
 
 # How far forward the default view searches for the next slate. Covers the
@@ -62,6 +63,7 @@ class NbaMatchupService:
         }
         self._schedule_cache: dict = {'data': None, 'date': None, 'ts': None}
         self._upcoming_cache: dict = {'data': None, 'ts': None}
+        self._whitelist_cache: dict = {'dates': None, 'ts': None}
 
     def _def_cache_valid(self) -> bool:
         return (
@@ -202,6 +204,26 @@ class NbaMatchupService:
 
         self._upcoming_cache.update({'data': found, 'ts': datetime.now()})
         return found
+
+    async def _ensure_whitelist(self) -> None:
+        """Every game date of the season, from ESPN's whitelist calendar —
+        static once published, so this is worth caching far longer than the
+        5-min schedule caches (a season doesn't grow new game days mid-day)."""
+        if (
+            self._whitelist_cache['ts'] is not None
+            and datetime.now() - self._whitelist_cache['ts'] < timedelta(hours=24)
+        ):
+            return
+        raw = await espn_client.calendar_whitelist_async(self._client)
+        self._whitelist_cache.update({
+            'dates': {
+                datetime.fromisoformat(s.replace('Z', '+00:00'))
+                .astimezone(ZoneInfo('America/New_York'))
+                .date()
+                for s in raw
+            },
+            'ts': datetime.now(),
+        })
 
     async def _countable_events_by_day(
         self, start: date, lookahead_days: int

--- a/backend/model_stats_inference/espn/client.py
+++ b/backend/model_stats_inference/espn/client.py
@@ -7,17 +7,19 @@ simple. All endpoints are unauthenticated JSON GETs.
 
 from __future__ import annotations
 
+import asyncio
 import time
 
+import httpx
 import requests
 
 BASE = "https://site.api.espn.com/apis/site/v2/sports/basketball/nba"
 
 REQUEST_TIMEOUT = 30
 SLEEP_BETWEEN_CALLS = 0.15
-_RETRY_DELAYS = [2.0, 5.0, 15.0]
+RETRY_DELAYS = [2.0, 5.0, 15.0]
 
-_HEADERS = {
+HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
@@ -26,7 +28,7 @@ _HEADERS = {
 }
 
 _session = requests.Session()
-_session.headers.update(_HEADERS)
+_session.headers.update(HEADERS)
 
 
 class EspnUnavailableError(RuntimeError):
@@ -36,7 +38,7 @@ class EspnUnavailableError(RuntimeError):
 def get_json(path: str, params: dict | None = None) -> dict:
     url = f"{BASE}/{path}"
     last: Exception | None = None
-    for attempt, delay in enumerate([0.0, *_RETRY_DELAYS]):
+    for attempt, delay in enumerate([0.0, *RETRY_DELAYS]):
         if delay:
             time.sleep(delay)
         try:
@@ -47,7 +49,38 @@ def get_json(path: str, params: dict | None = None) -> dict:
             return data
         except (requests.RequestException, ValueError) as e:
             last = e
-    raise EspnUnavailableError(f"GET {url} failed after {len(_RETRY_DELAYS) + 1} attempts: {last}")
+    raise EspnUnavailableError(f"GET {url} failed after {len(RETRY_DELAYS) + 1} attempts: {last}")
+
+
+async def async_get_json(client: httpx.AsyncClient, path: str, params: dict | None = None) -> dict:
+    """Async twin of ``get_json`` for FastAPI request-time callers (no
+    SLEEP_BETWEEN_CALLS pacing — that's for the nightly bulk pull's hundreds
+    of sequential requests, not a handful of per-request lookups)."""
+    url = f"{BASE}/{path}"
+    last: Exception | None = None
+    for attempt, delay in enumerate([0.0, *RETRY_DELAYS]):
+        if delay:
+            await asyncio.sleep(delay)
+        try:
+            resp = await client.get(url, params=params, timeout=REQUEST_TIMEOUT)
+            resp.raise_for_status()
+            return resp.json()
+        except (httpx.HTTPError, ValueError) as e:
+            last = e
+    raise EspnUnavailableError(f"GET {url} failed after {len(RETRY_DELAYS) + 1} attempts: {last}")
+
+
+async def scoreboard_async(client: httpx.AsyncClient, dates: str) -> dict:
+    """Scoreboard for a day ("YYYYMMDD") or a whole month ("YYYYMM"), async."""
+    return await async_get_json(client, "scoreboard", {"dates": dates, "limit": 1000})
+
+
+async def calendar_whitelist_async(client: httpx.AsyncClient) -> list[str]:
+    """Every game day of the current season (ISO datetime strings, UTC) in one
+    request — includes preseason/playoffs, not just regular season, so callers
+    still need their own countability filter on the days they fetch."""
+    data = await async_get_json(client, "scoreboard", {"calendartype": "whitelist"})
+    return data["leagues"][0]["calendar"]
 
 
 def scoreboard(dates: str) -> dict:

--- a/backend/model_stats_inference/espn/test_client.py
+++ b/backend/model_stats_inference/espn/test_client.py
@@ -1,0 +1,68 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from . import client
+
+
+def _resp(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_async_get_json_returns_parsed_body():
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=_resp({'ok': True}))
+
+    data = await client.async_get_json(fake_client, 'scoreboard', {'dates': '20260115'})
+
+    assert data == {'ok': True}
+    fake_client.get.assert_awaited_once()
+    _, kwargs = fake_client.get.call_args
+    assert kwargs['params'] == {'dates': '20260115'}
+
+
+@pytest.mark.asyncio
+async def test_async_get_json_raises_espn_unavailable_after_exhausting_retries(monkeypatch):
+    monkeypatch.setattr(client, 'RETRY_DELAYS', [0.0, 0.0])
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=httpx.ConnectError('down'))
+
+    with pytest.raises(client.EspnUnavailableError):
+        await client.async_get_json(fake_client, 'scoreboard')
+
+    assert fake_client.get.await_count == 3  # len(RETRY_DELAYS) + 1
+
+
+@pytest.mark.asyncio
+async def test_scoreboard_async_builds_dates_and_limit_params():
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=_resp({'events': []}))
+
+    await client.scoreboard_async(fake_client, '202601')
+
+    _, kwargs = fake_client.get.call_args
+    assert kwargs['params'] == {'dates': '202601', 'limit': 1000}
+
+
+@pytest.mark.asyncio
+async def test_calendar_whitelist_async_extracts_calendar_list():
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=_resp({
+        'leagues': [{'calendar': ['2025-10-02T07:00Z', '2026-06-13T07:00Z']}],
+    }))
+
+    dates = await client.calendar_whitelist_async(fake_client)
+
+    assert dates == ['2025-10-02T07:00Z', '2026-06-13T07:00Z']
+    _, kwargs = fake_client.get.call_args
+    assert kwargs['params'] == {'calendartype': 'whitelist'}
+
+
+def test_headers_and_retry_delays_are_shared_between_sync_and_async_paths():
+    assert client.HEADERS['Accept'] == 'application/json'
+    assert client.RETRY_DELAYS == [2.0, 5.0, 15.0]

--- a/backend/tests/services/test_nba_matchup_service.py
+++ b/backend/tests/services/test_nba_matchup_service.py
@@ -294,3 +294,59 @@ async def test_get_games_today_empty_on_no_games(service):
         games = await service.get_games_today()
 
     assert games == {}
+
+
+def _whitelist_resp(calendar: list[str]) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = {'leagues': [{'calendar': calendar}]}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _whitelist_get(calendar: list[str]):
+    """Fake ``httpx.AsyncClient.get`` for the whitelist-calendar request —
+    real calls go through ``client.async_get_json`` with ``params=``, not an
+    embedded query string, unlike the day/month scoreboard fakes above."""
+    async def _get(url: str, params: dict | None = None, timeout=None) -> MagicMock:
+        assert params == {'calendartype': 'whitelist'}
+        return _whitelist_resp(calendar)
+    return _get
+
+
+@pytest.mark.asyncio
+async def test_ensure_whitelist_parses_calendar_entries_to_et_dates(service):
+    calendar = ['2025-10-02T07:00Z', '2026-01-29T08:00Z', '2026-06-13T07:00Z']
+
+    with patch.object(service._client, 'get', new_callable=AsyncMock, side_effect=_whitelist_get(calendar)):
+        await service._ensure_whitelist()
+
+    assert service._whitelist_cache['dates'] == {
+        date(2025, 10, 2), date(2026, 1, 29), date(2026, 6, 13),
+    }
+
+
+@pytest.mark.asyncio
+async def test_ensure_whitelist_caches_for_24_hours(service):
+    calendar = ['2025-10-02T07:00Z']
+
+    with patch.object(
+        service._client, 'get', new_callable=AsyncMock, side_effect=_whitelist_get(calendar),
+    ) as get:
+        await service._ensure_whitelist()
+        await service._ensure_whitelist()
+
+    assert get.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_whitelist_refetches_after_ttl_expiry(service):
+    calendar = ['2025-10-02T07:00Z']
+    service._whitelist_cache = {'dates': {date(2020, 1, 1)}, 'ts': datetime.now() - timedelta(hours=25)}
+
+    with patch.object(
+        service._client, 'get', new_callable=AsyncMock, side_effect=_whitelist_get(calendar),
+    ) as get:
+        await service._ensure_whitelist()
+
+    assert get.await_count == 1
+    assert service._whitelist_cache['dates'] == {date(2025, 10, 2)}

--- a/backend/tests/services/test_nba_matchup_service.py
+++ b/backend/tests/services/test_nba_matchup_service.py
@@ -1,4 +1,3 @@
-import re
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -146,20 +145,19 @@ def _resp(events: list[dict]) -> MagicMock:
 
 
 def _client_get_by_day(events_by_day: dict[date, list[dict]]):
-    """Fake ``httpx.AsyncClient.get`` that answers both day ("YYYYMMDD") and
-    whole-month ("YYYYMM") scoreboard requests from one day->events map —
-    mirrors how ESPN's real scoreboard endpoint buckets by the requested range."""
-    async def _get(url: str) -> MagicMock:
-        key = re.search(r'dates=(\d+)', url).group(1)
-        if len(key) == 8:
-            d = date(int(key[:4]), int(key[4:6]), int(key[6:8]))
-            return _resp(events_by_day.get(d, []))
-        year, month = int(key[:4]), int(key[4:6])
-        matched = [
-            e for d, evs in events_by_day.items()
-            if d.year == year and d.month == month for e in evs
-        ]
-        return _resp(matched)
+    """Fake ``httpx.AsyncClient.get`` for the async ESPN client — answers the
+    whitelist-calendar request (candidates derived from ``events_by_day``'s
+    own keys, so every day with events is a valid candidate) and per-day
+    scoreboard requests. Real calls go through ``client.async_get_json`` with
+    ``params=``, not an embedded query string."""
+    calendar = [f'{d.isoformat()}T07:00Z' for d in events_by_day]
+
+    async def _get(url: str, params: dict, timeout: float | None = None) -> MagicMock:
+        if params.get('calendartype') == 'whitelist':
+            return _whitelist_resp(calendar)
+        dates = params['dates']
+        d = date(int(dates[:4]), int(dates[4:6]), int(dates[6:8]))
+        return _resp(events_by_day.get(d, []))
     return _get
 
 
@@ -207,11 +205,13 @@ async def test_default_view_rolls_forward_to_the_upcoming_slate(service):
     ) as get:
         games = await service.get_games_today()
 
-    # month-batched: at most 2 calls (start month + end-of-lookahead month),
-    # never one call per day of the 8-day window.
-    assert len(get.call_args_list) <= 2
-    for call in get.call_args_list:
-        assert re.search(r'dates=\d{6}(&|$)', call[0][0])
+    # 1 whitelist call + one day-fetch per whitelist candidate (today,
+    # tomorrow) — never one call per calendar day of the 8-day window.
+    assert len(get.call_args_list) == 3
+    day_calls = [c for c in get.call_args_list if c.kwargs['params'].get('calendartype') != 'whitelist']
+    assert len(day_calls) == 2
+    for call in day_calls:
+        assert len(call.kwargs['params']['dates']) == 8
     # the picked slate is the pending one, normalized to canonical abbrs
     assert games['NYK'].opponent == 'GSW'
     assert 'LAL' not in games
@@ -243,7 +243,9 @@ async def test_default_view_empty_when_no_upcoming_slate(service):
         games = await service.get_games_today()
 
     assert games == {}
-    assert len(get.call_args_list) <= 2  # month-batched, not one call per day
+    # offseason short circuit: whitelist has zero candidates in range -> only
+    # the whitelist call itself, no day-scoreboard fetches at all.
+    assert len(get.call_args_list) == 1
 
 
 @pytest.mark.asyncio
@@ -283,7 +285,7 @@ async def test_explicit_date_is_used_verbatim(service):
     ) as get:
         await service.get_games_today(date='20260412')
 
-    assert 'dates=20260412' in get.call_args[0][0]
+    assert get.call_args.kwargs['params']['dates'] == '20260412'
 
 
 @pytest.mark.asyncio
@@ -350,3 +352,27 @@ async def test_ensure_whitelist_refetches_after_ttl_expiry(service):
 
     assert get.await_count == 1
     assert service._whitelist_cache['dates'] == {date(2025, 10, 2)}
+
+
+@pytest.mark.asyncio
+async def test_get_games_today_and_get_upcoming_game_dates_share_one_fetch(service):
+    """Both callers read the same underlying day-events cache — a page load
+    that calls both (as /today's route does via _known_slate_dates) must not
+    double the ESPN traffic for the overlapping date range."""
+    today = _today()
+    events_by_day = {
+        today: [_scoreboard_event(13, 30, 'LAL', 'CHA', completed=False, game_date=today)],
+        today + timedelta(days=3): [
+            _scoreboard_event(18, 9, 'NY', 'GS', completed=False, game_date=today + timedelta(days=3))
+        ],
+    }
+
+    with patch.object(
+        service._client, 'get', new_callable=AsyncMock, side_effect=_client_get_by_day(events_by_day),
+    ) as get:
+        await service.get_upcoming_game_dates(lookahead_days=14)
+        first_call_count = len(get.call_args_list)
+        await service.get_games_today()
+
+    assert first_call_count > 0
+    assert len(get.call_args_list) == first_call_count


### PR DESCRIPTION
## Summary
- Replace whole-month scoreboard scanning with ESPN's `?calendartype=whitelist` calendar (1 request, ~229 season game dates) — `_countable_events_by_day` now fetches only the specific candidate days needed, never a whole month just to find them.
- Offseason short circuit: zero candidates in range → zero day-scoreboard calls (only the whitelist call).
- Merge `_schedule_cache`/`_upcoming_cache` (two independent 5-min TTLs over overlapping data) into one `_events_cache` shared by `get_games_today` and `get_upcoming_game_dates` — a page load calling both no longer double-fetches.
- Unify sync/async ESPN HTTP clients: `model_stats_inference/espn/client.py` gains `async_get_json`/`scoreboard_async`/`calendar_whitelist_async`, sharing `BASE`/`HEADERS`/`RETRY_DELAYS`/`EspnUnavailableError` with the nightly-ingest sync path instead of duplicating them (matchup service previously had no retry/backoff at all).
- No public API changes — `matchups.py` routes, `GameInfo`, `get_schedule_date()` contract unchanged.

Plan: `docs/superpowers/plans/2026-07-18-espn-whitelist-calendar.md`

## Test plan
- [x] `uv run pytest -q` — 356 passed
- [x] Live-verified against real ESPN data: offseason (today) correctly returns empty; in-season date (2026-01-15) correctly resolves games, and `_countable_events_by_day` picks exactly the real game days in the window