### PR TITLE
fix(mobile): stop horizontal page overflow on Players and Projections

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,14 @@
 
 @variant dark (&:where(.dark, .dark *));
 
+/* Guard against any child pushing the page wider than the viewport on
+   mobile — without this, one overflowing element scrolls the whole body
+   horizontally, revealing unstyled space past the layout's background. */
+html, body {
+  overflow-x: hidden;
+  max-width: 100%;
+}
+
 /* ── Dark mode base ── */
 .dark body {
   background-color: #111827;

--- a/frontend/src/pages/Players.css
+++ b/frontend/src/pages/Players.css
@@ -2,6 +2,7 @@
   padding: 20px;
   max-width: 1400px;
   margin: 0 auto;
+  overflow-x: hidden;
 }
 
 .filter-toggle {
@@ -201,7 +202,9 @@
 
 .table-container {
   max-height: 600px;
+  overflow-x: auto;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   border: 1px solid #ddd;
   border-radius: 8px;
   background: #fff;

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -129,14 +129,14 @@ const Players = () => {
             Showing {filteredPlayers.length} players
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {FF_MATCHUP_QUALITY && (
             <label className="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-300 cursor-pointer select-none" title="Pick a game day. Past dates (debug) show that slate with current player state.">
               <span>Slate</span>
               <select
                 value={slateDate}
                 onChange={(e) => setSlateDate(e.target.value)}
-                className="px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800"
+                className="px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 max-w-[50vw] sm:max-w-none"
               >
                 <option value="">
                   {slateDate === '' && currentSlateDate

--- a/frontend/src/pages/Projections.tsx
+++ b/frontend/src/pages/Projections.tsx
@@ -196,7 +196,7 @@ export default function Projections() {
   if (error) return <ErrorMessage message="Failed to load projections." />;
 
   return (
-    <div className="p-4 sm:p-6 max-w-7xl mx-auto space-y-6">
+    <div className="p-4 sm:p-6 max-w-7xl mx-auto space-y-6 overflow-x-hidden">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Projections</h1>
@@ -206,13 +206,13 @@ export default function Projections() {
               : "Live model projections for tonight's games."}
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 cursor-pointer select-none" title="Pick a game day. Past dates (debug) show that slate with current player state.">
             <span>Slate</span>
             <select
               value={slateDate}
               onChange={(e) => setSlateDate(e.target.value)}
-              className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800"
+              className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 max-w-[60vw] sm:max-w-none"
             >
               <option value="">
                 {slateDate === '' && currentSlateDate

--- a/frontend/src/pages/Trade/components/TeamRankingsBar.tsx
+++ b/frontend/src/pages/Trade/components/TeamRankingsBar.tsx
@@ -22,7 +22,7 @@ export const TeamRankingsBar: React.FC<TeamRankingsBarProps> = ({ categoryRanks 
   };
 
   return (
-    <div className="mb-3 border border-gray-200 rounded-lg overflow-hidden">
+    <div className="mb-3 border border-gray-200 rounded-lg overflow-x-auto">
       <table className="w-full text-xs">
         <thead>
           <tr className="bg-gray-50">


### PR DESCRIPTION
Non-wrapping filter rows (Slate select + toggle buttons) and a
table-container missing overflow-x:auto let content grow past the
viewport on narrow screens, dragging the whole page into horizontal
scroll and cutting off the trailing stat columns. Add a global
overflow-x guard, let the filter rows wrap, and give the players table
its own horizontal scroll region.