### PR TITLE
Filter Projections to team depth chart, tag injury status

### DIFF
--- a/backend/app/models/matchup_models.py
+++ b/backend/app/models/matchup_models.py
@@ -38,3 +38,5 @@ class PlayerMatchupResponse(BaseModel):
     league_avg_def_values: DefValues
     projection: Optional[Projection] = None
     game_date: Optional[str] = None  # ISO date this slate resolved to (None if unknown)
+    on_depth_chart: bool = True
+    injury_status: Optional[str] = None

--- a/backend/app/routes/matchups.py
+++ b/backend/app/routes/matchups.py
@@ -9,8 +9,10 @@ from app.models.matchup_models import DefRanks, DefValues, PlayerMatchupResponse
 from app.models.projection_models import Projection, ProjectionStats
 from app.services.data_provider import DataProvider
 from app.services.db_service import DBService
+from app.services.depth_chart_service import DepthChartService
 from app.services.live_projection_service import LiveProjectionService
 from app.services.nba_matchup_service import NbaMatchupService
+from app.utils.name_matching import normalize_player_name
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -18,6 +20,7 @@ logger = logging.getLogger(__name__)
 _matchup_service = NbaMatchupService()
 _data_provider = DataProvider()
 _projection_service = LiveProjectionService()
+_depth_chart_service = DepthChartService()
 
 
 @router.get('/dates', response_model=list[str])
@@ -124,6 +127,10 @@ async def get_matchups_today(
 
     players_df = await _data_provider.get_players_df(stat_split_type_id=0)
 
+    depth_chart_names = await _depth_chart_service.get_on_depth_chart_names(set(games_today.keys()))
+    injury_rows = await DBService().load_all_injury_statuses()
+    injury_lookup = {normalize_player_name(row['player']): row['status'] for row in injury_rows}
+
     try:
         projections = await _projection_service.project_today(players_df, games_today)
     except Exception as e:
@@ -183,6 +190,8 @@ async def get_matchups_today(
             league_avg_def_values=league_avg_def,
             projection=projection,
             game_date=resolved_date,
+            on_depth_chart=normalize_player_name(row['Name']) in depth_chart_names.get(pro_team, set()),
+            injury_status=injury_lookup.get(normalize_player_name(row['Name'])),
         ))
 
     if results:

--- a/backend/app/services/depth_chart_service.py
+++ b/backend/app/services/depth_chart_service.py
@@ -1,0 +1,57 @@
+import asyncio
+import logging
+
+import httpx
+
+from app.utils.constants import PRO_TEAM_MAP
+from app.utils.name_matching import normalize_player_name
+
+logger = logging.getLogger(__name__)
+
+_ABBREV_TO_TEAM_ID = {v: k for k, v in PRO_TEAM_MAP.items() if k != 0}
+_DEPTHCHART_URL = "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/teams/{team_id}/depthcharts"
+_CONCURRENCY = 30  # max possible distinct pro teams in one slate -- effectively one wave
+
+
+class DepthChartService:
+    """Fetches ESPN depth charts for a set of pro teams, in parallel, fail-open
+    per team — a slate that includes an ESPN outage for one team should still
+    render every other team's rows rather than losing the whole response."""
+
+    async def get_on_depth_chart_names(self, pro_teams: set[str]) -> dict[str, set[str]]:
+        semaphore = asyncio.Semaphore(_CONCURRENCY)
+        team_ids = {abbrev: _ABBREV_TO_TEAM_ID[abbrev] for abbrev in pro_teams if abbrev in _ABBREV_TO_TEAM_ID}
+
+        # Shared client so concurrent calls reuse one connection pool to
+        # site.api.espn.com instead of each paying its own TCP+TLS handshake.
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            async def fetch_one(abbrev: str, team_id: int) -> tuple[str, set[str]]:
+                async with semaphore:
+                    names = await self._fetch_depth_chart_names(client, team_id)
+                    return abbrev, names
+
+            results = await asyncio.gather(*(fetch_one(abbrev, tid) for abbrev, tid in team_ids.items()))
+        return dict(results)
+
+    async def _fetch_depth_chart_names(self, client: httpx.AsyncClient, team_id: int) -> set[str]:
+        try:
+            resp = await client.get(_DEPTHCHART_URL.format(team_id=team_id))
+            if resp.status_code != 200:
+                logger.error(f"Depth chart fetch for team {team_id} returned HTTP {resp.status_code}")
+                return set()
+
+            data = resp.json()
+            depthcharts = data.get("depthchart", [])
+            if not depthcharts:
+                return set()
+
+            names: set[str] = set()
+            for pos_val in depthcharts[0].get("positions", {}).values():
+                for athlete in pos_val.get("athletes", []):
+                    display_name = athlete.get("displayName", "")
+                    if display_name:
+                        names.add(normalize_player_name(display_name))
+            return names
+        except Exception as e:
+            logger.error(f"Depth chart fetch/parse failed for team {team_id}: {e}")
+            return set()

--- a/backend/model_stats_inference/serving/conftest.py
+++ b/backend/model_stats_inference/serving/conftest.py
@@ -89,34 +89,41 @@ def _make_team_logs(rng) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def raw_players() -> pd.DataFrame:
     return _make_players(np.random.default_rng(0))
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def team_logs() -> pd.DataFrame:
     return _make_team_logs(np.random.default_rng(1))
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def team_tables(team_logs):
     return rdata.build_team_allowed(team_logs), rdata.build_team_own(team_logs)
 
 
 @pytest.fixture
 def store(raw_players, team_tables) -> FeatureStore:
+    # Function-scoped: test_feature_store.py's test_nightly_update_appends_and_recomputes
+    # mutates the store in place via update_with_nightly_results, so it can't be
+    # shared across tests. Cheap to rebuild (no training) -- unlike feature_matrix
+    # / models_dir below, which stay module-scoped for the real time savings.
     team_allowed, team_own = team_tables
     return FeatureStore.build(raw_players, team_allowed, team_own)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def feature_matrix(raw_players, team_tables) -> pd.DataFrame:
     team_allowed, team_own = team_tables
     return rfeatures.build_feature_matrix(raw_players, team_allowed, team_own)
 
 
-@pytest.fixture
+# Deterministic fixed-seed synthetic data + read-only consumers (verified across
+# test_inference.py/test_reconcile.py/test_nightly.py) -- module scope trains
+# these tiny models once per file instead of once per test.
+@pytest.fixture(scope="module")
 def models_dir(feature_matrix, tmp_path_factory):
     """Train tiny per-target models on the synthetic data so inference can run,
     plus a reconciler built from in-sample residuals (pseudo-OOF)."""

--- a/backend/tests/routes/test_matchups_route.py
+++ b/backend/tests/routes/test_matchups_route.py
@@ -45,8 +45,19 @@ def mock_services(monkeypatch):
     provider = MagicMock()
     provider.get_players_df = AsyncMock(return_value=_MOCK_PLAYERS)
 
+    depth_chart_svc = MagicMock()
+    depth_chart_svc.get_on_depth_chart_names = AsyncMock(return_value={'LAL': {'anthonydavis'}})
+
     monkeypatch.setattr('app.routes.matchups._matchup_service', svc)
     monkeypatch.setattr('app.routes.matchups._data_provider', provider)
+    monkeypatch.setattr('app.routes.matchups._depth_chart_service', depth_chart_svc)
+    monkeypatch.setattr(
+        'app.routes.matchups.DBService',
+        lambda: MagicMock(
+            load_all_injury_statuses=AsyncMock(return_value=[]),
+            get_recent_game_dates=AsyncMock(return_value=[]),
+        ),
+    )
     return svc, provider
 
 
@@ -75,6 +86,34 @@ def test_response_shape(mock_services):
     assert 'league_avg_pace' in player
     assert 'pace_badge' not in player
     assert player['game_date'] == '2026-01-15'
+    assert player['on_depth_chart'] is True
+    assert player['injury_status'] is None
+
+
+def test_tags_player_not_on_depth_chart(mock_services, monkeypatch):
+    depth_chart_svc = MagicMock()
+    depth_chart_svc.get_on_depth_chart_names = AsyncMock(return_value={'LAL': set()})
+    monkeypatch.setattr('app.routes.matchups._depth_chart_service', depth_chart_svc)
+    client = TestClient(app)
+    data = client.get('/api/matchups/today').json()
+    # Backend tags only -- filtering happens client-side, so the player still
+    # appears in the response even when absent from the depth chart.
+    assert len(data) == 1
+    assert data[0]['on_depth_chart'] is False
+
+
+def test_tags_injury_status_from_db(mock_services, monkeypatch):
+    monkeypatch.setattr(
+        'app.routes.matchups.DBService',
+        lambda: MagicMock(
+            load_all_injury_statuses=AsyncMock(return_value=[
+                {'team': 'LAL', 'player': 'Anthony Davis', 'status': 'Out'},
+            ]),
+        ),
+    )
+    client = TestClient(app)
+    data = client.get('/api/matchups/today').json()
+    assert data[0]['injury_status'] == 'Out'
 
 
 def test_game_date_reflects_explicit_date_param(mock_services, monkeypatch):
@@ -82,7 +121,7 @@ def test_game_date_reflects_explicit_date_param(mock_services, monkeypatch):
     svc.get_upcoming_game_dates = AsyncMock(return_value=['2026-01-16'])
     monkeypatch.setattr(
         'app.routes.matchups.DBService',
-        lambda: MagicMock(get_recent_game_dates=AsyncMock(return_value=[])),
+        lambda: MagicMock(get_recent_game_dates=AsyncMock(return_value=[]), load_all_injury_statuses=AsyncMock(return_value=[])),
     )
     client = TestClient(app)
     data = client.get('/api/matchups/today?date=20260116').json()
@@ -159,7 +198,7 @@ def test_rejects_date_outside_known_slates(mock_services, monkeypatch):
     svc.get_upcoming_game_dates = AsyncMock(return_value=['2026-01-16'])
     monkeypatch.setattr(
         'app.routes.matchups.DBService',
-        lambda: MagicMock(get_recent_game_dates=AsyncMock(return_value=[])),
+        lambda: MagicMock(get_recent_game_dates=AsyncMock(return_value=[]), load_all_injury_statuses=AsyncMock(return_value=[])),
     )
     client = TestClient(app)
     resp = client.get('/api/matchups/today?date=20990101')
@@ -171,7 +210,7 @@ def test_accepts_upcoming_date_in_whitelist(mock_services, monkeypatch):
     svc.get_upcoming_game_dates = AsyncMock(return_value=['2026-01-16'])
     monkeypatch.setattr(
         'app.routes.matchups.DBService',
-        lambda: MagicMock(get_recent_game_dates=AsyncMock(return_value=[])),
+        lambda: MagicMock(get_recent_game_dates=AsyncMock(return_value=[]), load_all_injury_statuses=AsyncMock(return_value=[])),
     )
     client = TestClient(app)
     resp = client.get('/api/matchups/today?date=20260116')

--- a/frontend/src/components/InjuryBadge.tsx
+++ b/frontend/src/components/InjuryBadge.tsx
@@ -1,0 +1,16 @@
+const STATUS_STYLE: Record<string, string> = {
+  Out: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400',
+  Doubtful: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400',
+  Questionable: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400',
+  Probable: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400',
+};
+
+export default function InjuryBadge({ status }: { status: string | null | undefined }) {
+  if (!status) return null;
+  const style = STATUS_STYLE[status] ?? 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+  return (
+    <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium leading-none ${style}`}>
+      {status}
+    </span>
+  );
+}

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -6,6 +6,7 @@ import type { PlayerMatchup } from '../types/api';
 import TimePeriodSelector from '../components/TimePeriodSelector';
 import { CoverageNotice } from '../components/DateRangePicker';
 import { MatchupCell, MatchupExpandRow } from '../components/MatchupDisplay';
+import InjuryBadge from '../components/InjuryBadge';
 import { FF_MATCHUP_QUALITY, FF_PROJECTIONS, FF_PAST_SLATES } from '../config/featureFlags';
 import './Players.css';
 
@@ -495,7 +496,7 @@ const PlayerTable = ({
           return (
             <React.Fragment key={`${player.player_name}-${idx}`}>
               <tr>
-                <td>{player.player_name}</td>
+                <td>{player.player_name} <InjuryBadge status={matchup?.injury_status} /></td>
                 <td>{player.pro_team}</td>
                 <td>{player.positions.join(', ')}</td>
                 <td>{getTeamDisplay(player)}</td>

--- a/frontend/src/pages/Projections.tsx
+++ b/frontend/src/pages/Projections.tsx
@@ -5,6 +5,7 @@ import type { PlayerMatchup, ProjectionStats } from '../types/api';
 import { coherentInts } from '../utils/coherentRound';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorMessage from '../components/ErrorMessage';
+import InjuryBadge from '../components/InjuryBadge';
 
 const STAT_COLS: [keyof ProjectionStats, string][] = [
   ['pts', 'PTS'], ['reb', 'REB'], ['ast', 'AST'], ['three_pm', '3PM'], ['stl', 'STL'], ['blk', 'BLK'],
@@ -83,7 +84,7 @@ function ProjectionRow({ matchup, integerMode }: { matchup: PlayerMatchup; integ
     return (
       <tr className="border-t border-gray-100 dark:border-gray-800">
         <td className="px-3 py-2 whitespace-nowrap font-medium text-gray-900 dark:text-gray-100 sticky left-0 z-10 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700">
-          <StatusDot status="red" reason={proj.reason} /> <span className="ml-1">{matchup.player_name}</span>
+          <StatusDot status="red" reason={proj.reason} /> <span className="ml-1">{matchup.player_name}</span> <InjuryBadge status={matchup.injury_status} />
         </td>
         <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-gray-400">
           {matchup.pro_team} {matchup.is_home ? 'vs' : '@'} {matchup.opponent}
@@ -102,7 +103,7 @@ function ProjectionRow({ matchup, integerMode }: { matchup: PlayerMatchup; integ
   return (
     <tr className="border-t border-gray-100 dark:border-gray-800 hover:bg-blue-50/40 dark:hover:bg-gray-800/40">
       <td className="px-3 py-2 whitespace-nowrap font-medium text-gray-900 dark:text-gray-100 sticky left-0 z-10 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700">
-        <StatusDot status={proj.status} reason={proj.reason} /> <span className="ml-1">{matchup.player_name}</span>
+        <StatusDot status={proj.status} reason={proj.reason} /> <span className="ml-1">{matchup.player_name}</span> <InjuryBadge status={matchup.injury_status} />
       </td>
       <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-gray-400">
         {matchup.pro_team} {matchup.is_home ? 'vs' : '@'} {matchup.opponent}
@@ -162,7 +163,17 @@ export default function Projections() {
     return m;
   }, [allPlayers]);
 
-  const withGames = useMemo(() => matchups.filter((m) => m.projection != null), [matchups]);
+  // Live slate = the "Upcoming (live)" view resolving to today's real slate date.
+  // Only there do we hide Out players outright; an explicit picked date is a
+  // what-if/debug view where Out is tag-only (InjuryBadge), never filtered.
+  const isLiveSlate = slateDate === '' && !!currentSlateDate;
+
+  const withGames = useMemo(() => matchups.filter((m) => {
+    if (m.projection == null) return false;
+    if (!m.on_depth_chart) return false;
+    if (isLiveSlate && m.injury_status === 'Out') return false;
+    return true;
+  }), [matchups, isLiveSlate]);
 
   const nbaTeamOptions = useMemo(
     () => Array.from(new Set(withGames.map((m) => m.pro_team))).sort(),

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -10,6 +10,7 @@ import { CoverageNotice } from '../components/DateRangePicker'
 import DataDateBadge from '../components/DataDateBadge'
 import { aggregatePlayerAverages } from '../utils/statsUtils'
 import { MatchupCell, MatchupExpandRow } from '../components/MatchupDisplay'
+import InjuryBadge from '../components/InjuryBadge'
 import { FF_MATCHUP_QUALITY, FF_PROJECTIONS } from '../config/featureFlags'
 
 const TeamDetail = () => {
@@ -511,7 +512,7 @@ const TeamDetail = () => {
                           title={noData ? 'Excluded from average — no data for this range' : undefined}
                         />
                       </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 sticky left-0 z-10 bg-white border-r border-gray-200">{player.player_name}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 sticky left-0 z-10 bg-white border-r border-gray-200">{player.player_name} <InjuryBadge status={matchup?.injury_status} /></td>
                       <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">{player.positions.join(', ')}</td>
                       <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500">{player.pro_team}</td>
                       {noData ? (

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -334,6 +334,8 @@ export interface PlayerMatchup {
   league_avg_def_values: DefValues;
   projection: Projection | null;
   game_date: string | null;
+  on_depth_chart: boolean;
+  injury_status: string | null;
 }
 
 export interface PlayerStoreSummary {


### PR DESCRIPTION
## Summary
- Projections always filters to each rostered player's ESPN depth chart (forward-looking -- keeps call-ups/returns that recent-games history would miss). No toggle.
- On the live slate only, Out players are hidden; explicit past/what-if slate dates keep Out players visible, tag-only.
- Injury status (Out/Doubtful/Questionable/Probable) shown as a label next to the player name on Projections, Players, and TeamDetail -- never filters anything on those two pages.
- Backend tags each `/api/matchups/today` row with `on_depth_chart` / `injury_status` rather than filtering server-side, so the client owns slate-dependent rules.
- New `DepthChartService` fetches all teams in a slate concurrently through one shared `httpx.AsyncClient` (fixes a per-team TCP+TLS handshake and an artificial concurrency cap that serialized a full 30-team slate into 4 sequential waves -- measured 42.6s -> 15.75s cold on a full slate).
- Bonus: widened 5 fixtures in `model_stats_inference/serving/conftest.py` to module scope (deterministic, never mutated) -- cuts full backend suite from ~160s to ~100-130s.

## Test plan
- [x] Backend: `uv run pytest -q` -- 419 passed
- [x] Frontend: `npm run test -- --run` -- 114 passed, 3 skipped
- [x] Frontend: `tsc --noEmit` clean
- [x] Manually verified in browser against real season data (2026-04-10/04-12 slates): depth-chart filtering drops bench/inactive players correctly (369/881 excluded on one slate), injury badge renders next to player name on Players page
- [x] Perf baseline captured before/after on production and locally (see PR discussion for numbers)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>