### PR TITLE
feat(trends): per-player game-log charts and a hot/cold shooting mode

### DIFF
--- a/backend/app/models/trend_models.py
+++ b/backend/app/models/trend_models.py
@@ -10,6 +10,8 @@ class RegressionStatItem(BaseModel):
     dev: float
     attempts_per_game: float
     drift_score: float
+    window_pct: Optional[float] = None  # None when the window holds no attempts
+    window_attempts: int = 0  # sample behind window_pct — small means treat it loosely
 
 
 class RegressionPlayerGroup(BaseModel):

--- a/backend/app/models/trend_models.py
+++ b/backend/app/models/trend_models.py
@@ -13,6 +13,7 @@ class RegressionStatItem(BaseModel):
 
 
 class RegressionPlayerGroup(BaseModel):
+    player_id: int
     player_name: str
     pro_team: str
     position: str
@@ -24,10 +25,12 @@ class RegressionPlayerGroup(BaseModel):
 class RegressionResponse(BaseModel):
     items: list[RegressionPlayerGroup]
     window_days: int
+    baseline_seasons: int
     last_updated: str
 
 
 class MinutesMoverItem(BaseModel):
+    player_id: int
     player_name: str
     pro_team: str
     position: str
@@ -48,6 +51,7 @@ class MinutesResponse(BaseModel):
 
 
 class UsageRoleItem(BaseModel):
+    player_id: int
     player_name: str
     pro_team: str
     position: str
@@ -68,3 +72,31 @@ class UsageResponse(BaseModel):
     items: list[UsageRoleItem]
     window_days: int
     last_updated: str
+
+
+class GameLogEntry(BaseModel):
+    game_date: str
+    matchup: str
+    min: float
+    usg: float
+    fgm: int
+    fga: int
+    ftm: int
+    fta: int
+    fg3m: int
+    fg3a: int
+
+
+class GameLogResponse(BaseModel):
+    player_id: int
+    player_name: str
+    season: str
+    window_days: int
+    window_start: str
+    season_gp: int
+    season_mpg: float
+    season_usg: float
+    season_pct: dict[str, float]  # '3P%' | 'FT%' | 'FG%' -> season-to-date pct
+    baseline_pct: dict[str, float]  # same keys -> prior-season baseline pct
+    baseline_seasons: int
+    games: list[GameLogEntry]

--- a/backend/app/models/trend_models.py
+++ b/backend/app/models/trend_models.py
@@ -3,7 +3,15 @@ from typing import Literal, Optional
 from pydantic import BaseModel
 
 
+RegressionMode = Literal['season', 'form']
+
+
 class RegressionStatItem(BaseModel):
+    """Field meanings shift with the request's mode — the shape is shared so one
+    table can render both. mode=season: current_pct is season-to-date, baseline_pct
+    is prior seasons only, attempts_per_game is season volume, drift_score is the
+    volume-weighted drift. mode=form: current_pct is the window only, baseline_pct
+    excludes the window, attempts_per_game is window volume, drift_score is |z|."""
     stat: Literal['3P%', 'FT%', 'FG%']
     current_pct: float
     baseline_pct: float
@@ -12,6 +20,7 @@ class RegressionStatItem(BaseModel):
     drift_score: float
     window_pct: Optional[float] = None  # None when the window holds no attempts
     window_attempts: int = 0  # sample behind window_pct — small means treat it loosely
+    z: Optional[float] = None  # two-proportion z of dev; mode=form only
 
 
 class RegressionPlayerGroup(BaseModel):
@@ -28,6 +37,7 @@ class RegressionResponse(BaseModel):
     items: list[RegressionPlayerGroup]
     window_days: int
     baseline_seasons: int
+    mode: RegressionMode
     last_updated: str
 
 

--- a/backend/app/models/trend_models.py
+++ b/backend/app/models/trend_models.py
@@ -110,5 +110,7 @@ class GameLogResponse(BaseModel):
     season_usg: float
     season_pct: dict[str, float]  # '3P%' | 'FT%' | 'FG%' -> season-to-date pct
     baseline_pct: dict[str, float]  # same keys -> prior-season baseline pct
+    league_pct: dict[str, float]  # same keys -> league-wide pct this season
+    league_usg: Optional[float] = None  # minutes-weighted league USG%, ~20 by construction
     baseline_seasons: int
     games: list[GameLogEntry]

--- a/backend/app/routes/trends.py
+++ b/backend/app/routes/trends.py
@@ -1,8 +1,12 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
-from app.models.trend_models import MinutesResponse, RegressionResponse, UsageResponse
+from app.models.trend_models import GameLogResponse, MinutesResponse, RegressionResponse, UsageResponse
 from app.services.data_provider import DataProvider
-from app.services.trend_service import DEFAULT_RECENCY_WINDOW_DAYS, TrendService
+from app.services.trend_service import (
+    DEFAULT_BASELINE_SEASONS,
+    DEFAULT_RECENCY_WINDOW_DAYS,
+    TrendService,
+)
 
 router = APIRouter()
 
@@ -11,9 +15,12 @@ _data_provider = DataProvider()
 
 
 @router.get('/regression', response_model=RegressionResponse)
-async def get_shooting_regression(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> RegressionResponse:
+async def get_shooting_regression(
+    window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+    baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+) -> RegressionResponse:
     players_df = await _data_provider.get_players_df()
-    return await _trend_service.get_shooting_regression(players_df, window_days)
+    return await _trend_service.get_shooting_regression(players_df, window_days, baseline_seasons)
 
 
 @router.get('/minutes', response_model=MinutesResponse)
@@ -26,3 +33,15 @@ async def get_minutes_movers(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> 
 async def get_usage_role(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> UsageResponse:
     players_df = await _data_provider.get_players_df()
     return await _trend_service.get_usage_role(players_df, window_days)
+
+
+@router.get('/player/{player_id}/gamelog', response_model=GameLogResponse)
+async def get_player_game_log(
+    player_id: int,
+    window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+    baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+) -> GameLogResponse:
+    response = await _trend_service.get_player_game_log(player_id, window_days, baseline_seasons)
+    if response is None:
+        raise HTTPException(status_code=404, detail=f'No game log for player {player_id} this season')
+    return response

--- a/backend/app/routes/trends.py
+++ b/backend/app/routes/trends.py
@@ -1,10 +1,17 @@
 from fastapi import APIRouter, HTTPException
 
-from app.models.trend_models import GameLogResponse, MinutesResponse, RegressionResponse, UsageResponse
+from app.models.trend_models import (
+    GameLogResponse,
+    MinutesResponse,
+    RegressionMode,
+    RegressionResponse,
+    UsageResponse,
+)
 from app.services.data_provider import DataProvider
 from app.services.trend_service import (
     DEFAULT_BASELINE_SEASONS,
     DEFAULT_RECENCY_WINDOW_DAYS,
+    DEFAULT_REGRESSION_MODE,
     TrendService,
 )
 
@@ -18,9 +25,10 @@ _data_provider = DataProvider()
 async def get_shooting_regression(
     window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+    mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> RegressionResponse:
     players_df = await _data_provider.get_players_df()
-    return await _trend_service.get_shooting_regression(players_df, window_days, baseline_seasons)
+    return await _trend_service.get_shooting_regression(players_df, window_days, baseline_seasons, mode)
 
 
 @router.get('/minutes', response_model=MinutesResponse)
@@ -40,8 +48,9 @@ async def get_player_game_log(
     player_id: int,
     window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+    mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> GameLogResponse:
-    response = await _trend_service.get_player_game_log(player_id, window_days, baseline_seasons)
+    response = await _trend_service.get_player_game_log(player_id, window_days, baseline_seasons, mode)
     if response is None:
         raise HTTPException(status_code=404, detail=f'No game log for player {player_id} this season')
     return response

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -914,6 +914,50 @@ class DBService:
             logger.error(f"Failed to fetch usage components for {start}..{end} ({season}): {e}")
             return pd.DataFrame()
 
+    async def get_player_game_log(self, player_id: int, season: str, start: date, end: date) -> pd.DataFrame:
+        """Single player's per-game rows with the same team components
+        get_usage_components returns, so USG% per game can be computed with the
+        identical formula and the chart agrees with the table by construction."""
+        pool = await self._get_pool()
+        if pool is None:
+            return pd.DataFrame()
+        try:
+            async with pool.acquire() as conn:
+                rows = await conn.fetch(
+                    """
+                    SELECT
+                        p.player_name,
+                        p.game_date,
+                        p.matchup,
+                        p.min AS p_min,
+                        p.fgm, p.fga, p.ftm, p.fta, p.fg3m, p.fg3a,
+                        p.fga AS p_fga,
+                        p.fta AS p_fta,
+                        p.tov AS p_tov,
+                        t.fga AS t_fga,
+                        t.fta AS t_fta,
+                        t.tov AS t_tov,
+                        tm.team_min AS t_min
+                    FROM fs_player_games p
+                    JOIN fs_team_games t
+                        ON t.team_id = p.team_id AND t.game_id = p.game_id
+                    JOIN (
+                        SELECT team_id, game_id, SUM(min) AS team_min
+                        FROM fs_player_games
+                        WHERE season = $2 AND game_date BETWEEN $3 AND $4
+                        GROUP BY team_id, game_id
+                    ) tm ON tm.team_id = p.team_id AND tm.game_id = p.game_id
+                    WHERE p.player_id = $1 AND p.season = $2
+                      AND p.game_date BETWEEN $3 AND $4 AND p.min > 0
+                    ORDER BY p.game_date
+                    """,
+                    player_id, season, start, end,
+                )
+                return pd.DataFrame([dict(r) for r in rows])
+        except Exception as e:
+            logger.error(f"Failed to fetch game log for player {player_id} ({season}): {e}")
+            return pd.DataFrame()
+
     async def get_games_since(self, since_date: date) -> dict[int, int]:
         """player_id -> distinct games played with game_date >= since_date
         (any season) — trailing-window recency count (e.g. games in the last

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -6,6 +6,8 @@ import pandas as pd
 
 from app.config import settings
 from app.models.trend_models import (
+    GameLogEntry,
+    GameLogResponse,
     MinutesMoverItem,
     MinutesResponse,
     RegressionPlayerGroup,
@@ -27,11 +29,16 @@ _TREND_CACHE_TTL = timedelta(hours=6)
 
 # current_min_att / baseline_min_att: sample-size gates below which a pct is
 # too noisy to trust (plan's volume gates), independent of drift_score.
+# baseline_min_att is stated per baseline season and multiplied by how many
+# seasons the baseline spans — a 1-season baseline has half the attempts.
 _STAT_SPECS = {
-    '3P%': {'att': 'fg3a', 'pct': 'fg3_pct', 'current_min_att': 40, 'baseline_min_att': 150},
-    'FT%': {'att': 'fta', 'pct': 'ft_pct', 'current_min_att': 40, 'baseline_min_att': 150},
-    'FG%': {'att': 'fga', 'pct': 'fg_pct', 'current_min_att': 100, 'baseline_min_att': 300},
+    '3P%': {'att': 'fg3a', 'pct': 'fg3_pct', 'current_min_att': 40, 'baseline_min_att_per_season': 75},
+    'FT%': {'att': 'fta', 'pct': 'ft_pct', 'current_min_att': 40, 'baseline_min_att_per_season': 75},
+    'FG%': {'att': 'fga', 'pct': 'fg_pct', 'current_min_att': 100, 'baseline_min_att_per_season': 150},
 }
+
+DEFAULT_BASELINE_SEASONS = 2
+VALID_BASELINE_SEASONS = (1, 2)
 
 
 def compute_regression_groups(
@@ -39,6 +46,7 @@ def compute_regression_groups(
     baseline_df: pd.DataFrame,
     games_last_15d: dict[int, int],
     players_df: pd.DataFrame,
+    baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
 ) -> list[RegressionPlayerGroup]:
     """Pure calc: current-season vs prior-2-season baseline shooting -> volume-gated,
     drift-filtered, player-grouped regression items. No DB/network access."""
@@ -63,7 +71,8 @@ def compute_regression_groups(
         for stat_name, spec in _STAT_SPECS.items():
             current_att = current_row[spec['att']]
             baseline_att = baseline_row[spec['att']]
-            if current_att < spec['current_min_att'] or baseline_att < spec['baseline_min_att']:
+            min_baseline_att = spec['baseline_min_att_per_season'] * baseline_seasons
+            if current_att < spec['current_min_att'] or baseline_att < min_baseline_att:
                 continue
             current_pct = current_row[spec['pct']] * 100
             baseline_pct = baseline_row[spec['pct']] * 100
@@ -95,6 +104,7 @@ def compute_regression_groups(
         position = str(espn_row.get('Positions', 'Unknown')).split(',')[0].strip() or 'Unknown'
 
         groups.append(RegressionPlayerGroup(
+            player_id=player_id,
             player_name=player_name,
             pro_team=str(espn_row.get('Pro Team', 'Unknown')),
             position=position,
@@ -154,6 +164,7 @@ def compute_minutes_movers(
         position = str(espn_row.get('Positions', 'Unknown')).split(',')[0].strip() or 'Unknown'
 
         items.append(MinutesMoverItem(
+            player_id=player_id,
             player_name=player_name,
             pro_team=str(espn_row.get('Pro Team', 'Unknown')),
             position=position,
@@ -253,6 +264,7 @@ def compute_usage_role(
         position = str(espn_row.get('Positions', 'Unknown')).split(',')[0].strip() or 'Unknown'
 
         items.append(UsageRoleItem(
+            player_id=int(player_id),
             player_name=player_name,
             pro_team=str(espn_row.get('Pro Team', 'Unknown')),
             position=position,
@@ -273,45 +285,123 @@ def compute_usage_role(
     return items
 
 
+def _pct(makes, attempts) -> float:
+    return float(makes) / float(attempts) * 100 if attempts else 0.0
+
+
+def _player_pct_map(df: pd.DataFrame, player_id: int) -> dict[str, float]:
+    """Attempt-weighted 3P%/FT%/FG% for one player out of an
+    aggregate_shooting_by_player frame. Empty dict if the player isn't in it
+    (rookie, or no prior-season rows)."""
+    if df.empty:
+        return {}
+    rows = df[df['player_id'] == player_id]
+    if rows.empty:
+        return {}
+    row = rows.iloc[0]
+    return {name: float(row[spec['pct']]) * 100 for name, spec in _STAT_SPECS.items()}
+
+
+def build_game_log(
+    games_df: pd.DataFrame,
+    player_id: int,
+    season: str,
+    window_days: int,
+    window_start,
+    baseline_pct: dict[str, float],
+    baseline_seasons: int,
+) -> GameLogResponse:
+    """Pure calc: per-game rows -> chart-ready game log. USG% per game uses the
+    same _usg_per_game as Usage & Role, so the chart's window mean equals the
+    table's l5_usg by construction. No DB/network access."""
+    usg_series = games_df.apply(_usg_per_game, axis=1)
+    entries = [
+        GameLogEntry(
+            game_date=str(row['game_date']),
+            matchup=str(row['matchup'] or ''),
+            min=float(row['p_min']),
+            usg=float(usg_series.iloc[i]),
+            fgm=int(row['fgm']), fga=int(row['fga']),
+            ftm=int(row['ftm']), fta=int(row['fta']),
+            fg3m=int(row['fg3m']), fg3a=int(row['fg3a']),
+        )
+        for i, (_, row) in enumerate(games_df.iterrows())
+    ]
+    return GameLogResponse(
+        player_id=player_id,
+        player_name=str(games_df.iloc[0]['player_name']),
+        season=season,
+        window_days=window_days,
+        window_start=str(window_start),
+        season_gp=len(entries),
+        season_mpg=float(games_df['p_min'].mean()),
+        season_usg=float(usg_series.mean()),
+        season_pct={
+            '3P%': _pct(games_df['fg3m'].sum(), games_df['fg3a'].sum()),
+            'FT%': _pct(games_df['ftm'].sum(), games_df['fta'].sum()),
+            'FG%': _pct(games_df['fgm'].sum(), games_df['fga'].sum()),
+        },
+        baseline_pct=baseline_pct,
+        baseline_seasons=baseline_seasons,
+        games=entries,
+    )
+
+
 def _normalize_window_days(window_days: int) -> int:
     return window_days if window_days in VALID_RECENCY_WINDOWS_DAYS else DEFAULT_RECENCY_WINDOW_DAYS
+
+
+def _normalize_baseline_seasons(baseline_seasons: int) -> int:
+    return baseline_seasons if baseline_seasons in VALID_BASELINE_SEASONS else DEFAULT_BASELINE_SEASONS
+
+
+def prior_season_strings(baseline_seasons: int) -> list[str]:
+    return [espn_season_string(settings.season_id - n) for n in range(1, baseline_seasons + 1)]
 
 
 class TrendService:
     def __init__(self):
         self.logger = logging.getLogger(__name__)
         self._db = DBService()
-        self._regression_cache: dict[int, dict] = {}
+        self._regression_cache: dict[tuple[int, int], dict] = {}
         self._minutes_cache: dict[int, dict] = {}
         self._usage_cache: dict[int, dict] = {}
+        self._game_log_cache: dict[tuple[int, int, int], dict] = {}
 
     @staticmethod
-    def _cache_valid(cache: dict, window_days: int) -> bool:
-        entry = cache.get(window_days)
+    def _cache_valid(cache: dict, key) -> bool:
+        entry = cache.get(key)
         return entry is not None and datetime.now() - entry['ts'] < _TREND_CACHE_TTL
 
-    async def get_shooting_regression(self, players_df: pd.DataFrame, window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> RegressionResponse:
+    async def get_shooting_regression(
+        self,
+        players_df: pd.DataFrame,
+        window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+        baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+    ) -> RegressionResponse:
         window_days = _normalize_window_days(window_days)
-        if self._cache_valid(self._regression_cache, window_days):
-            return self._regression_cache[window_days]['data']
+        baseline_seasons = _normalize_baseline_seasons(baseline_seasons)
+        cache_key = (window_days, baseline_seasons)
+        if self._cache_valid(self._regression_cache, cache_key):
+            return self._regression_cache[cache_key]['data']
 
         current_season = espn_season_string(settings.season_id)
         anchor_date = await get_season_anchor_date(current_season, self._db)
-        prior_seasons = [
-            espn_season_string(settings.season_id - 1),
-            espn_season_string(settings.season_id - 2),
-        ]
 
         current_df = await self._db.aggregate_shooting_by_player(
             [current_season], start=settings.season_start, end=anchor_date
         )
-        baseline_df = await self._db.aggregate_shooting_by_player(prior_seasons)
+        baseline_df = await self._db.aggregate_shooting_by_player(prior_season_strings(baseline_seasons))
         games_last_15d = await self._db.get_games_since(anchor_date - timedelta(days=window_days))
 
-        groups = compute_regression_groups(current_df, baseline_df, games_last_15d, players_df)
-        groups = [g for g in groups if g.fantasy_status == 'FA']
-        response = RegressionResponse(items=groups, window_days=window_days, last_updated=datetime.now().isoformat())
-        self._regression_cache[window_days] = {'data': response, 'ts': datetime.now()}
+        groups = compute_regression_groups(current_df, baseline_df, games_last_15d, players_df, baseline_seasons)
+        response = RegressionResponse(
+            items=groups,
+            window_days=window_days,
+            baseline_seasons=baseline_seasons,
+            last_updated=datetime.now().isoformat(),
+        )
+        self._regression_cache[cache_key] = {'data': response, 'ts': datetime.now()}
         return response
 
     async def get_minutes_movers(self, players_df: pd.DataFrame, window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> MinutesResponse:
@@ -332,7 +422,6 @@ class TrendService:
         games_last_15d = await self._db.get_games_since(window_start)
 
         items = compute_minutes_movers(season_df, window_df, games_last_15d, players_df)
-        items = [i for i in items if i.fantasy_status == 'FA']
         response = MinutesResponse(items=items, window_days=window_days, last_updated=datetime.now().isoformat())
         self._minutes_cache[window_days] = {'data': response, 'ts': datetime.now()}
         return response
@@ -350,7 +439,37 @@ class TrendService:
         games_last_15d = await self._db.get_games_since(window_start)
 
         items = compute_usage_role(games_df, games_last_15d, players_df, window_start)
-        items = [i for i in items if i.fantasy_status == 'FA']
         response = UsageResponse(items=items, window_days=window_days, last_updated=datetime.now().isoformat())
         self._usage_cache[window_days] = {'data': response, 'ts': datetime.now()}
+        return response
+
+    async def get_player_game_log(
+        self,
+        player_id: int,
+        window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+        baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+    ) -> Optional[GameLogResponse]:
+        window_days = _normalize_window_days(window_days)
+        baseline_seasons = _normalize_baseline_seasons(baseline_seasons)
+        cache_key = (player_id, window_days, baseline_seasons)
+        if self._cache_valid(self._game_log_cache, cache_key):
+            return self._game_log_cache[cache_key]['data']
+
+        current_season = espn_season_string(settings.season_id)
+        anchor_date = await get_season_anchor_date(current_season, self._db)
+        window_start = anchor_date - timedelta(days=window_days)
+
+        games_df = await self._db.get_player_game_log(
+            player_id, current_season, settings.season_start, anchor_date
+        )
+        if games_df.empty:
+            return None
+
+        baseline_df = await self._db.aggregate_shooting_by_player(prior_season_strings(baseline_seasons))
+        baseline_pct = _player_pct_map(baseline_df, player_id)
+
+        response = build_game_log(
+            games_df, player_id, current_season, window_days, window_start, baseline_pct, baseline_seasons
+        )
+        self._game_log_cache[cache_key] = {'data': response, 'ts': datetime.now()}
         return response

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -47,6 +47,7 @@ def compute_regression_groups(
     games_last_15d: dict[int, int],
     players_df: pd.DataFrame,
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+    window_df: Optional[pd.DataFrame] = None,
 ) -> list[RegressionPlayerGroup]:
     """Pure calc: current-season vs prior-2-season baseline shooting -> volume-gated,
     drift-filtered, player-grouped regression items. No DB/network access."""
@@ -58,6 +59,10 @@ def compute_regression_groups(
         for _, row in players_df.iterrows()
     }
     baseline_by_id = {int(r['player_id']): r for _, r in baseline_df.iterrows()}
+    window_by_id = (
+        {int(r['player_id']): r for _, r in window_df.iterrows()}
+        if window_df is not None and not window_df.empty else {}
+    )
 
     groups: list[RegressionPlayerGroup] = []
     for _, current_row in current_df.iterrows():
@@ -67,6 +72,7 @@ def compute_regression_groups(
             continue  # no baseline (rookie / first season) -> not ranked
 
         gp = current_row['gp']
+        window_row = window_by_id.get(player_id)
         stats: list[RegressionStatItem] = []
         for stat_name, spec in _STAT_SPECS.items():
             current_att = current_row[spec['att']]
@@ -81,6 +87,7 @@ def compute_regression_groups(
             drift_score = attempts_per_game * abs(dev) / 100
             if drift_score < DRIFT_THRESHOLD:
                 continue
+            window_att = int(window_row[spec['att']]) if window_row is not None else 0
             stats.append(RegressionStatItem(
                 stat=stat_name,
                 current_pct=current_pct,
@@ -88,6 +95,8 @@ def compute_regression_groups(
                 dev=dev,
                 attempts_per_game=attempts_per_game,
                 drift_score=drift_score,
+                window_pct=float(window_row[spec['pct']]) * 100 if window_att else None,
+                window_attempts=window_att,
             ))
 
         if not stats:
@@ -388,13 +397,19 @@ class TrendService:
         current_season = espn_season_string(settings.season_id)
         anchor_date = await get_season_anchor_date(current_season, self._db)
 
+        window_start = anchor_date - timedelta(days=window_days)
         current_df = await self._db.aggregate_shooting_by_player(
             [current_season], start=settings.season_start, end=anchor_date
         )
+        window_df = await self._db.aggregate_shooting_by_player(
+            [current_season], start=window_start, end=anchor_date
+        )
         baseline_df = await self._db.aggregate_shooting_by_player(prior_season_strings(baseline_seasons))
-        games_last_15d = await self._db.get_games_since(anchor_date - timedelta(days=window_days))
+        games_last_15d = await self._db.get_games_since(window_start)
 
-        groups = compute_regression_groups(current_df, baseline_df, games_last_15d, players_df, baseline_seasons)
+        groups = compute_regression_groups(
+            current_df, baseline_df, games_last_15d, players_df, baseline_seasons, window_df
+        )
         response = RegressionResponse(
             items=groups,
             window_days=window_days,

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -10,6 +11,7 @@ from app.models.trend_models import (
     GameLogResponse,
     MinutesMoverItem,
     MinutesResponse,
+    RegressionMode,
     RegressionPlayerGroup,
     RegressionResponse,
     RegressionStatItem,
@@ -32,13 +34,106 @@ _TREND_CACHE_TTL = timedelta(hours=6)
 # baseline_min_att is stated per baseline season and multiplied by how many
 # seasons the baseline spans — a 1-season baseline has half the attempts.
 _STAT_SPECS = {
-    '3P%': {'att': 'fg3a', 'pct': 'fg3_pct', 'current_min_att': 40, 'baseline_min_att_per_season': 75},
-    'FT%': {'att': 'fta', 'pct': 'ft_pct', 'current_min_att': 40, 'baseline_min_att_per_season': 75},
-    'FG%': {'att': 'fga', 'pct': 'fg_pct', 'current_min_att': 100, 'baseline_min_att_per_season': 150},
+    '3P%': {'att': 'fg3a', 'mk': 'fg3m', 'pct': 'fg3_pct', 'current_min_att': 40, 'baseline_min_att_per_season': 75},
+    'FT%': {'att': 'fta', 'mk': 'ftm', 'pct': 'ft_pct', 'current_min_att': 40, 'baseline_min_att_per_season': 75},
+    'FG%': {'att': 'fga', 'mk': 'fgm', 'pct': 'fg_pct', 'current_min_att': 100, 'baseline_min_att_per_season': 150},
 }
 
 DEFAULT_BASELINE_SEASONS = 2
 VALID_BASELINE_SEASONS = (1, 2)
+
+DEFAULT_REGRESSION_MODE: RegressionMode = 'season'
+
+# mode='form' gates. The z gate replaces a fixed attempt threshold: the same
+# percentage-point gap is noise on 13 attempts and signal on 90, and free throws
+# and field goals self-calibrate without a per-stat number to tune.
+FORM_MIN_WINDOW_ATT = 10
+FORM_MIN_BASELINE_ATT = 50
+FORM_MIN_ABS_Z = 1.5
+
+
+def _season_outlier_stat(
+    stat_name: str,
+    spec: dict,
+    current_row,
+    baseline_row,
+    window_row,
+    gp,
+    baseline_seasons: int,
+) -> Optional[RegressionStatItem]:
+    """mode='season': this season to date vs prior seasons only."""
+    current_att = current_row[spec['att']]
+    baseline_att = baseline_row[spec['att']]
+    min_baseline_att = spec['baseline_min_att_per_season'] * baseline_seasons
+    if current_att < spec['current_min_att'] or baseline_att < min_baseline_att:
+        return None
+    current_pct = float(current_row[spec['pct']]) * 100
+    baseline_pct = float(baseline_row[spec['pct']]) * 100
+    dev = current_pct - baseline_pct
+    attempts_per_game = float(current_att / gp) if gp else 0.0
+    drift_score = attempts_per_game * abs(dev) / 100
+    if drift_score < DRIFT_THRESHOLD:
+        return None
+    window_att = int(window_row[spec['att']]) if window_row is not None else 0
+    return RegressionStatItem(
+        stat=stat_name,
+        current_pct=current_pct,
+        baseline_pct=baseline_pct,
+        dev=dev,
+        attempts_per_game=attempts_per_game,
+        drift_score=drift_score,
+        window_pct=float(window_row[spec['pct']]) * 100 if window_att else None,
+        window_attempts=window_att,
+    )
+
+
+def _form_stat(
+    stat_name: str,
+    spec: dict,
+    current_row,
+    baseline_row,
+    window_row,
+) -> Optional[RegressionStatItem]:
+    """mode='form': the recency window vs a baseline of prior seasons plus this
+    season before the window. The baseline shares no games with the window, so the
+    two-proportion z-test below is valid — comparing the window against the whole
+    season would compare a part to a whole containing it and shrink every gap."""
+    att_win = int(window_row[spec['att']])
+    mk_win = int(window_row[spec['mk']])
+    att_pre = int(current_row[spec['att']]) - att_win
+    mk_pre = int(current_row[spec['mk']]) - mk_win
+    att_prior = int(baseline_row[spec['att']]) if baseline_row is not None else 0
+    mk_prior = int(baseline_row[spec['mk']]) if baseline_row is not None else 0
+
+    att_base = att_prior + att_pre
+    mk_base = mk_prior + mk_pre
+    if att_win < FORM_MIN_WINDOW_ATT or att_base < FORM_MIN_BASELINE_ATT:
+        return None
+
+    form_pct = mk_win / att_win * 100
+    baseline_pct = mk_base / att_base * 100
+    gap = form_pct - baseline_pct
+
+    pooled = (mk_win + mk_base) / (att_win + att_base)
+    se = math.sqrt(pooled * (1 - pooled) * (1 / att_win + 1 / att_base)) * 100
+    if se <= 0:
+        return None
+    z = gap / se
+    if abs(z) < FORM_MIN_ABS_Z:
+        return None
+
+    window_gp = int(window_row['gp'])
+    return RegressionStatItem(
+        stat=stat_name,
+        current_pct=form_pct,
+        baseline_pct=baseline_pct,
+        dev=gap,
+        attempts_per_game=att_win / window_gp if window_gp else 0.0,
+        drift_score=abs(z),
+        window_pct=form_pct,
+        window_attempts=att_win,
+        z=z,
+    )
 
 
 def compute_regression_groups(
@@ -48,17 +143,24 @@ def compute_regression_groups(
     players_df: pd.DataFrame,
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
     window_df: Optional[pd.DataFrame] = None,
+    mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> list[RegressionPlayerGroup]:
-    """Pure calc: current-season vs prior-2-season baseline shooting -> volume-gated,
-    drift-filtered, player-grouped regression items. No DB/network access."""
-    if current_df.empty or baseline_df.empty:
+    """Pure calc: shooting deviation -> gated, player-grouped items. No DB/network
+    access. mode='season' ranks season-vs-history outliers; mode='form' ranks
+    significant hot/cold stretches inside the recency window."""
+    if current_df.empty:
+        return []
+    if mode == 'season' and baseline_df.empty:
         return []
 
     espn_by_name = {
         resolve_join_key(str(row.get('Name', ''))): row
         for _, row in players_df.iterrows()
     }
-    baseline_by_id = {int(r['player_id']): r for _, r in baseline_df.iterrows()}
+    baseline_by_id = (
+        {int(r['player_id']): r for _, r in baseline_df.iterrows()}
+        if not baseline_df.empty else {}
+    )
     window_by_id = (
         {int(r['player_id']): r for _, r in window_df.iterrows()}
         if window_df is not None and not window_df.empty else {}
@@ -68,36 +170,24 @@ def compute_regression_groups(
     for _, current_row in current_df.iterrows():
         player_id = int(current_row['player_id'])
         baseline_row = baseline_by_id.get(player_id)
-        if baseline_row is None:
-            continue  # no baseline (rookie / first season) -> not ranked
+        window_row = window_by_id.get(player_id)
+        if mode == 'season' and baseline_row is None:
+            continue  # no prior seasons (rookie) -> nothing to deviate from
+        if mode == 'form' and window_row is None:
+            continue  # no games in the window -> no current form to judge
 
         gp = current_row['gp']
-        window_row = window_by_id.get(player_id)
         stats: list[RegressionStatItem] = []
         for stat_name, spec in _STAT_SPECS.items():
-            current_att = current_row[spec['att']]
-            baseline_att = baseline_row[spec['att']]
-            min_baseline_att = spec['baseline_min_att_per_season'] * baseline_seasons
-            if current_att < spec['current_min_att'] or baseline_att < min_baseline_att:
-                continue
-            current_pct = current_row[spec['pct']] * 100
-            baseline_pct = baseline_row[spec['pct']] * 100
-            dev = current_pct - baseline_pct
-            attempts_per_game = current_att / gp if gp else 0.0
-            drift_score = attempts_per_game * abs(dev) / 100
-            if drift_score < DRIFT_THRESHOLD:
-                continue
-            window_att = int(window_row[spec['att']]) if window_row is not None else 0
-            stats.append(RegressionStatItem(
-                stat=stat_name,
-                current_pct=current_pct,
-                baseline_pct=baseline_pct,
-                dev=dev,
-                attempts_per_game=attempts_per_game,
-                drift_score=drift_score,
-                window_pct=float(window_row[spec['pct']]) * 100 if window_att else None,
-                window_attempts=window_att,
-            ))
+            item = (
+                _form_stat(stat_name, spec, current_row, baseline_row, window_row)
+                if mode == 'form'
+                else _season_outlier_stat(
+                    stat_name, spec, current_row, baseline_row, window_row, gp, baseline_seasons
+                )
+            )
+            if item is not None:
+                stats.append(item)
 
         if not stats:
             continue
@@ -108,7 +198,7 @@ def compute_regression_groups(
             logger.warning(f"No ESPN roster match for '{player_name}' — skipped from Shooting Regression")
             continue
 
-        stats.sort(key=lambda s: abs(s.dev), reverse=True)
+        stats.sort(key=(lambda s: s.drift_score) if mode == 'form' else (lambda s: abs(s.dev)), reverse=True)
         fantasy_team_name = espn_row.get('fantasy_team_name')
         position = str(espn_row.get('Positions', 'Unknown')).split(',')[0].strip() or 'Unknown'
 
@@ -311,6 +401,31 @@ def _player_pct_map(df: pd.DataFrame, player_id: int) -> dict[str, float]:
     return {name: float(row[spec['pct']]) * 100 for name, spec in _STAT_SPECS.items()}
 
 
+def _form_baseline_pct(
+    baseline_df: pd.DataFrame,
+    games_df: pd.DataFrame,
+    player_id: int,
+    window_start,
+) -> dict[str, float]:
+    """mode='form' baseline for the chart's reference line: prior seasons pooled
+    with this season's games before the window. Excludes the window itself so the
+    line the chart draws is the one the table's z-score was computed against."""
+    prior = baseline_df[baseline_df['player_id'] == player_id] if not baseline_df.empty else baseline_df
+    prior_row = prior.iloc[0] if not prior.empty else None
+    pre = games_df[games_df['game_date'] < window_start]
+
+    out: dict[str, float] = {}
+    for name, spec in _STAT_SPECS.items():
+        mk = int(pre[spec['mk']].sum())
+        att = int(pre[spec['att']].sum())
+        if prior_row is not None:
+            mk += int(prior_row[spec['mk']])
+            att += int(prior_row[spec['att']])
+        if att:
+            out[name] = mk / att * 100
+    return out
+
+
 def build_game_log(
     games_df: pd.DataFrame,
     player_id: int,
@@ -372,10 +487,10 @@ class TrendService:
     def __init__(self):
         self.logger = logging.getLogger(__name__)
         self._db = DBService()
-        self._regression_cache: dict[tuple[int, int], dict] = {}
+        self._regression_cache: dict[tuple[int, int, str], dict] = {}
         self._minutes_cache: dict[int, dict] = {}
         self._usage_cache: dict[int, dict] = {}
-        self._game_log_cache: dict[tuple[int, int, int], dict] = {}
+        self._game_log_cache: dict[tuple[int, int, int, str], dict] = {}
 
     @staticmethod
     def _cache_valid(cache: dict, key) -> bool:
@@ -387,10 +502,11 @@ class TrendService:
         players_df: pd.DataFrame,
         window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
         baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+        mode: RegressionMode = DEFAULT_REGRESSION_MODE,
     ) -> RegressionResponse:
         window_days = _normalize_window_days(window_days)
         baseline_seasons = _normalize_baseline_seasons(baseline_seasons)
-        cache_key = (window_days, baseline_seasons)
+        cache_key = (window_days, baseline_seasons, mode)
         if self._cache_valid(self._regression_cache, cache_key):
             return self._regression_cache[cache_key]['data']
 
@@ -408,12 +524,13 @@ class TrendService:
         games_last_15d = await self._db.get_games_since(window_start)
 
         groups = compute_regression_groups(
-            current_df, baseline_df, games_last_15d, players_df, baseline_seasons, window_df
+            current_df, baseline_df, games_last_15d, players_df, baseline_seasons, window_df, mode
         )
         response = RegressionResponse(
             items=groups,
             window_days=window_days,
             baseline_seasons=baseline_seasons,
+            mode=mode,
             last_updated=datetime.now().isoformat(),
         )
         self._regression_cache[cache_key] = {'data': response, 'ts': datetime.now()}
@@ -463,10 +580,11 @@ class TrendService:
         player_id: int,
         window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
         baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
+        mode: RegressionMode = DEFAULT_REGRESSION_MODE,
     ) -> Optional[GameLogResponse]:
         window_days = _normalize_window_days(window_days)
         baseline_seasons = _normalize_baseline_seasons(baseline_seasons)
-        cache_key = (player_id, window_days, baseline_seasons)
+        cache_key = (player_id, window_days, baseline_seasons, mode)
         if self._cache_valid(self._game_log_cache, cache_key):
             return self._game_log_cache[cache_key]['data']
 
@@ -481,7 +599,11 @@ class TrendService:
             return None
 
         baseline_df = await self._db.aggregate_shooting_by_player(prior_season_strings(baseline_seasons))
-        baseline_pct = _player_pct_map(baseline_df, player_id)
+        baseline_pct = (
+            _form_baseline_pct(baseline_df, games_df, player_id, window_start)
+            if mode == 'form'
+            else _player_pct_map(baseline_df, player_id)
+        )
 
         response = build_game_log(
             games_df, player_id, current_season, window_days, window_start, baseline_pct, baseline_seasons

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -40,7 +40,11 @@ _STAT_SPECS = {
 }
 
 DEFAULT_BASELINE_SEASONS = 2
-VALID_BASELINE_SEASONS = (1, 2)
+# 0 = no prior seasons, so mode='form' judges the window against this season
+# alone. Meaningless for mode='season', which has nothing left to compare to —
+# the service coerces it back to the default there.
+VALID_BASELINE_SEASONS = (0, 1, 2)
+DEFAULT_FORM_BASELINE_SEASONS = 0
 
 DEFAULT_REGRESSION_MODE: RegressionMode = 'season'
 
@@ -493,8 +497,12 @@ def _normalize_window_days(window_days: int) -> int:
     return window_days if window_days in VALID_RECENCY_WINDOWS_DAYS else DEFAULT_RECENCY_WINDOW_DAYS
 
 
-def _normalize_baseline_seasons(baseline_seasons: int) -> int:
-    return baseline_seasons if baseline_seasons in VALID_BASELINE_SEASONS else DEFAULT_BASELINE_SEASONS
+def _normalize_baseline_seasons(baseline_seasons: int, mode: RegressionMode = DEFAULT_REGRESSION_MODE) -> int:
+    if baseline_seasons not in VALID_BASELINE_SEASONS:
+        return DEFAULT_BASELINE_SEASONS
+    if baseline_seasons == 0 and mode != 'form':
+        return DEFAULT_BASELINE_SEASONS
+    return baseline_seasons
 
 
 def prior_season_strings(baseline_seasons: int) -> list[str]:
@@ -524,7 +532,7 @@ class TrendService:
         mode: RegressionMode = DEFAULT_REGRESSION_MODE,
     ) -> RegressionResponse:
         window_days = _normalize_window_days(window_days)
-        baseline_seasons = _normalize_baseline_seasons(baseline_seasons)
+        baseline_seasons = _normalize_baseline_seasons(baseline_seasons, mode)
         cache_key = (window_days, baseline_seasons, mode)
         if self._cache_valid(self._regression_cache, cache_key):
             return self._regression_cache[cache_key]['data']
@@ -539,7 +547,7 @@ class TrendService:
         window_df = await self._db.aggregate_shooting_by_player(
             [current_season], start=window_start, end=anchor_date
         )
-        baseline_df = await self._db.aggregate_shooting_by_player(prior_season_strings(baseline_seasons))
+        baseline_df = await self._prior_shooting(baseline_seasons)
         games_last_15d = await self._db.get_games_since(window_start)
 
         groups = compute_regression_groups(
@@ -594,6 +602,12 @@ class TrendService:
         self._usage_cache[window_days] = {'data': response, 'ts': datetime.now()}
         return response
 
+    async def _prior_shooting(self, baseline_seasons: int) -> pd.DataFrame:
+        seasons = prior_season_strings(baseline_seasons)
+        if not seasons:
+            return pd.DataFrame()
+        return await self._db.aggregate_shooting_by_player(seasons)
+
     async def _get_league_refs(self, season: str, end) -> tuple[dict[str, float], Optional[float]]:
         """League-wide shooting pcts and USG%, cached together — one pull serves
         every player's chart. USG% lands at ~20 by construction (five players
@@ -626,7 +640,7 @@ class TrendService:
         mode: RegressionMode = DEFAULT_REGRESSION_MODE,
     ) -> Optional[GameLogResponse]:
         window_days = _normalize_window_days(window_days)
-        baseline_seasons = _normalize_baseline_seasons(baseline_seasons)
+        baseline_seasons = _normalize_baseline_seasons(baseline_seasons, mode)
         cache_key = (player_id, window_days, baseline_seasons, mode)
         if self._cache_valid(self._game_log_cache, cache_key):
             return self._game_log_cache[cache_key]['data']
@@ -641,7 +655,7 @@ class TrendService:
         if games_df.empty:
             return None
 
-        baseline_df = await self._db.aggregate_shooting_by_player(prior_season_strings(baseline_seasons))
+        baseline_df = await self._prior_shooting(baseline_seasons)
         baseline_pct = (
             _form_baseline_pct(baseline_df, games_df, player_id, window_start)
             if mode == 'form'

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -401,6 +401,20 @@ def _player_pct_map(df: pd.DataFrame, player_id: int) -> dict[str, float]:
     return {name: float(row[spec['pct']]) * 100 for name, spec in _STAT_SPECS.items()}
 
 
+def _league_pct_map(df: pd.DataFrame) -> dict[str, float]:
+    """League-wide 3P%/FT%/FG% from an aggregate_shooting_by_player frame:
+    every player's makes over every player's attempts. Answers 'is this player
+    hurting the category', which his own history cannot."""
+    if df.empty:
+        return {}
+    out: dict[str, float] = {}
+    for name, spec in _STAT_SPECS.items():
+        att = int(df[spec['att']].sum())
+        if att:
+            out[name] = int(df[spec['mk']].sum()) / att * 100
+    return out
+
+
 def _form_baseline_pct(
     baseline_df: pd.DataFrame,
     games_df: pd.DataFrame,
@@ -434,6 +448,8 @@ def build_game_log(
     window_start,
     baseline_pct: dict[str, float],
     baseline_seasons: int,
+    league_pct: Optional[dict[str, float]] = None,
+    league_usg: Optional[float] = None,
 ) -> GameLogResponse:
     """Pure calc: per-game rows -> chart-ready game log. USG% per game uses the
     same _usg_per_game as Usage & Role, so the chart's window mean equals the
@@ -466,6 +482,8 @@ def build_game_log(
             'FG%': _pct(games_df['fgm'].sum(), games_df['fga'].sum()),
         },
         baseline_pct=baseline_pct,
+        league_pct=league_pct or {},
+        league_usg=league_usg,
         baseline_seasons=baseline_seasons,
         games=entries,
     )
@@ -491,6 +509,7 @@ class TrendService:
         self._minutes_cache: dict[int, dict] = {}
         self._usage_cache: dict[int, dict] = {}
         self._game_log_cache: dict[tuple[int, int, int, str], dict] = {}
+        self._league_cache: dict[str, dict] = {}
 
     @staticmethod
     def _cache_valid(cache: dict, key) -> bool:
@@ -575,6 +594,30 @@ class TrendService:
         self._usage_cache[window_days] = {'data': response, 'ts': datetime.now()}
         return response
 
+    async def _get_league_refs(self, season: str, end) -> tuple[dict[str, float], Optional[float]]:
+        """League-wide shooting pcts and USG%, cached together — one pull serves
+        every player's chart. USG% lands at ~20 by construction (five players
+        split 100% of possessions), which is exactly why it is a useful anchor
+        for judging whether a given usage is high."""
+        if self._cache_valid(self._league_cache, season):
+            entry = self._league_cache[season]['data']
+            return entry['pct'], entry['usg']
+
+        shooting_df = await self._db.aggregate_shooting_by_player(
+            [season], start=settings.season_start, end=end
+        )
+        usage_df = await self._db.get_usage_components(season, settings.season_start, end)
+        league_usg = None
+        if not usage_df.empty:
+            usg = usage_df.apply(_usg_per_game, axis=1)
+            total_min = usage_df['p_min'].sum()
+            if total_min:
+                league_usg = float((usg * usage_df['p_min']).sum() / total_min)
+
+        data = {'pct': _league_pct_map(shooting_df), 'usg': league_usg}
+        self._league_cache[season] = {'data': data, 'ts': datetime.now()}
+        return data['pct'], data['usg']
+
     async def get_player_game_log(
         self,
         player_id: int,
@@ -605,8 +648,11 @@ class TrendService:
             else _player_pct_map(baseline_df, player_id)
         )
 
+        league_pct, league_usg = await self._get_league_refs(current_season, anchor_date)
+
         response = build_game_log(
-            games_df, player_id, current_season, window_days, window_start, baseline_pct, baseline_seasons
+            games_df, player_id, current_season, window_days, window_start,
+            baseline_pct, baseline_seasons, league_pct, league_usg,
         )
         self._game_log_cache[cache_key] = {'data': response, 'ts': datetime.now()}
         return response

--- a/backend/tests/routes/test_trends_route.py
+++ b/backend/tests/routes/test_trends_route.py
@@ -72,6 +72,7 @@ _MOCK_GAME_LOG = GameLogResponse(
     season_mpg=28.0, season_usg=21.4,
     season_pct={'3P%': 35.0, 'FT%': 80.0, 'FG%': 47.0},
     baseline_pct={'3P%': 38.0, 'FT%': 78.0, 'FG%': 49.0},
+    league_pct={'3P%': 36.0, 'FT%': 78.5, 'FG%': 47.0},
     baseline_seasons=2,
     games=[
         GameLogEntry(game_date='2026-07-10', matchup='CHI vs. MIL', min=30.0, usg=22.5,

--- a/backend/tests/routes/test_trends_route.py
+++ b/backend/tests/routes/test_trends_route.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 from app.models.trend_models import (
+    GameLogEntry,
+    GameLogResponse,
     MinutesMoverItem,
     MinutesResponse,
     RegressionPlayerGroup,
@@ -22,7 +24,7 @@ _MOCK_PLAYERS = pd.DataFrame([
 _MOCK_RESPONSE = RegressionResponse(
     items=[
         RegressionPlayerGroup(
-            player_name='Klay Thompson', pro_team='DAL', position='SG', fantasy_status='FA',
+            player_id=202691, player_name='Klay Thompson', pro_team='DAL', position='SG', fantasy_status='FA',
             games_last_15d=6,
             stats=[RegressionStatItem(
                 stat='3P%', current_pct=33.1, baseline_pct=41.2, dev=-8.1,
@@ -31,6 +33,7 @@ _MOCK_RESPONSE = RegressionResponse(
         ),
     ],
     window_days=15,
+    baseline_seasons=2,
     last_updated='2026-07-18T12:00:00',
 )
 
@@ -38,7 +41,7 @@ _MOCK_RESPONSE = RegressionResponse(
 _MOCK_MINUTES_RESPONSE = MinutesResponse(
     items=[
         MinutesMoverItem(
-            player_name='Ayo Dosunmu', pro_team='CHI', position='PG', fantasy_status='FA',
+            player_id=1630245, player_name='Ayo Dosunmu', pro_team='CHI', position='PG', fantasy_status='FA',
             games_last_15d=7, season_mpg=24.1, l5_mpg=31.8, delta_mpg=7.7,
             season_gp=48, window_gp=5, low_sample=False,
         ),
@@ -51,7 +54,7 @@ _MOCK_MINUTES_RESPONSE = MinutesResponse(
 _MOCK_USAGE_RESPONSE = UsageResponse(
     items=[
         UsageRoleItem(
-            player_name='Ayo Dosunmu', pro_team='CHI', position='PG', fantasy_status='FA',
+            player_id=1630245, player_name='Ayo Dosunmu', pro_team='CHI', position='PG', fantasy_status='FA',
             games_last_15d=7, season_usg=18.2, l5_usg=24.6, delta_usg=6.4,
             season_mpg=24.1, l5_mpg=31.8, delta_mpg=7.7,
             season_gp=48, window_gp=5, role_badge='Role ↑',
@@ -62,12 +65,29 @@ _MOCK_USAGE_RESPONSE = UsageResponse(
 )
 
 
+_MOCK_GAME_LOG = GameLogResponse(
+    player_id=1630245, player_name='Ayo Dosunmu', season='2025-26',
+    window_days=15, window_start='2026-07-03', season_gp=2,
+    season_mpg=28.0, season_usg=21.4,
+    season_pct={'3P%': 35.0, 'FT%': 80.0, 'FG%': 47.0},
+    baseline_pct={'3P%': 38.0, 'FT%': 78.0, 'FG%': 49.0},
+    baseline_seasons=2,
+    games=[
+        GameLogEntry(game_date='2026-07-10', matchup='CHI vs. MIL', min=30.0, usg=22.5,
+                     fgm=7, fga=14, ftm=2, fta=2, fg3m=2, fg3a=5),
+        GameLogEntry(game_date='2026-07-12', matchup='CHI @ DET', min=26.0, usg=20.3,
+                     fgm=5, fga=12, ftm=4, fta=6, fg3m=1, fg3a=4),
+    ],
+)
+
+
 @pytest.fixture
 def mock_services(monkeypatch):
     svc = MagicMock()
     svc.get_shooting_regression = AsyncMock(return_value=_MOCK_RESPONSE)
     svc.get_minutes_movers = AsyncMock(return_value=_MOCK_MINUTES_RESPONSE)
     svc.get_usage_role = AsyncMock(return_value=_MOCK_USAGE_RESPONSE)
+    svc.get_player_game_log = AsyncMock(return_value=_MOCK_GAME_LOG)
 
     provider = MagicMock()
     provider.get_players_df = AsyncMock(return_value=_MOCK_PLAYERS)
@@ -143,3 +163,48 @@ def test_get_usage_passes_players_df_to_service(mock_services):
     svc.get_usage_role.assert_awaited_once()
     called_df = svc.get_usage_role.call_args.args[0]
     assert called_df.equals(_MOCK_PLAYERS)
+
+
+def test_get_regression_passes_baseline_seasons(mock_services):
+    svc, _ = mock_services
+    client = TestClient(app)
+    client.get('/api/trends/regression?baseline_seasons=1')
+
+    assert svc.get_shooting_regression.call_args.args[2] == 1
+
+
+def test_get_regression_defaults_to_two_baseline_seasons(mock_services):
+    svc, _ = mock_services
+    client = TestClient(app)
+    client.get('/api/trends/regression')
+
+    assert svc.get_shooting_regression.call_args.args[2] == 2
+
+
+def test_get_game_log_returns_response(mock_services):
+    client = TestClient(app)
+    resp = client.get('/api/trends/player/1630245/gamelog')
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['player_name'] == 'Ayo Dosunmu'
+    assert len(data['games']) == 2
+    assert data['games'][0]['usg'] == pytest.approx(22.5)
+    assert data['baseline_pct']['3P%'] == pytest.approx(38.0)
+
+
+def test_get_game_log_passes_params_to_service(mock_services):
+    svc, _ = mock_services
+    client = TestClient(app)
+    client.get('/api/trends/player/1630245/gamelog?window_days=30&baseline_seasons=1')
+
+    svc.get_player_game_log.assert_awaited_once_with(1630245, 30, 1)
+
+
+def test_get_game_log_404_when_no_rows(mock_services):
+    svc, _ = mock_services
+    svc.get_player_game_log = AsyncMock(return_value=None)
+    client = TestClient(app)
+    resp = client.get('/api/trends/player/999/gamelog')
+
+    assert resp.status_code == 404

--- a/backend/tests/routes/test_trends_route.py
+++ b/backend/tests/routes/test_trends_route.py
@@ -34,6 +34,7 @@ _MOCK_RESPONSE = RegressionResponse(
     ],
     window_days=15,
     baseline_seasons=2,
+    mode='season',
     last_updated='2026-07-18T12:00:00',
 )
 
@@ -181,6 +182,27 @@ def test_get_regression_defaults_to_two_baseline_seasons(mock_services):
     assert svc.get_shooting_regression.call_args.args[2] == 2
 
 
+def test_get_regression_defaults_to_season_mode(mock_services):
+    svc, _ = mock_services
+    client = TestClient(app)
+    client.get('/api/trends/regression')
+
+    assert svc.get_shooting_regression.call_args.args[3] == 'season'
+
+
+def test_get_regression_passes_form_mode(mock_services):
+    svc, _ = mock_services
+    client = TestClient(app)
+    client.get('/api/trends/regression?mode=form')
+
+    assert svc.get_shooting_regression.call_args.args[3] == 'form'
+
+
+def test_get_regression_rejects_unknown_mode(mock_services):
+    client = TestClient(app)
+    assert client.get('/api/trends/regression?mode=vibes').status_code == 422
+
+
 def test_get_game_log_returns_response(mock_services):
     client = TestClient(app)
     resp = client.get('/api/trends/player/1630245/gamelog')
@@ -198,7 +220,7 @@ def test_get_game_log_passes_params_to_service(mock_services):
     client = TestClient(app)
     client.get('/api/trends/player/1630245/gamelog?window_days=30&baseline_seasons=1')
 
-    svc.get_player_game_log.assert_awaited_once_with(1630245, 30, 1)
+    svc.get_player_game_log.assert_awaited_once_with(1630245, 30, 1, 'season')
 
 
 def test_get_game_log_404_when_no_rows(mock_services):

--- a/backend/tests/services/test_trend_service.py
+++ b/backend/tests/services/test_trend_service.py
@@ -7,10 +7,12 @@ import pytest
 from app.config import settings
 from app.services.trend_service import (
     TrendService,
+    build_game_log,
     classify_role_badge,
     compute_minutes_movers,
     compute_regression_groups,
     compute_usage_role,
+    prior_season_strings,
 )
 
 
@@ -257,7 +259,7 @@ async def test_get_shooting_regression_recomputes_after_ttl_expires(service):
         mock_db.get_games_since = AsyncMock(return_value={})
 
         await service.get_shooting_regression(players_df)
-        service._regression_cache[15]['ts'] = datetime.now() - timedelta(hours=7)
+        service._regression_cache[(15, 2)]['ts'] = datetime.now() - timedelta(hours=7)
         await service.get_shooting_regression(players_df)
 
         assert mock_db.aggregate_shooting_by_player.call_count == 4  # two calls, twice
@@ -615,3 +617,107 @@ async def test_get_usage_role_uses_cache_within_ttl(service):
         await service.get_usage_role(players_df)
 
         assert mock_db.get_usage_components.call_count == 1
+
+
+def _one_season_baseline_case():
+    """~90 baseline 3PA: passes the 1-season gate (75), fails the 2-season one (150)."""
+    current = pd.DataFrame([_current_row(1, "Thin Baseline", 50, fg3m=120, fg3a=400)])
+    baseline = pd.DataFrame([_current_row(1, "Thin Baseline", 30, fg3m=36, fg3a=90)])
+    players_df = _players_df([{
+        "Name": "Thin Baseline", "Pro Team": "PHX", "Positions": "SG",
+        "status": "FREEAGENT", "fantasy_team_name": None,
+    }])
+    return current, baseline, players_df
+
+
+def test_baseline_gate_scales_down_for_one_season_baseline():
+    current, baseline, players_df = _one_season_baseline_case()
+
+    assert compute_regression_groups(current, baseline, {1: 5}, players_df, baseline_seasons=2) == []
+    groups = compute_regression_groups(current, baseline, {1: 5}, players_df, baseline_seasons=1)
+
+    assert len(groups) == 1
+    assert groups[0].stats[0].stat == "3P%"
+
+
+def test_prior_season_strings_length_follows_baseline_seasons():
+    with patch.object(settings, "season_id", 2026):
+        assert prior_season_strings(1) == ["2024-25"]
+        assert prior_season_strings(2) == ["2024-25", "2023-24"]
+
+
+def test_regression_items_carry_player_id():
+    current = pd.DataFrame([_current_row(77, "Id Carrier", 50, fg3m=140, fg3a=420)])
+    baseline = pd.DataFrame([_current_row(77, "Id Carrier", 100, fg3m=320, fg3a=800)])
+    players_df = _players_df([{
+        "Name": "Id Carrier", "Pro Team": "MIA", "Positions": "SF",
+        "status": "FREEAGENT", "fantasy_team_name": None,
+    }])
+
+    groups = compute_regression_groups(current, baseline, {77: 5}, players_df)
+
+    assert groups[0].player_id == 77
+
+
+def test_rostered_players_are_no_longer_filtered_out():
+    current = pd.DataFrame([_current_row(1, "Rostered Guy", 50, fg3m=140, fg3a=420)])
+    baseline = pd.DataFrame([_current_row(1, "Rostered Guy", 100, fg3m=320, fg3a=800)])
+    players_df = _players_df([{
+        "Name": "Rostered Guy", "Pro Team": "BOS", "Positions": "SF",
+        "status": "ONTEAM", "fantasy_team_name": "Team Rocket",
+    }])
+
+    groups = compute_regression_groups(current, baseline, {1: 5}, players_df)
+
+    assert [g.fantasy_status for g in groups] == ["Team Rocket"]
+
+
+def _game_log_row(game_date, p_min, fgm, fga, ftm, fta, fg3m, fg3a, tov=2.0):
+    return {
+        "player_name": "Log Guy", "game_date": game_date, "matchup": "BOS vs. MIA",
+        "p_min": p_min, "fgm": fgm, "fga": fga, "ftm": ftm, "fta": fta,
+        "fg3m": fg3m, "fg3a": fg3a,
+        "p_fga": fga, "p_fta": fta, "p_tov": tov,
+        "t_fga": 88.0, "t_fta": 20.0, "t_tov": 13.0, "t_min": 240.0,
+    }
+
+
+def test_build_game_log_aggregates_season_percentages_from_totals():
+    games_df = pd.DataFrame([
+        _game_log_row(date(2026, 6, 1), 30.0, 7, 14, 2, 2, 2, 5),
+        _game_log_row(date(2026, 6, 3), 26.0, 5, 12, 4, 6, 1, 3),
+    ])
+
+    log = build_game_log(
+        games_df, 42, "2025-26", 15, date(2026, 5, 20), {"3P%": 38.0}, 2
+    )
+
+    assert log.season_gp == 2
+    assert log.season_mpg == pytest.approx(28.0)
+    assert log.season_pct["FG%"] == pytest.approx(12 / 26 * 100)
+    assert log.season_pct["3P%"] == pytest.approx(3 / 8 * 100)
+    assert log.season_pct["FT%"] == pytest.approx(6 / 8 * 100)
+    assert log.baseline_pct == {"3P%": 38.0}
+    assert log.baseline_seasons == 2
+
+
+def test_build_game_log_usg_matches_usage_role_formula():
+    games_df = pd.DataFrame([_game_log_row(date(2026, 6, 1), 30.0, 7, 14, 2, 2, 2, 5)])
+
+    log = build_game_log(games_df, 42, "2025-26", 15, date(2026, 5, 20), {}, 2)
+
+    expected = 100 * (14 + 0.44 * 2 + 2.0) * (240.0 / 5) / (30.0 * (88.0 + 0.44 * 20.0 + 13.0))
+    assert log.games[0].usg == pytest.approx(expected)
+    assert log.season_usg == pytest.approx(expected)
+
+
+def test_build_game_log_preserves_game_order_and_shot_counts():
+    games_df = pd.DataFrame([
+        _game_log_row(date(2026, 6, 1), 30.0, 7, 14, 2, 2, 2, 5),
+        _game_log_row(date(2026, 6, 3), 26.0, 5, 12, 4, 6, 1, 3),
+    ])
+
+    log = build_game_log(games_df, 42, "2025-26", 15, date(2026, 5, 20), {}, 2)
+
+    assert [g.game_date for g in log.games] == ["2026-06-01", "2026-06-03"]
+    assert [g.fg3a for g in log.games] == [5, 3]

--- a/backend/tests/services/test_trend_service.py
+++ b/backend/tests/services/test_trend_service.py
@@ -219,9 +219,11 @@ async def test_get_shooting_regression_wires_db_calls_and_returns_response(servi
         response = await service.get_shooting_regression(players_df)
 
         assert response.items == []
-        assert mock_db.aggregate_shooting_by_player.call_count == 2
-        current_call, baseline_call = mock_db.aggregate_shooting_by_player.call_args_list
+        assert mock_db.aggregate_shooting_by_player.call_count == 3
+        current_call, window_call, baseline_call = mock_db.aggregate_shooting_by_player.call_args_list
         assert current_call.args[0] == ["2025-26"]
+        assert window_call.args[0] == ["2025-26"]
+        assert window_call.kwargs["start"] == date(2026, 5, 17)
         assert baseline_call.args[0] == ["2024-25", "2023-24"]
         mock_db.get_games_since.assert_awaited_once_with(date(2026, 5, 17))
 
@@ -242,7 +244,7 @@ async def test_get_shooting_regression_uses_cache_within_ttl(service):
         await service.get_shooting_regression(players_df)
         await service.get_shooting_regression(players_df)
 
-        assert mock_db.aggregate_shooting_by_player.call_count == 2  # only the first call
+        assert mock_db.aggregate_shooting_by_player.call_count == 3  # only the first call
 
 
 @pytest.mark.asyncio
@@ -262,7 +264,7 @@ async def test_get_shooting_regression_recomputes_after_ttl_expires(service):
         service._regression_cache[(15, 2)]['ts'] = datetime.now() - timedelta(hours=7)
         await service.get_shooting_regression(players_df)
 
-        assert mock_db.aggregate_shooting_by_player.call_count == 4  # two calls, twice
+        assert mock_db.aggregate_shooting_by_player.call_count == 6  # three calls, twice
 
 
 def _season_row(player_id, player_name, gp, min_total):
@@ -721,3 +723,55 @@ def test_build_game_log_preserves_game_order_and_shot_counts():
 
     assert [g.game_date for g in log.games] == ["2026-06-01", "2026-06-03"]
     assert [g.fg3a for g in log.games] == [5, 3]
+
+
+def _regression_case():
+    current = pd.DataFrame([_current_row(9, "Window Guy", 50, fg3m=140, fg3a=420)])
+    baseline = pd.DataFrame([_current_row(9, "Window Guy", 100, fg3m=320, fg3a=800)])
+    players_df = _players_df([{
+        "Name": "Window Guy", "Pro Team": "GSW", "Positions": "SG",
+        "status": "FREEAGENT", "fantasy_team_name": None,
+    }])
+    return current, baseline, players_df
+
+
+def test_window_pct_reported_from_window_frame():
+    current, baseline, players_df = _regression_case()
+    window = pd.DataFrame([_current_row(9, "Window Guy", 6, fg3m=15, fg3a=30)])
+
+    groups = compute_regression_groups(current, baseline, {9: 6}, players_df, 2, window)
+    stat = groups[0].stats[0]
+
+    assert stat.window_pct == pytest.approx(50.0)
+    assert stat.window_attempts == 30
+    assert stat.current_pct == pytest.approx(140 / 420 * 100)
+
+
+def test_window_pct_is_none_when_window_has_no_attempts():
+    current, baseline, players_df = _regression_case()
+    window = pd.DataFrame([_current_row(9, "Window Guy", 2, fg3m=0, fg3a=0)])
+
+    groups = compute_regression_groups(current, baseline, {9: 2}, players_df, 2, window)
+    stat = groups[0].stats[0]
+
+    assert stat.window_pct is None
+    assert stat.window_attempts == 0
+
+
+def test_window_pct_is_none_when_player_absent_from_window():
+    current, baseline, players_df = _regression_case()
+    window = pd.DataFrame([_current_row(999, "Someone Else", 5, fg3m=10, fg3a=20)])
+
+    groups = compute_regression_groups(current, baseline, {9: 0}, players_df, 2, window)
+
+    assert groups[0].stats[0].window_pct is None
+
+
+def test_window_frame_omitted_leaves_window_fields_empty():
+    current, baseline, players_df = _regression_case()
+
+    groups = compute_regression_groups(current, baseline, {9: 6}, players_df)
+    stat = groups[0].stats[0]
+
+    assert stat.window_pct is None
+    assert stat.window_attempts == 0

--- a/backend/tests/services/test_trend_service.py
+++ b/backend/tests/services/test_trend_service.py
@@ -261,7 +261,7 @@ async def test_get_shooting_regression_recomputes_after_ttl_expires(service):
         mock_db.get_games_since = AsyncMock(return_value={})
 
         await service.get_shooting_regression(players_df)
-        service._regression_cache[(15, 2)]['ts'] = datetime.now() - timedelta(hours=7)
+        service._regression_cache[(15, 2, 'season')]['ts'] = datetime.now() - timedelta(hours=7)
         await service.get_shooting_regression(players_df)
 
         assert mock_db.aggregate_shooting_by_player.call_count == 6  # three calls, twice
@@ -775,3 +775,94 @@ def test_window_frame_omitted_leaves_window_fields_empty():
 
     assert stat.window_pct is None
     assert stat.window_attempts == 0
+
+
+def _form_players_df(name="Klay Thompson"):
+    return _players_df([{
+        "Name": name, "Pro Team": "DAL", "Positions": "SG",
+        "status": "FREEAGENT", "fantasy_team_name": None,
+    }])
+
+
+def test_form_baseline_excludes_the_window():
+    # season 100/300, window 30/60 -> pre is 70/240; prior adds 140/400.
+    current = pd.DataFrame([_current_row(1, "Klay Thompson", 30, fg3m=100, fg3a=300)])
+    baseline = pd.DataFrame([_current_row(1, "Klay Thompson", 60, fg3m=140, fg3a=400)])
+    window = pd.DataFrame([_current_row(1, "Klay Thompson", 6, fg3m=30, fg3a=60)])
+
+    groups = compute_regression_groups(
+        current, baseline, {1: 6}, _form_players_df(), 2, window, 'form'
+    )
+
+    stat = next(s for s in groups[0].stats if s.stat == "3P%")
+    assert stat.baseline_pct == pytest.approx(210 / 640 * 100)
+    assert stat.current_pct == pytest.approx(50.0)
+    assert stat.dev == pytest.approx(50.0 - 210 / 640 * 100)
+    assert stat.attempts_per_game == pytest.approx(10.0)
+    assert stat.window_attempts == 60
+    assert stat.z == pytest.approx(2.68, abs=0.02)
+    assert stat.drift_score == pytest.approx(abs(stat.z))
+
+
+def test_form_mode_ranks_rookie_that_season_mode_drops():
+    current = pd.DataFrame([_current_row(7, "Rookie Guy", 20, fg3m=60, fg3a=200)])
+    window = pd.DataFrame([_current_row(7, "Rookie Guy", 5, fg3m=25, fg3a=50)])
+    players_df = _form_players_df("Rookie Guy")
+
+    form_groups = compute_regression_groups(
+        current, pd.DataFrame(), {7: 5}, players_df, 2, window, 'form'
+    )
+    season_groups = compute_regression_groups(
+        current, pd.DataFrame(), {7: 5}, players_df, 2, window, 'season'
+    )
+
+    assert [g.player_name for g in form_groups] == ["Rookie Guy"]
+    stat = form_groups[0].stats[0]
+    assert stat.baseline_pct == pytest.approx(35 / 150 * 100)
+    assert season_groups == []
+
+
+def test_form_z_gate_rejects_thin_window_and_keeps_thick_one():
+    baseline = pd.DataFrame([_current_row(1, "Klay Thompson", 60, fg3m=200, fg3a=500)])
+    players_df = _form_players_df()
+
+    thin_current = pd.DataFrame([_current_row(1, "Klay Thompson", 3, fg3m=6, fg3a=12)])
+    thin_window = pd.DataFrame([_current_row(1, "Klay Thompson", 3, fg3m=6, fg3a=12)])
+    thick_current = pd.DataFrame([_current_row(1, "Klay Thompson", 20, fg3m=45, fg3a=90)])
+    thick_window = pd.DataFrame([_current_row(1, "Klay Thompson", 20, fg3m=45, fg3a=90)])
+
+    thin = compute_regression_groups(
+        thin_current, baseline, {1: 3}, players_df, 2, thin_window, 'form'
+    )
+    thick = compute_regression_groups(
+        thick_current, baseline, {1: 20}, players_df, 2, thick_window, 'form'
+    )
+
+    # Same 10pp gap in both; only the larger sample clears |z| >= 1.5.
+    assert thin == []
+    assert thick[0].stats[0].z == pytest.approx(1.77, abs=0.02)
+
+
+def test_form_mode_skips_players_with_no_window_games():
+    current = pd.DataFrame([_current_row(1, "Klay Thompson", 30, fg3m=100, fg3a=300)])
+    baseline = pd.DataFrame([_current_row(1, "Klay Thompson", 60, fg3m=140, fg3a=400)])
+    window = pd.DataFrame([_current_row(999, "Someone Else", 5, fg3m=10, fg3a=20)])
+
+    groups = compute_regression_groups(
+        current, baseline, {1: 0}, _form_players_df(), 2, window, 'form'
+    )
+
+    assert groups == []
+
+
+def test_season_mode_output_unchanged_when_mode_is_explicit():
+    current, baseline, players_df = _regression_case()
+    window = pd.DataFrame([_current_row(9, "Klay Thompson", 5, fg3m=12, fg3a=30)])
+
+    default_groups = compute_regression_groups(current, baseline, {9: 6}, players_df, 2, window)
+    explicit_groups = compute_regression_groups(
+        current, baseline, {9: 6}, players_df, 2, window, 'season'
+    )
+
+    assert default_groups == explicit_groups
+    assert all(s.z is None for g in explicit_groups for s in g.stats)

--- a/backend/tests/services/test_trend_service.py
+++ b/backend/tests/services/test_trend_service.py
@@ -7,6 +7,7 @@ import pytest
 from app.config import settings
 from app.services.trend_service import (
     TrendService,
+    _normalize_baseline_seasons,
     build_game_log,
     classify_role_badge,
     compute_minutes_movers,
@@ -866,3 +867,28 @@ def test_season_mode_output_unchanged_when_mode_is_explicit():
 
     assert default_groups == explicit_groups
     assert all(s.z is None for g in explicit_groups for s in g.stats)
+
+
+def test_zero_baseline_seasons_judges_form_against_this_season_only():
+    # prior seasons exist but must be ignored: baseline is 70/240 from the
+    # pre-window games alone, not pooled with the 140/400 prior rows.
+    current = pd.DataFrame([_current_row(1, "Klay Thompson", 30, fg3m=100, fg3a=300)])
+    baseline = pd.DataFrame([_current_row(1, "Klay Thompson", 60, fg3m=140, fg3a=400)])
+    window = pd.DataFrame([_current_row(1, "Klay Thompson", 6, fg3m=30, fg3a=60)])
+
+    pooled = compute_regression_groups(
+        current, baseline, {1: 6}, _form_players_df(), 2, window, 'form'
+    )
+    this_season = compute_regression_groups(
+        current, pd.DataFrame(), {1: 6}, _form_players_df(), 0, window, 'form'
+    )
+
+    assert next(s for s in pooled[0].stats if s.stat == "3P%").baseline_pct == pytest.approx(210 / 640 * 100)
+    assert next(s for s in this_season[0].stats if s.stat == "3P%").baseline_pct == pytest.approx(70 / 240 * 100)
+
+
+def test_zero_baseline_seasons_is_rejected_for_season_mode():
+    assert _normalize_baseline_seasons(0, 'form') == 0
+    assert _normalize_baseline_seasons(0, 'season') == 2
+    assert _normalize_baseline_seasons(1, 'form') == 1
+    assert _normalize_baseline_seasons(9, 'form') == 2

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -207,8 +207,10 @@ export default function TrendGameLogChart({
     return <p className="py-4 text-xs text-gray-500 dark:text-gray-400">No games on record for {playerName} this season.</p>
   }
 
-  const selectableStats = (Object.keys(STAT_FIELDS) as RegressionStat[]).filter(k =>
-    log.games.some(g => (g[STAT_FIELDS[k].att] as number) > 0))
+  const selectableStats = qualifiedStats.length
+    ? qualifiedStats
+    : (Object.keys(STAT_FIELDS) as RegressionStat[]).filter(k =>
+        log.games.some(g => (g[STAT_FIELDS[k].att] as number) > 0))
 
   const windowRows = rows.filter(r => r.date >= log.window_start)
   const bandStart = windowRows.length ? windowRows[0].label : null
@@ -259,25 +261,21 @@ export default function TrendGameLogChart({
       <div className="flex flex-wrap items-center gap-2 mb-2">
         <span className="text-xs text-gray-500 dark:text-gray-400 mr-auto">
           {playerName} —{' '}
-          {mode === 'minutes' && 'minutes per game'}
-          {mode === 'usage' && 'usage rate per game, bars = minutes'}
+          {mode === 'minutes' && 'minutes in each game'}
+          {mode === 'usage' && 'usage rate in each game · bars = minutes'}
           {mode === 'shooting' && `${stat}, ${ROLLING_GAMES}-game attempt-weighted · bars = attempts`}
         </span>
         {mode === 'shooting' && selectableStats.length > 1 && (
           <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-[11px]">
-            {selectableStats.map(s => {
-              const flagged = qualifiedStats.length > 0 && !qualifiedStats.includes(s)
-              return (
-                <button
-                  key={s}
-                  onClick={e => { e.stopPropagation(); onStatChange?.(s) }}
-                  title={flagged ? `${s} did not clear the table's volume / drift filter — shown here for reference` : undefined}
-                  className={`px-2.5 py-1 ${s === stat ? 'bg-blue-600 text-white' : `bg-white dark:bg-gray-700 ${flagged ? 'text-gray-400 dark:text-gray-500 italic' : 'text-gray-600 dark:text-gray-300'}`}`}
-                >
-                  {s}{flagged ? '*' : ''}
-                </button>
-              )
-            })}
+            {selectableStats.map(s => (
+              <button
+                key={s}
+                onClick={e => { e.stopPropagation(); onStatChange?.(s) }}
+                className={`px-2.5 py-1 ${s === stat ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300'}`}
+              >
+                {s}
+              </button>
+            ))}
           </div>
         )}
       </div>
@@ -346,12 +344,12 @@ export default function TrendGameLogChart({
 
       <Legend items={[
         {
-          label: mode === 'minutes' ? 'Minutes per game'
-            : mode === 'usage' ? 'Usage rate per game'
-            : `${stat}, ${ROLLING_GAMES}-game attempt-weighted`,
+          label: mode === 'minutes' ? 'Minutes — single game'
+            : mode === 'usage' ? 'USG% — single game'
+            : `${stat} — trailing ${ROLLING_GAMES} games, attempt-weighted`,
           color: LINE_COLOR[mode],
         },
-        ...(mode === 'minutes' ? [] : [{ label: mode === 'usage' ? 'Minutes played' : 'Attempts', bar: true }]),
+        ...(mode === 'minutes' ? [] : [{ label: mode === 'usage' ? 'Minutes — single game' : 'Attempts — single game', bar: true }]),
         ...(seasonRef === undefined ? [] : [{
           label: `This season to date — ${seasonRef.toFixed(1)}${unit}`,
           color: 'var(--trend-season-line)',

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -38,13 +38,13 @@ const BAR_COLOR = '#8b5cf6'
 // so a capped point never reads as part of the line it sits on.
 const CAPPED_COLOR = '#d946ef'
 
-type LegendItem = { label: string; color?: string; band?: boolean; dash?: string; bar?: boolean; marker?: boolean }
+type LegendItem = { label: string; hint?: string; color?: string; band?: boolean; dash?: string; bar?: boolean; marker?: boolean }
 
 function Legend({ items }: { items: LegendItem[] }) {
   return (
     <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-[10px] sm:text-[11px] text-gray-500 dark:text-gray-400">
       {items.map(i => (
-        <span key={i.label} className="inline-flex items-center gap-1.5">
+        <span key={i.label} title={i.hint} className={`inline-flex items-center gap-1.5 ${i.hint ? 'cursor-help' : ''}`}>
           {i.band && <span className="inline-block w-3.5 h-2.5 rounded-sm" style={{ background: 'var(--trend-band)', border: '1px solid var(--trend-band-label)' }} />}
           {i.bar && <span className="inline-block w-3.5 h-2.5 rounded-sm" style={{ background: BAR_COLOR, opacity: 0.45 }} />}
           {i.marker && <span style={{ color: i.color }}>▲</span>}
@@ -191,14 +191,13 @@ interface Props {
   windowDays: number
   baselineSeasons?: number
   stat?: RegressionStat
-  zScore?: number | null
   qualifiedStats?: RegressionStat[]
   onStatChange?: (stat: RegressionStat) => void
 }
 
 export default function TrendGameLogChart({
   playerId, playerName, mode, regressionMode = 'season', windowDays, baselineSeasons = 2,
-  stat = '3P%', zScore = null, qualifiedStats = [], onStatChange,
+  stat = '3P%', qualifiedStats = [], onStatChange,
 }: Props) {
   const { data: log, isLoading, error } = useGetTrendGameLogQuery({ playerId, windowDays, baselineSeasons, mode: regressionMode })
   const isForm = mode === 'shooting' && regressionMode === 'form'
@@ -220,11 +219,7 @@ export default function TrendGameLogChart({
   const bandStart = windowRows.length ? windowRows[0].label : null
   const bandEnd = rows[rows.length - 1].label
 
-  // In form mode the baseline deliberately excludes the window, so drawing the
-  // season line beside it invites the part-whole comparison the mode rejects.
-  const seasonRef = isForm
-    ? undefined
-    : mode === 'minutes' ? log.season_mpg : mode === 'usage' ? log.season_usg : log.season_pct[stat]
+  const seasonRef = mode === 'minutes' ? log.season_mpg : mode === 'usage' ? log.season_usg : log.season_pct[stat]
   const baselineRef = mode === 'shooting' ? log.baseline_pct[stat] : undefined
   const unit = mode === 'minutes' ? '' : '%'
 
@@ -268,12 +263,13 @@ export default function TrendGameLogChart({
               [`Last ${windowDays}d ${stat}`, windowShooting === null
                 ? 'no attempts'
                 : `${windowShooting.pct.toFixed(1)}% on ${windowShooting.attPerGame.toFixed(1)} att/g`],
-              ['Baseline', baselineRef === undefined ? 'no history' : `${baselineRef.toFixed(1)}%`],
+              [`Baseline (through ${shortDate(log.window_start)})`,
+                baselineRef === undefined ? 'no history' : `${baselineRef.toFixed(1)}%`],
               ['Gap',
                 baselineRef === undefined || windowShooting === null
                   ? '—'
                   : `${windowShooting.pct - baselineRef >= 0 ? '+' : ''}${(windowShooting.pct - baselineRef).toFixed(1)}%`],
-              ['z', zScore === null ? '—' : `${zScore >= 0 ? '+' : ''}${zScore.toFixed(2)}`],
+              [`Season ${stat}`, seasonRef === undefined ? '—' : `${seasonRef.toFixed(1)}%`],
               ['Games', String(log.season_gp)],
             ]
           : [
@@ -297,7 +293,7 @@ export default function TrendGameLogChart({
           {playerName} —{' '}
           {mode === 'minutes' && 'minutes in each game'}
           {mode === 'usage' && 'usage rate in each game · bars = minutes'}
-          {mode === 'shooting' && `${stat}, ${ROLLING_GAMES}-game attempt-weighted · bars = attempts`}
+          {mode === 'shooting' && `${stat}, rolling ${ROLLING_GAMES} games · bars = attempts`}
         </span>
         {mode === 'shooting' && selectableStats.length > 1 && (
           <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-[11px]">
@@ -378,26 +374,35 @@ export default function TrendGameLogChart({
 
       <Legend items={[
         {
-          label: mode === 'minutes' ? 'Minutes — single game'
-            : mode === 'usage' ? 'USG% — single game'
-            : `${stat} — trailing ${ROLLING_GAMES} games, attempt-weighted`,
+          label: mode === 'minutes' ? 'Minutes' : mode === 'usage' ? 'USG%' : `${stat} · ${ROLLING_GAMES}g`,
+          hint: mode === 'shooting'
+            ? `Rolling ${ROLLING_GAMES} games: total makes ÷ total attempts, so a 1-for-1 night doesn't count as a 100% game`
+            : 'One point per game',
           color: LINE_COLOR[mode],
         },
-        ...(mode === 'minutes' ? [] : [{ label: mode === 'usage' ? 'Minutes — single game' : 'Attempts — single game', bar: true }]),
+        ...(mode === 'minutes' ? [] : [{
+          label: mode === 'usage' ? 'Minutes' : 'Attempts',
+          hint: 'One bar per game',
+          bar: true,
+        }]),
         ...(seasonRef === undefined ? [] : [{
-          label: `This season to date — ${seasonRef.toFixed(1)}${unit}`,
+          label: `Season ${seasonRef.toFixed(1)}${unit}`,
+          hint: isForm
+            ? 'This season to date — includes the recency window, so it is context, not the comparison'
+            : 'This season to date',
           color: 'var(--trend-season-line)',
           dash: '6 3',
         }]),
         ...(baselineRef === undefined ? [] : [{
-          label: isForm
-            ? `Baseline, everything outside the window — ${baselineRef.toFixed(1)}%`
-            : `Baseline, ${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} — ${baselineRef.toFixed(1)}%`,
+          label: `Baseline ${baselineRef.toFixed(1)}%`,
+          hint: isForm
+            ? `${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} plus this season up to ${shortDate(log.window_start)} — excludes the window, and is what the gap is measured against`
+            : `${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`}, excludes this season`,
           color: '#ef4444',
           dash: '2 3',
         }]),
-        { label: `Last ${windowDays} days`, band: true },
-        ...(cappedCount > 0 ? [{ label: 'Capped — true value in tooltip', color: CAPPED_COLOR, marker: true }] : []),
+        { label: `Last ${windowDays}d`, hint: `The recency window — games since ${shortDate(log.window_start)}`, band: true },
+        ...(cappedCount > 0 ? [{ label: 'Capped', hint: 'Off-scale point pinned to the axis — true value in the tooltip', color: CAPPED_COLOR, marker: true }] : []),
       ]} />
     </div>
   )

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -37,6 +37,7 @@ const BAR_COLOR = '#8b5cf6'
 // Distinct from every series colour (blue / amber / green) and from the bars,
 // so a capped point never reads as part of the line it sits on.
 const CAPPED_COLOR = '#d946ef'
+const LEAGUE_COLOR = '#f59e0b'
 
 type LegendItem = { label: string; hint?: string; color?: string; band?: boolean; dash?: string; bar?: boolean; marker?: boolean }
 
@@ -221,11 +222,14 @@ export default function TrendGameLogChart({
 
   const seasonRef = mode === 'minutes' ? log.season_mpg : mode === 'usage' ? log.season_usg : log.season_pct[stat]
   const baselineRef = mode === 'shooting' ? log.baseline_pct[stat] : undefined
+  const leagueRef = mode === 'shooting'
+    ? log.league_pct[stat]
+    : mode === 'usage' ? (log.league_usg ?? undefined) : undefined
   const unit = mode === 'minutes' ? '' : '%'
 
   const { domain, cap } = chartScale(
     rows.map(r => r.value),
-    [seasonRef, baselineRef].filter((v): v is number => v !== undefined),
+    [seasonRef, baselineRef, leagueRef].filter((v): v is number => v !== undefined),
   )
   const cappedRows = rows.map(r => (r.value > cap ? { ...r, value: cap, capped: true } : r))
   const cappedCount = cappedRows.filter(r => r.capped).length
@@ -263,7 +267,7 @@ export default function TrendGameLogChart({
               [`Last ${windowDays}d ${stat}`, windowShooting === null
                 ? 'no attempts'
                 : `${windowShooting.pct.toFixed(1)}% on ${windowShooting.attPerGame.toFixed(1)} att/g`],
-              [`Baseline (through ${shortDate(log.window_start)})`,
+              [`Baseline (${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} + this season thru ${shortDate(log.window_start)})`,
                 baselineRef === undefined ? 'no history' : `${baselineRef.toFixed(1)}%`],
               ['Gap',
                 baselineRef === undefined || windowShooting === null
@@ -337,6 +341,16 @@ export default function TrendGameLogChart({
                 />
               )}
               {mode !== 'minutes' && <Bar yAxisId="bar" dataKey="bar" fill={BAR_COLOR} fillOpacity={0.45} isAnimationActive={false} />}
+              {leagueRef !== undefined && (
+                <ReferenceLine
+                  yAxisId="main"
+                  y={leagueRef}
+                  stroke={LEAGUE_COLOR}
+                  strokeWidth={1.5}
+                  strokeDasharray="1 4"
+                  ifOverflow="extendDomain"
+                />
+              )}
               {seasonRef !== undefined && (
                 <ReferenceLine
                   yAxisId="main"
@@ -394,14 +408,24 @@ export default function TrendGameLogChart({
           dash: '6 3',
         }]),
         ...(baselineRef === undefined ? [] : [{
-          label: `Baseline ${baselineRef.toFixed(1)}%`,
+          label: isForm
+            ? `Baseline ${baselineRef.toFixed(1)}% = ${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} + this season thru ${shortDate(log.window_start)}`
+            : `Baseline ${baselineRef.toFixed(1)}% = ${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`}, this season excluded`,
           hint: isForm
             ? `${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} plus this season up to ${shortDate(log.window_start)} — excludes the window, and is what the gap is measured against`
             : `${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`}, excludes this season`,
           color: '#ef4444',
           dash: '2 3',
         }]),
-        { label: `Last ${windowDays}d`, hint: `The recency window — games since ${shortDate(log.window_start)}`, band: true },
+        ...(leagueRef === undefined ? [] : [{
+          label: `NBA ${leagueRef.toFixed(1)}%`,
+          hint: mode === 'usage'
+            ? 'League-wide USG%, minutes-weighted. It sits near 20% by construction — five players on the floor split every possession — so read it as the line that separates a high-usage role from a low-usage one, not as a figure that moves.'
+            : `League-wide ${stat} this season, every player's makes over every player's attempts — shows whether he helps or hurts the category, which his own history cannot`,
+          color: LEAGUE_COLOR,
+          dash: '1 4',
+        }]),
+        { label: `Last ${windowDays}d window`, hint: `The recency window — games since ${shortDate(log.window_start)}`, band: true },
         ...(cappedCount > 0 ? [{ label: 'Capped', hint: 'Off-scale point pinned to the axis — true value in the tooltip', color: CAPPED_COLOR, marker: true }] : []),
       ]} />
     </div>

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -35,18 +35,22 @@ interface ChartRow {
   date: string
   label: string
   matchup: string
-  value: number
+  value: number      // plotted value, capped at the axis ceiling
+  trueValue: number  // what actually happened, always shown in the tooltip
+  capped: boolean
   bar: number
   rawPct: number | null
+  minutes: number
 }
 
 function buildRows(log: GameLogResponse, mode: GameLogMode, stat: RegressionStat): ChartRow[] {
   return log.games.map((g, i) => {
+    const base = { date: g.game_date, label: shortDate(g.game_date), matchup: g.matchup, minutes: g.min, capped: false }
     if (mode === 'minutes') {
-      return { date: g.game_date, label: shortDate(g.game_date), matchup: g.matchup, value: g.min, bar: 0, rawPct: null }
+      return { ...base, value: g.min, trueValue: g.min, bar: 0, rawPct: null }
     }
     if (mode === 'usage') {
-      return { date: g.game_date, label: shortDate(g.game_date), matchup: g.matchup, value: g.usg, bar: g.min, rawPct: null }
+      return { ...base, value: g.usg, trueValue: g.usg, bar: g.min, rawPct: null }
     }
     const { made, att } = STAT_FIELDS[stat]
     const from = Math.max(0, i - ROLLING_GAMES + 1)
@@ -54,11 +58,11 @@ function buildRows(log: GameLogResponse, mode: GameLogMode, stat: RegressionStat
     const madeSum = slice.reduce((s, x) => s + (x[made] as number), 0)
     const attSum = slice.reduce((s, x) => s + (x[att] as number), 0)
     const attempts = g[att] as number
+    const rolling = attSum ? (madeSum / attSum) * 100 : 0
     return {
-      date: g.game_date,
-      label: shortDate(g.game_date),
-      matchup: g.matchup,
-      value: attSum ? (madeSum / attSum) * 100 : 0,
+      ...base,
+      value: rolling,
+      trueValue: rolling,
       bar: attempts,
       rawPct: attempts ? ((g[made] as number) / attempts) * 100 : null,
     }
@@ -71,16 +75,34 @@ function percentile(sorted: number[], q: number): number {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (i - lo)
 }
 
-// A garbage-time game (2 minutes, one shot) produces a USG% north of 100 and a
-// single-game shooting % of 0 or 100. Scaling to those makes the actual trend a
-// flat line, so the axis covers the 5th-95th percentile and outliers clip.
-function robustDomain(values: number[], refs: number[]): [number, number] {
+const OUTLIER_HEADROOM = 1.35
+
+// USG% is a rate per minute on court, so a 2-minute cameo with one shot scores
+// as if that pace held for a whole game and lands north of 100. The axis must
+// not scale to those or the real trend flattens — but it must never cut off the
+// bottom or a legitimately low game vanishes. So: floor is always the true
+// minimum, ceiling only backs off when the top outliers sit far above the 95th
+// percentile, and any point above it is capped and marked rather than clipped.
+function chartScale(values: number[], refs: number[]): { domain: [number, number]; cap: number } {
   const sorted = [...values].sort((a, b) => a - b)
-  let lo = percentile(sorted, 0.05)
-  let hi = percentile(sorted, 0.95)
+  const dataMin = sorted[0]
+  const dataMax = sorted[sorted.length - 1]
+  const p95 = percentile(sorted, 0.95)
+
+  const cap = dataMax > p95 * OUTLIER_HEADROOM ? p95 * OUTLIER_HEADROOM : dataMax
+
+  let lo = dataMin
+  let hi = cap
   for (const r of refs) { lo = Math.min(lo, r); hi = Math.max(hi, r) }
-  const pad = (hi - lo || 1) * 0.15
-  return [Math.max(0, lo - pad), hi + pad]
+  const pad = (hi - lo || 1) * 0.08
+  return { domain: [Math.max(0, lo - pad), hi + pad], cap }
+}
+
+function CappedDot(props: { cx?: number; cy?: number; payload?: ChartRow; stroke?: string }) {
+  const { cx, cy, payload, stroke } = props
+  if (cx === undefined || cy === undefined) return null
+  if (!payload?.capped) return <circle cx={cx} cy={cy} r={2} fill={stroke} />
+  return <path d={`M${cx - 4},${cy + 3} L${cx},${cy - 3} L${cx + 4},${cy + 3} Z`} fill={stroke} />
 }
 
 function StatBlock({ rows }: { rows: [string, string][] }) {
@@ -109,7 +131,8 @@ function ChartTooltip({ active, payload, mode, stat }: {
   return (
     <div className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1.5 text-[11px] shadow">
       <div className="font-semibold text-gray-800 dark:text-gray-100">{r.label} · {r.matchup}</div>
-      <div className="text-gray-600 dark:text-gray-300">{main}: {r.value.toFixed(1)}{unit}</div>
+      <div className="text-gray-600 dark:text-gray-300">{main}: {r.trueValue.toFixed(1)}{unit}</div>
+      {r.capped && <div className="text-amber-600 dark:text-amber-400">above the axis — {r.minutes.toFixed(0)} min played</div>}
       {mode === 'usage' && <div className="text-gray-500 dark:text-gray-400">MIN: {r.bar.toFixed(0)}</div>}
       {mode === 'shooting' && (
         <div className="text-gray-500 dark:text-gray-400">
@@ -152,10 +175,12 @@ export default function TrendGameLogChart({
   const baselineRef = mode === 'shooting' ? log.baseline_pct[stat] : undefined
   const unit = mode === 'minutes' ? '' : '%'
 
-  const domain = robustDomain(
+  const { domain, cap } = chartScale(
     rows.map(r => r.value),
     [seasonRef, baselineRef].filter((v): v is number => v !== undefined),
   )
+  const cappedRows = rows.map(r => (r.value > cap ? { ...r, value: cap, capped: true } : r))
+  const cappedCount = cappedRows.filter(r => r.capped).length
 
   const windowMean = windowRows.length
     ? windowRows.reduce((s, r) => s + r.value, 0) / windowRows.length
@@ -210,11 +235,17 @@ export default function TrendGameLogChart({
         )}
       </div>
 
+      {cappedCount > 0 && (
+        <p className="text-[10px] text-amber-600 dark:text-amber-400 mb-1">
+          ▲ {cappedCount} {cappedCount === 1 ? 'game sits' : 'games sit'} above the axis — short garbage-time
+          appearances where a per-minute rate overstates the real role. Hover for the true value.
+        </p>
+      )}
       <div className="flex flex-col sm:flex-row gap-3 items-stretch">
         <div className="w-full min-w-0 flex-none h-[150px] sm:flex-1 sm:h-[180px]">
           <ResponsiveContainer width="100%" height="100%">
-            <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="currentColor" className="text-gray-200 dark:text-gray-700" />
+            <ComposedChart data={cappedRows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--trend-grid)" />
               <XAxis dataKey="label" tick={{ fontSize: 9 }} interval="preserveStartEnd" minTickGap={24} />
               <YAxis yAxisId="main" tick={{ fontSize: 9 }} domain={domain} allowDataOverflow width={34} tickFormatter={(v: number) => v.toFixed(0)} />
               <YAxis yAxisId="bar" orientation="right" hide domain={[0, (max: number) => max * 3]} />
@@ -224,9 +255,8 @@ export default function TrendGameLogChart({
                   yAxisId="main"
                   x1={bandStart}
                   x2={bandEnd}
-                  fill="#3b82f6"
-                  fillOpacity={0.12}
-                  label={{ value: `last ${windowDays}d`, position: 'insideTop', fontSize: 9, fill: '#3b82f6' }}
+                  fill="var(--trend-band)"
+                  label={{ value: `last ${windowDays}d`, position: 'insideTop', fontSize: 9, fill: 'var(--trend-band-label)' }}
                 />
               )}
               {mode !== 'minutes' && <Bar yAxisId="bar" dataKey="bar" fill="#8b5cf6" fillOpacity={0.45} isAnimationActive={false} />}
@@ -234,9 +264,11 @@ export default function TrendGameLogChart({
                 <ReferenceLine
                   yAxisId="main"
                   y={seasonRef}
-                  stroke="#9ca3af"
-                  strokeDasharray="5 4"
-                  label={{ value: `season ${seasonRef.toFixed(1)}${unit}`, position: 'insideTopRight', fontSize: 9, fill: '#9ca3af' }}
+                  stroke="var(--trend-season-line)"
+                  strokeWidth={1.5}
+                  strokeDasharray="6 3"
+                  ifOverflow="extendDomain"
+                  label={{ value: `season ${seasonRef.toFixed(1)}${unit}`, position: 'insideTopLeft', fontSize: 9, fontWeight: 600, fill: 'var(--trend-season-line)' }}
                 />
               )}
               {baselineRef !== undefined && (
@@ -245,7 +277,9 @@ export default function TrendGameLogChart({
                   y={baselineRef}
                   stroke="#ef4444"
                   strokeDasharray="2 3"
-                  label={{ value: `baseline ${baselineRef.toFixed(1)}%`, position: 'insideBottomLeft', fontSize: 9, fill: '#ef4444' }}
+                  strokeWidth={1.5}
+                  ifOverflow="extendDomain"
+                  label={{ value: `baseline ${baselineRef.toFixed(1)}%`, position: 'insideBottomRight', fontSize: 9, fontWeight: 600, fill: '#ef4444' }}
                 />
               )}
               <Line
@@ -254,7 +288,7 @@ export default function TrendGameLogChart({
                 dataKey="value"
                 stroke={mode === 'minutes' ? '#3b82f6' : mode === 'usage' ? '#f59e0b' : '#10b981'}
                 strokeWidth={2}
-                dot={{ r: 2 }}
+                dot={<CappedDot />}
                 isAnimationActive={false}
               />
             </ComposedChart>

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -27,6 +27,36 @@ const STAT_FIELDS: Record<RegressionStat, { made: keyof GameLogEntry; att: keyof
   'FG%': { made: 'fgm', att: 'fga', label: 'FGM' },
 }
 
+const LINE_COLOR: Record<GameLogMode, string> = {
+  minutes: '#3b82f6',
+  usage: '#f59e0b',
+  shooting: '#10b981',
+}
+
+const BAR_COLOR = '#8b5cf6'
+
+type LegendItem = { label: string; color?: string; band?: boolean; dash?: string; bar?: boolean; marker?: boolean }
+
+function Legend({ items }: { items: LegendItem[] }) {
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-[10px] sm:text-[11px] text-gray-500 dark:text-gray-400">
+      {items.map(i => (
+        <span key={i.label} className="inline-flex items-center gap-1.5">
+          {i.band && <span className="inline-block w-3.5 h-2.5 rounded-sm" style={{ background: 'var(--trend-band)', border: '1px solid var(--trend-band-label)' }} />}
+          {i.bar && <span className="inline-block w-3.5 h-2.5 rounded-sm" style={{ background: BAR_COLOR, opacity: 0.45 }} />}
+          {i.marker && <span style={{ color: i.color }}>▲</span>}
+          {!i.band && !i.bar && !i.marker && (
+            <svg viewBox="0 0 16 4" className="w-4 h-1 overflow-visible" aria-hidden="true">
+              <line x1="0" y1="2" x2="16" y2="2" stroke={i.color} strokeWidth="2" strokeDasharray={i.dash} />
+            </svg>
+          )}
+          {i.label}
+        </span>
+      ))}
+    </div>
+  )
+}
+
 function shortDate(iso: string): string {
   return iso.slice(5).replace('-', '/')
 }
@@ -150,12 +180,12 @@ interface Props {
   windowDays: number
   baselineSeasons?: number
   stat?: RegressionStat
-  availableStats?: RegressionStat[]
+  qualifiedStats?: RegressionStat[]
   onStatChange?: (stat: RegressionStat) => void
 }
 
 export default function TrendGameLogChart({
-  playerId, playerName, mode, windowDays, baselineSeasons = 2, stat = '3P%', availableStats = [], onStatChange,
+  playerId, playerName, mode, windowDays, baselineSeasons = 2, stat = '3P%', qualifiedStats = [], onStatChange,
 }: Props) {
   const { data: log, isLoading, error } = useGetTrendGameLogQuery({ playerId, windowDays, baselineSeasons })
 
@@ -166,6 +196,9 @@ export default function TrendGameLogChart({
   if (!log || rows.length === 0) {
     return <p className="py-4 text-xs text-gray-500 dark:text-gray-400">No games on record for {playerName} this season.</p>
   }
+
+  const selectableStats = (Object.keys(STAT_FIELDS) as RegressionStat[]).filter(k =>
+    log.games.some(g => (g[STAT_FIELDS[k].att] as number) > 0))
 
   const windowRows = rows.filter(r => r.date >= log.window_start)
   const bandStart = windowRows.length ? windowRows[0].label : null
@@ -220,17 +253,21 @@ export default function TrendGameLogChart({
           {mode === 'usage' && 'usage rate per game, bars = minutes'}
           {mode === 'shooting' && `${stat}, ${ROLLING_GAMES}-game attempt-weighted · bars = attempts`}
         </span>
-        {mode === 'shooting' && availableStats.length > 1 && (
+        {mode === 'shooting' && selectableStats.length > 1 && (
           <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-[11px]">
-            {availableStats.map(s => (
-              <button
-                key={s}
-                onClick={e => { e.stopPropagation(); onStatChange?.(s) }}
-                className={`px-2.5 py-1 ${s === stat ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300'}`}
-              >
-                {s}
-              </button>
-            ))}
+            {selectableStats.map(s => {
+              const flagged = qualifiedStats.length > 0 && !qualifiedStats.includes(s)
+              return (
+                <button
+                  key={s}
+                  onClick={e => { e.stopPropagation(); onStatChange?.(s) }}
+                  title={flagged ? `${s} did not clear the table's volume / drift filter — shown here for reference` : undefined}
+                  className={`px-2.5 py-1 ${s === stat ? 'bg-blue-600 text-white' : `bg-white dark:bg-gray-700 ${flagged ? 'text-gray-400 dark:text-gray-500 italic' : 'text-gray-600 dark:text-gray-300'}`}`}
+                >
+                  {s}{flagged ? '*' : ''}
+                </button>
+              )
+            })}
           </div>
         )}
       </div>
@@ -256,10 +293,9 @@ export default function TrendGameLogChart({
                   x1={bandStart}
                   x2={bandEnd}
                   fill="var(--trend-band)"
-                  label={{ value: `last ${windowDays}d`, position: 'insideTop', fontSize: 9, fill: 'var(--trend-band-label)' }}
                 />
               )}
-              {mode !== 'minutes' && <Bar yAxisId="bar" dataKey="bar" fill="#8b5cf6" fillOpacity={0.45} isAnimationActive={false} />}
+              {mode !== 'minutes' && <Bar yAxisId="bar" dataKey="bar" fill={BAR_COLOR} fillOpacity={0.45} isAnimationActive={false} />}
               {seasonRef !== undefined && (
                 <ReferenceLine
                   yAxisId="main"
@@ -268,7 +304,6 @@ export default function TrendGameLogChart({
                   strokeWidth={1.5}
                   strokeDasharray="6 3"
                   ifOverflow="extendDomain"
-                  label={{ value: `season ${seasonRef.toFixed(1)}${unit}`, position: 'insideTopLeft', fontSize: 9, fontWeight: 600, fill: 'var(--trend-season-line)' }}
                 />
               )}
               {baselineRef !== undefined && (
@@ -279,14 +314,13 @@ export default function TrendGameLogChart({
                   strokeDasharray="2 3"
                   strokeWidth={1.5}
                   ifOverflow="extendDomain"
-                  label={{ value: `baseline ${baselineRef.toFixed(1)}%`, position: 'insideBottomRight', fontSize: 9, fontWeight: 600, fill: '#ef4444' }}
                 />
               )}
               <Line
                 yAxisId="main"
                 type="monotone"
                 dataKey="value"
-                stroke={mode === 'minutes' ? '#3b82f6' : mode === 'usage' ? '#f59e0b' : '#10b981'}
+                stroke={LINE_COLOR[mode]}
                 strokeWidth={2}
                 dot={<CappedDot />}
                 isAnimationActive={false}
@@ -296,6 +330,28 @@ export default function TrendGameLogChart({
         </div>
         <StatBlock rows={statRows} />
       </div>
+
+      <Legend items={[
+        {
+          label: mode === 'minutes' ? 'Minutes per game'
+            : mode === 'usage' ? 'Usage rate per game'
+            : `${stat}, ${ROLLING_GAMES}-game attempt-weighted`,
+          color: LINE_COLOR[mode],
+        },
+        ...(mode === 'minutes' ? [] : [{ label: mode === 'usage' ? 'Minutes played' : 'Attempts', bar: true }]),
+        ...(seasonRef === undefined ? [] : [{
+          label: `This season to date — ${seasonRef.toFixed(1)}${unit}`,
+          color: 'var(--trend-season-line)',
+          dash: '6 3',
+        }]),
+        ...(baselineRef === undefined ? [] : [{
+          label: `Baseline, ${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} — ${baselineRef.toFixed(1)}%`,
+          color: '#ef4444',
+          dash: '2 3',
+        }]),
+        { label: `Last ${windowDays} days`, band: true },
+        ...(cappedCount > 0 ? [{ label: 'Capped — true value in tooltip', color: LINE_COLOR[mode], marker: true }] : []),
+      ]} />
     </div>
   )
 }

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -1,0 +1,267 @@
+import { useMemo } from 'react'
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ReferenceArea,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { useGetTrendGameLogQuery } from '../store/api/fantasyApi'
+import LoadingSpinner from './LoadingSpinner'
+import ErrorMessage from './ErrorMessage'
+import type { GameLogEntry, GameLogResponse, RegressionStat } from '../types/api'
+import { BASELINE_LABEL } from '../utils/trendBaseline'
+
+export type GameLogMode = 'minutes' | 'usage' | 'shooting'
+
+const ROLLING_GAMES = 5
+
+const STAT_FIELDS: Record<RegressionStat, { made: keyof GameLogEntry; att: keyof GameLogEntry; label: string }> = {
+  '3P%': { made: 'fg3m', att: 'fg3a', label: '3PM' },
+  'FT%': { made: 'ftm', att: 'fta', label: 'FTM' },
+  'FG%': { made: 'fgm', att: 'fga', label: 'FGM' },
+}
+
+function shortDate(iso: string): string {
+  return iso.slice(5).replace('-', '/')
+}
+
+interface ChartRow {
+  date: string
+  label: string
+  matchup: string
+  value: number
+  bar: number
+  rawPct: number | null
+}
+
+function buildRows(log: GameLogResponse, mode: GameLogMode, stat: RegressionStat): ChartRow[] {
+  return log.games.map((g, i) => {
+    if (mode === 'minutes') {
+      return { date: g.game_date, label: shortDate(g.game_date), matchup: g.matchup, value: g.min, bar: 0, rawPct: null }
+    }
+    if (mode === 'usage') {
+      return { date: g.game_date, label: shortDate(g.game_date), matchup: g.matchup, value: g.usg, bar: g.min, rawPct: null }
+    }
+    const { made, att } = STAT_FIELDS[stat]
+    const from = Math.max(0, i - ROLLING_GAMES + 1)
+    const slice = log.games.slice(from, i + 1)
+    const madeSum = slice.reduce((s, x) => s + (x[made] as number), 0)
+    const attSum = slice.reduce((s, x) => s + (x[att] as number), 0)
+    const attempts = g[att] as number
+    return {
+      date: g.game_date,
+      label: shortDate(g.game_date),
+      matchup: g.matchup,
+      value: attSum ? (madeSum / attSum) * 100 : 0,
+      bar: attempts,
+      rawPct: attempts ? ((g[made] as number) / attempts) * 100 : null,
+    }
+  })
+}
+
+function percentile(sorted: number[], q: number): number {
+  const i = (sorted.length - 1) * q
+  const lo = Math.floor(i), hi = Math.ceil(i)
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (i - lo)
+}
+
+// A garbage-time game (2 minutes, one shot) produces a USG% north of 100 and a
+// single-game shooting % of 0 or 100. Scaling to those makes the actual trend a
+// flat line, so the axis covers the 5th-95th percentile and outliers clip.
+function robustDomain(values: number[], refs: number[]): [number, number] {
+  const sorted = [...values].sort((a, b) => a - b)
+  let lo = percentile(sorted, 0.05)
+  let hi = percentile(sorted, 0.95)
+  for (const r of refs) { lo = Math.min(lo, r); hi = Math.max(hi, r) }
+  const pad = (hi - lo || 1) * 0.15
+  return [Math.max(0, lo - pad), hi + pad]
+}
+
+function StatBlock({ rows }: { rows: [string, string][] }) {
+  return (
+    <div className="flex flex-row sm:flex-col flex-wrap gap-x-4 gap-y-1 sm:w-48 sm:flex-none justify-center">
+      {rows.map(([k, v]) => (
+        <div key={k} className="flex justify-between gap-3 text-xs border-b border-dashed border-gray-200 dark:border-gray-700 pb-0.5 flex-1 sm:flex-none min-w-[45%] sm:min-w-0">
+          <span className="text-gray-500 dark:text-gray-400">{k}</span>
+          <span className="text-gray-800 dark:text-gray-200 font-medium whitespace-nowrap">{v}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ChartTooltip({ active, payload, mode, stat }: {
+  active?: boolean
+  payload?: { payload: ChartRow }[]
+  mode: GameLogMode
+  stat: RegressionStat
+}) {
+  if (!active || !payload?.length) return null
+  const r = payload[0].payload
+  const unit = mode === 'minutes' ? ' min' : '%'
+  const main = mode === 'minutes' ? 'MPG' : mode === 'usage' ? 'USG' : `${stat} (${ROLLING_GAMES}g)`
+  return (
+    <div className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1.5 text-[11px] shadow">
+      <div className="font-semibold text-gray-800 dark:text-gray-100">{r.label} · {r.matchup}</div>
+      <div className="text-gray-600 dark:text-gray-300">{main}: {r.value.toFixed(1)}{unit}</div>
+      {mode === 'usage' && <div className="text-gray-500 dark:text-gray-400">MIN: {r.bar.toFixed(0)}</div>}
+      {mode === 'shooting' && (
+        <div className="text-gray-500 dark:text-gray-400">
+          This game: {r.rawPct === null ? 'no attempts' : `${r.rawPct.toFixed(0)}% on ${r.bar}`}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface Props {
+  playerId: number
+  playerName: string
+  mode: GameLogMode
+  windowDays: number
+  baselineSeasons?: number
+  stat?: RegressionStat
+  availableStats?: RegressionStat[]
+  onStatChange?: (stat: RegressionStat) => void
+}
+
+export default function TrendGameLogChart({
+  playerId, playerName, mode, windowDays, baselineSeasons = 2, stat = '3P%', availableStats = [], onStatChange,
+}: Props) {
+  const { data: log, isLoading, error } = useGetTrendGameLogQuery({ playerId, windowDays, baselineSeasons })
+
+  const rows = useMemo(() => (log ? buildRows(log, mode, stat) : []), [log, mode, stat])
+
+  if (isLoading) return <div className="py-6"><LoadingSpinner /></div>
+  if (error) return <ErrorMessage message={`Could not load ${playerName}'s game log.`} />
+  if (!log || rows.length === 0) {
+    return <p className="py-4 text-xs text-gray-500 dark:text-gray-400">No games on record for {playerName} this season.</p>
+  }
+
+  const windowRows = rows.filter(r => r.date >= log.window_start)
+  const bandStart = windowRows.length ? windowRows[0].label : null
+  const bandEnd = rows[rows.length - 1].label
+
+  const seasonRef = mode === 'minutes' ? log.season_mpg : mode === 'usage' ? log.season_usg : log.season_pct[stat]
+  const baselineRef = mode === 'shooting' ? log.baseline_pct[stat] : undefined
+  const unit = mode === 'minutes' ? '' : '%'
+
+  const domain = robustDomain(
+    rows.map(r => r.value),
+    [seasonRef, baselineRef].filter((v): v is number => v !== undefined),
+  )
+
+  const windowMean = windowRows.length
+    ? windowRows.reduce((s, r) => s + r.value, 0) / windowRows.length
+    : null
+
+  const statRows: [string, string][] =
+    mode === 'minutes'
+      ? [
+          ['Season MPG', log.season_mpg.toFixed(1)],
+          [`${windowDays}d MPG`, windowMean === null ? '—' : windowMean.toFixed(1)],
+          ['Games', String(log.season_gp)],
+        ]
+      : mode === 'usage'
+        ? [
+            ['Season USG%', `${log.season_usg.toFixed(1)}%`],
+            [`${windowDays}d USG%`, windowMean === null ? '—' : `${windowMean.toFixed(1)}%`],
+            ['Season MPG', log.season_mpg.toFixed(1)],
+            ['Games', String(log.season_gp)],
+          ]
+        : [
+            [`Season ${stat}`, seasonRef === undefined ? '—' : `${seasonRef.toFixed(1)}%`],
+            [`Baseline (${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`})`,
+              baselineRef === undefined ? 'no prior data' : `${baselineRef.toFixed(1)}%`],
+            ['Δ vs baseline',
+              baselineRef === undefined || seasonRef === undefined
+                ? '—'
+                : `${seasonRef - baselineRef >= 0 ? '+' : ''}${(seasonRef - baselineRef).toFixed(1)}%`],
+            ['Games', String(log.season_gp)],
+          ]
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400 mr-auto">
+          {playerName} —{' '}
+          {mode === 'minutes' && 'minutes per game'}
+          {mode === 'usage' && 'usage rate per game, bars = minutes'}
+          {mode === 'shooting' && `${stat}, ${ROLLING_GAMES}-game attempt-weighted · bars = attempts`}
+        </span>
+        {mode === 'shooting' && availableStats.length > 1 && (
+          <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-[11px]">
+            {availableStats.map(s => (
+              <button
+                key={s}
+                onClick={e => { e.stopPropagation(); onStatChange?.(s) }}
+                className={`px-2.5 py-1 ${s === stat ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300'}`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 items-stretch">
+        <div className="w-full min-w-0 flex-none h-[150px] sm:flex-1 sm:h-[180px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="currentColor" className="text-gray-200 dark:text-gray-700" />
+              <XAxis dataKey="label" tick={{ fontSize: 9 }} interval="preserveStartEnd" minTickGap={24} />
+              <YAxis yAxisId="main" tick={{ fontSize: 9 }} domain={domain} allowDataOverflow width={34} tickFormatter={(v: number) => v.toFixed(0)} />
+              <YAxis yAxisId="bar" orientation="right" hide domain={[0, (max: number) => max * 3]} />
+              <Tooltip content={<ChartTooltip mode={mode} stat={stat} />} />
+              {bandStart && (
+                <ReferenceArea
+                  yAxisId="main"
+                  x1={bandStart}
+                  x2={bandEnd}
+                  fill="#3b82f6"
+                  fillOpacity={0.12}
+                  label={{ value: `last ${windowDays}d`, position: 'insideTop', fontSize: 9, fill: '#3b82f6' }}
+                />
+              )}
+              {mode !== 'minutes' && <Bar yAxisId="bar" dataKey="bar" fill="#8b5cf6" fillOpacity={0.45} isAnimationActive={false} />}
+              {seasonRef !== undefined && (
+                <ReferenceLine
+                  yAxisId="main"
+                  y={seasonRef}
+                  stroke="#9ca3af"
+                  strokeDasharray="5 4"
+                  label={{ value: `season ${seasonRef.toFixed(1)}${unit}`, position: 'insideTopRight', fontSize: 9, fill: '#9ca3af' }}
+                />
+              )}
+              {baselineRef !== undefined && (
+                <ReferenceLine
+                  yAxisId="main"
+                  y={baselineRef}
+                  stroke="#ef4444"
+                  strokeDasharray="2 3"
+                  label={{ value: `baseline ${baselineRef.toFixed(1)}%`, position: 'insideBottomLeft', fontSize: 9, fill: '#ef4444' }}
+                />
+              )}
+              <Line
+                yAxisId="main"
+                type="monotone"
+                dataKey="value"
+                stroke={mode === 'minutes' ? '#3b82f6' : mode === 'usage' ? '#f59e0b' : '#10b981'}
+                strokeWidth={2}
+                dot={{ r: 2 }}
+                isAnimationActive={false}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+        <StatBlock rows={statRows} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -238,6 +238,12 @@ export default function TrendGameLogChart({
     ? windowRows.reduce((s, r) => s + r.value, 0) / windowRows.length
     : null
 
+  // baseline_seasons can be 0 in form mode: no prior seasons, this season only
+  const priorLabel = BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`
+  const formSpan = log.baseline_seasons === 0
+    ? `this season thru ${shortDate(log.window_start)}`
+    : `${priorLabel} + this season thru ${shortDate(log.window_start)}`
+
   const windowShooting = (() => {
     if (mode !== 'shooting') return null
     const { made, att } = STAT_FIELDS[stat]
@@ -267,7 +273,7 @@ export default function TrendGameLogChart({
               [`Last ${windowDays}d ${stat}`, windowShooting === null
                 ? 'no attempts'
                 : `${windowShooting.pct.toFixed(1)}% on ${windowShooting.attPerGame.toFixed(1)} att/g`],
-              [`Baseline (${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} + this season thru ${shortDate(log.window_start)})`,
+              [`Baseline (${formSpan})`,
                 baselineRef === undefined ? 'no history' : `${baselineRef.toFixed(1)}%`],
               ['Gap',
                 baselineRef === undefined || windowShooting === null
@@ -281,7 +287,7 @@ export default function TrendGameLogChart({
             [`${windowDays}d ${stat}`, windowShooting === null
               ? 'no attempts'
               : `${windowShooting.pct.toFixed(1)}% on ${windowShooting.attPerGame.toFixed(1)} att/g`],
-            [`Baseline (${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`})`,
+            [`Baseline (${priorLabel})`,
               baselineRef === undefined ? 'no prior data' : `${baselineRef.toFixed(1)}%`],
             ['Δ vs baseline',
               baselineRef === undefined || seasonRef === undefined
@@ -409,11 +415,11 @@ export default function TrendGameLogChart({
         }]),
         ...(baselineRef === undefined ? [] : [{
           label: isForm
-            ? `Baseline ${baselineRef.toFixed(1)}% = ${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} + this season thru ${shortDate(log.window_start)}`
-            : `Baseline ${baselineRef.toFixed(1)}% = ${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`}, this season excluded`,
+            ? `Baseline ${baselineRef.toFixed(1)}% = ${formSpan}`
+            : `Baseline ${baselineRef.toFixed(1)}% = ${priorLabel}, this season excluded`,
           hint: isForm
-            ? `${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} plus this season up to ${shortDate(log.window_start)} — excludes the window, and is what the gap is measured against`
-            : `${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`}, excludes this season`,
+            ? `${formSpan} — excludes the window itself, and is what the gap is measured against`
+            : `${priorLabel}, excludes this season`,
           color: '#ef4444',
           dash: '2 3',
         }]),

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -231,6 +231,16 @@ export default function TrendGameLogChart({
     ? windowRows.reduce((s, r) => s + r.value, 0) / windowRows.length
     : null
 
+  const windowShooting = (() => {
+    if (mode !== 'shooting') return null
+    const { made, att } = STAT_FIELDS[stat]
+    const inWindow = log.games.filter(g => g.game_date >= log.window_start)
+    const attSum = inWindow.reduce((n, g) => n + (g[att] as number), 0)
+    if (!attSum) return null
+    const madeSum = inWindow.reduce((n, g) => n + (g[made] as number), 0)
+    return { pct: (madeSum / attSum) * 100, attempts: attSum }
+  })()
+
   const statRows: [string, string][] =
     mode === 'minutes'
       ? [
@@ -247,6 +257,9 @@ export default function TrendGameLogChart({
           ]
         : [
             [`Season ${stat}`, seasonRef === undefined ? '—' : `${seasonRef.toFixed(1)}%`],
+            [`${windowDays}d ${stat}`, windowShooting === null
+              ? 'no attempts'
+              : `${windowShooting.pct.toFixed(1)}% on ${windowShooting.attempts}`],
             [`Baseline (${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`})`,
               baselineRef === undefined ? 'no prior data' : `${baselineRef.toFixed(1)}%`],
             ['Δ vs baseline',

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -14,7 +14,7 @@ import {
 import { useGetTrendGameLogQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from './LoadingSpinner'
 import ErrorMessage from './ErrorMessage'
-import type { GameLogEntry, GameLogResponse, RegressionStat } from '../types/api'
+import type { GameLogEntry, GameLogResponse, RegressionStat, RegressionMode } from '../types/api'
 import { BASELINE_LABEL } from '../utils/trendBaseline'
 
 export type GameLogMode = 'minutes' | 'usage' | 'shooting'
@@ -187,17 +187,21 @@ interface Props {
   playerId: number
   playerName: string
   mode: GameLogMode
+  regressionMode?: RegressionMode
   windowDays: number
   baselineSeasons?: number
   stat?: RegressionStat
+  zScore?: number | null
   qualifiedStats?: RegressionStat[]
   onStatChange?: (stat: RegressionStat) => void
 }
 
 export default function TrendGameLogChart({
-  playerId, playerName, mode, windowDays, baselineSeasons = 2, stat = '3P%', qualifiedStats = [], onStatChange,
+  playerId, playerName, mode, regressionMode = 'season', windowDays, baselineSeasons = 2,
+  stat = '3P%', zScore = null, qualifiedStats = [], onStatChange,
 }: Props) {
-  const { data: log, isLoading, error } = useGetTrendGameLogQuery({ playerId, windowDays, baselineSeasons })
+  const { data: log, isLoading, error } = useGetTrendGameLogQuery({ playerId, windowDays, baselineSeasons, mode: regressionMode })
+  const isForm = mode === 'shooting' && regressionMode === 'form'
 
   const rows = useMemo(() => (log ? buildRows(log, mode, stat) : []), [log, mode, stat])
 
@@ -216,7 +220,11 @@ export default function TrendGameLogChart({
   const bandStart = windowRows.length ? windowRows[0].label : null
   const bandEnd = rows[rows.length - 1].label
 
-  const seasonRef = mode === 'minutes' ? log.season_mpg : mode === 'usage' ? log.season_usg : log.season_pct[stat]
+  // In form mode the baseline deliberately excludes the window, so drawing the
+  // season line beside it invites the part-whole comparison the mode rejects.
+  const seasonRef = isForm
+    ? undefined
+    : mode === 'minutes' ? log.season_mpg : mode === 'usage' ? log.season_usg : log.season_pct[stat]
   const baselineRef = mode === 'shooting' ? log.baseline_pct[stat] : undefined
   const unit = mode === 'minutes' ? '' : '%'
 
@@ -238,7 +246,7 @@ export default function TrendGameLogChart({
     const attSum = inWindow.reduce((n, g) => n + (g[att] as number), 0)
     if (!attSum) return null
     const madeSum = inWindow.reduce((n, g) => n + (g[made] as number), 0)
-    return { pct: (madeSum / attSum) * 100, attempts: attSum }
+    return { pct: (madeSum / attSum) * 100, attPerGame: attSum / inWindow.length }
   })()
 
   const statRows: [string, string][] =
@@ -255,11 +263,24 @@ export default function TrendGameLogChart({
             ['Season MPG', log.season_mpg.toFixed(1)],
             ['Games', String(log.season_gp)],
           ]
-        : [
+        : isForm
+          ? [
+              [`Last ${windowDays}d ${stat}`, windowShooting === null
+                ? 'no attempts'
+                : `${windowShooting.pct.toFixed(1)}% on ${windowShooting.attPerGame.toFixed(1)} att/g`],
+              ['Baseline', baselineRef === undefined ? 'no history' : `${baselineRef.toFixed(1)}%`],
+              ['Gap',
+                baselineRef === undefined || windowShooting === null
+                  ? '—'
+                  : `${windowShooting.pct - baselineRef >= 0 ? '+' : ''}${(windowShooting.pct - baselineRef).toFixed(1)}%`],
+              ['z', zScore === null ? '—' : `${zScore >= 0 ? '+' : ''}${zScore.toFixed(2)}`],
+              ['Games', String(log.season_gp)],
+            ]
+          : [
             [`Season ${stat}`, seasonRef === undefined ? '—' : `${seasonRef.toFixed(1)}%`],
             [`${windowDays}d ${stat}`, windowShooting === null
               ? 'no attempts'
-              : `${windowShooting.pct.toFixed(1)}% on ${windowShooting.attempts}`],
+              : `${windowShooting.pct.toFixed(1)}% on ${windowShooting.attPerGame.toFixed(1)} att/g`],
             [`Baseline (${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`})`,
               baselineRef === undefined ? 'no prior data' : `${baselineRef.toFixed(1)}%`],
             ['Δ vs baseline',
@@ -369,7 +390,9 @@ export default function TrendGameLogChart({
           dash: '6 3',
         }]),
         ...(baselineRef === undefined ? [] : [{
-          label: `Baseline, ${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} — ${baselineRef.toFixed(1)}%`,
+          label: isForm
+            ? `Baseline, everything outside the window — ${baselineRef.toFixed(1)}%`
+            : `Baseline, ${BASELINE_LABEL[log.baseline_seasons] ?? `${log.baseline_seasons} seasons`} — ${baselineRef.toFixed(1)}%`,
           color: '#ef4444',
           dash: '2 3',
         }]),

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -34,6 +34,9 @@ const LINE_COLOR: Record<GameLogMode, string> = {
 }
 
 const BAR_COLOR = '#8b5cf6'
+// Distinct from every series colour (blue / amber / green) and from the bars,
+// so a capped point never reads as part of the line it sits on.
+const CAPPED_COLOR = '#d946ef'
 
 type LegendItem = { label: string; color?: string; band?: boolean; dash?: string; bar?: boolean; marker?: boolean }
 
@@ -132,7 +135,14 @@ function CappedDot(props: { cx?: number; cy?: number; payload?: ChartRow; stroke
   const { cx, cy, payload, stroke } = props
   if (cx === undefined || cy === undefined) return null
   if (!payload?.capped) return <circle cx={cx} cy={cy} r={2} fill={stroke} />
-  return <path d={`M${cx - 4},${cy + 3} L${cx},${cy - 3} L${cx + 4},${cy + 3} Z`} fill={stroke} />
+  return (
+    <path
+      d={`M${cx - 5},${cy + 4} L${cx},${cy - 4} L${cx + 5},${cy + 4} Z`}
+      fill={CAPPED_COLOR}
+      stroke="var(--trend-grid)"
+      strokeWidth={1}
+    />
+  )
 }
 
 function StatBlock({ rows }: { rows: [string, string][] }) {
@@ -162,7 +172,7 @@ function ChartTooltip({ active, payload, mode, stat }: {
     <div className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1.5 text-[11px] shadow">
       <div className="font-semibold text-gray-800 dark:text-gray-100">{r.label} · {r.matchup}</div>
       <div className="text-gray-600 dark:text-gray-300">{main}: {r.trueValue.toFixed(1)}{unit}</div>
-      {r.capped && <div className="text-amber-600 dark:text-amber-400">above the axis — {r.minutes.toFixed(0)} min played</div>}
+      {r.capped && <div style={{ color: CAPPED_COLOR }}>above the axis — {r.minutes.toFixed(0)} min played</div>}
       {mode === 'usage' && <div className="text-gray-500 dark:text-gray-400">MIN: {r.bar.toFixed(0)}</div>}
       {mode === 'shooting' && (
         <div className="text-gray-500 dark:text-gray-400">
@@ -273,7 +283,7 @@ export default function TrendGameLogChart({
       </div>
 
       {cappedCount > 0 && (
-        <p className="text-[10px] text-amber-600 dark:text-amber-400 mb-1">
+        <p className="text-[10px] mb-1" style={{ color: CAPPED_COLOR }}>
           ▲ {cappedCount} {cappedCount === 1 ? 'game sits' : 'games sit'} above the axis — short garbage-time
           appearances where a per-minute rate overstates the real role. Hover for the true value.
         </p>
@@ -293,6 +303,9 @@ export default function TrendGameLogChart({
                   x1={bandStart}
                   x2={bandEnd}
                   fill="var(--trend-band)"
+                  fillOpacity={1}
+                  stroke="var(--trend-band-label)"
+                  strokeOpacity={0.5}
                 />
               )}
               {mode !== 'minutes' && <Bar yAxisId="bar" dataKey="bar" fill={BAR_COLOR} fillOpacity={0.45} isAnimationActive={false} />}
@@ -350,7 +363,7 @@ export default function TrendGameLogChart({
           dash: '2 3',
         }]),
         { label: `Last ${windowDays} days`, band: true },
-        ...(cappedCount > 0 ? [{ label: 'Capped — true value in tooltip', color: LINE_COLOR[mode], marker: true }] : []),
+        ...(cappedCount > 0 ? [{ label: 'Capped — true value in tooltip', color: CAPPED_COLOR, marker: true }] : []),
       ]} />
     </div>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,6 +10,22 @@ html, body {
   max-width: 100%;
 }
 
+/* Trend game-log chart palette. The recency band needs a different hue per
+   theme: blue-on-white reads as a highlight, but on the dark navy page it
+   competes with the blue minutes line, so dark mode uses teal. */
+:root {
+  --trend-band: rgba(59, 130, 246, 0.13);
+  --trend-band-label: #2563eb;
+  --trend-season-line: #6b7280;
+  --trend-grid: #e5e7eb;
+}
+.dark {
+  --trend-band: rgba(45, 212, 191, 0.16);
+  --trend-band-label: #5eead4;
+  --trend-season-line: #cbd5e1;
+  --trend-grid: #374151;
+}
+
 /* ── Dark mode base ── */
 .dark body {
   background-color: #111827;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,13 +14,13 @@ html, body {
    theme: blue-on-white reads as a highlight, but on the dark navy page it
    competes with the blue minutes line, so dark mode uses teal. */
 :root {
-  --trend-band: rgba(59, 130, 246, 0.13);
+  --trend-band: rgba(59, 130, 246, 0.20);
   --trend-band-label: #2563eb;
   --trend-season-line: #6b7280;
   --trend-grid: #e5e7eb;
 }
 .dark {
-  --trend-band: rgba(45, 212, 191, 0.16);
+  --trend-band: rgba(45, 212, 191, 0.26);
   --trend-band-label: #5eead4;
   --trend-season-line: #cbd5e1;
   --trend-grid: #374151;

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -332,9 +332,27 @@ function UsageTable({ items, filters, windowDays }: { items: UsageRoleItem[]; fi
   )
 }
 
+const LOW_WINDOW_ATT = 20  // below this the window % is one hot night, not a trend
+
+function WindowPct({ stat, windowDays }: { stat: RegressionStatItem; windowDays: number }) {
+  if (stat.window_pct === null) {
+    return <span className="text-gray-400 dark:text-gray-500" title={`No attempts in the last ${windowDays} days`}>—</span>
+  }
+  const thin = stat.window_attempts < LOW_WINDOW_ATT
+  return (
+    <span
+      className={thin ? 'text-gray-400 dark:text-gray-500' : 'text-gray-700 dark:text-gray-300'}
+      title={`${stat.window_attempts} attempts in the last ${windowDays} days${thin ? ' — small sample, read loosely' : ''}`}
+    >
+      {stat.window_pct.toFixed(1)}%{thin ? '*' : ''}
+    </span>
+  )
+}
+
 const REG_SORT_VAL: Record<string, (s: RegressionStatItem) => number | string> = {
   stat: s => s.stat,
   cur: s => s.current_pct,
+  win: s => s.window_pct ?? -1,
   base: s => s.baseline_pct,
   dev: s => s.dev,
   att: s => s.attempts_per_game,
@@ -430,7 +448,8 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
               <Th col="team" label="Team" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="NBA team" />
               <Th col="g15" label={`G(${windowDays}d)`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title={`Games played in the last ${windowDays} days`} />
               <Th col="stat" label="Stat" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting category: 3P%, FT%, or FG%" />
-              <Th col="cur" label="Current%" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting % this season to date" />
+              <Th col="cur" label="Season%" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting % across the whole season to date. This is the number compared against the baseline." />
+              <Th col="win" label={`${windowDays}d %`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Shooting % over the last ${windowDays} days only. Shows whether the correction has already started. Greyed with * when the window holds fewer than ${LOW_WINDOW_ATT} attempts.`} />
               <Th col="base" label={`Baseline (${BASELINE_LABEL[baselineSeasons]})`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Attempt-weighted shooting % over the ${BASELINE_LABEL[baselineSeasons]} before this one. Excludes this season.`} />
               <Th col="dev" label="Δ vs baseline" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Current% minus baseline%, in percentage points (not a relative change). Negative = cold (buy-low), positive = hot (sell-high)" />
               <Th col="att" label="Att/g" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="Attempts per game this season" />
@@ -439,7 +458,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
             </tr>
           </thead>
           <tbody>
-            {groups.length === 0 && <EmptyRow colSpan={10} />}
+            {groups.length === 0 && <EmptyRow colSpan={11} />}
             {groups.map(({ group, stats }) => {
               const openStat = expanded[group.player_id]
               const toggle = (stat: RegressionStat) => toggleStat(group.player_id, stat)
@@ -470,6 +489,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
                     {i > 0 && <span className="text-gray-400 dark:text-gray-500">↳ </span>}{s.stat}
                   </td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{s.current_pct.toFixed(1)}%</td>
+                  <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><WindowPct stat={s} windowDays={windowDays} /></td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{s.baseline_pct.toFixed(1)}%</td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><DeltaPill value={s.dev} unit="%" /></td>
                   <td className="hidden sm:table-cell px-3 py-2 text-gray-700 dark:text-gray-300">{s.attempts_per_game.toFixed(1)}</td>
@@ -478,7 +498,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
                 </tr>
               )})}
               {openStat !== undefined && (
-                <ExpandRow colSpan={10}>
+                <ExpandRow colSpan={11}>
                   <TrendGameLogChart
                     playerId={group.player_id}
                     playerName={group.player_name}

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -16,8 +16,8 @@ type Ownership = 'all' | 'fa' | 'rostered'
 const ALL_POSITIONS = ['PG', 'SG', 'SF', 'PF', 'C']
 
 const BASELINE_OPTIONS: [number, string, string][] = [
-  [2, 'Prior 2 seasons', 'Attempt-weighted % across the two seasons before this one. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
-  [1, 'Last season', 'Attempt-weighted % for last season only. Reacts faster to a real change, noisier for low-volume shooters.'],
+  [2, 'vs prior 2 seasons', 'Compare this season against the two seasons before it, attempt-weighted. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
+  [1, 'vs last season', 'Compare this season against last season only. Reacts faster to a real change, noisier for low-volume shooters.'],
 ]
 
 const OWNERSHIP_OPTIONS: [Ownership, string][] = [
@@ -486,7 +486,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
                     windowDays={windowDays}
                     baselineSeasons={baselineSeasons}
                     stat={openStat}
-                    availableStats={stats.map(s => s.stat)}
+                    qualifiedStats={stats.map(s => s.stat)}
                     onStatChange={stat => setExpanded(prev => ({ ...prev, [group.player_id]: stat }))}
                   />
                 </ExpandRow>
@@ -600,7 +600,7 @@ export default function Trends() {
               {teamOptions.map(t => <option key={t} value={t}>{t}</option>)}
             </select>
             {tab === 'regression' && (
-              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Which past seasons this season's shooting is measured against. The current season is always what is being measured — it is the Current% column.">
                 {BASELINE_OPTIONS.map(([value, label, help]) => (
                   <button
                     key={value}

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -65,6 +65,16 @@ function ExpandRow({ colSpan, children }: { colSpan: number; children: React.Rea
   )
 }
 
+function useExpandedSet() {
+  const [open, setOpen] = useState<Set<number>>(new Set())
+  const toggle = (id: number) => setOpen(prev => {
+    const next = new Set(prev)
+    if (!next.delete(id)) next.add(id)
+    return next
+  })
+  return { open, toggle }
+}
+
 function Caret({ open }: { open: boolean }) {
   return (
     <svg
@@ -149,7 +159,7 @@ const MIN_SORT_VAL: Record<string, (r: MinutesMoverItem) => number | string> = {
 function MinutesTable({ items, filters, windowDays }: { items: MinutesMoverItem[]; filters: Filters; windowDays: number }) {
   const [sortCol, setSortCol] = useState('delta')
   const [sortAsc, setSortAsc] = useState(false)
-  const [expanded, setExpanded] = useState<number | null>(null)
+  const { open: expanded, toggle } = useExpandedSet()
 
   const rows = useMemo(() => {
     const filtered = items.filter(r => passesShared(r, filters))
@@ -185,15 +195,15 @@ function MinutesTable({ items, filters, windowDays }: { items: MinutesMoverItem[
         <tbody>
           {rows.length === 0 && <EmptyRow colSpan={9} />}
           {rows.map(r => {
-            const open = expanded === r.player_id
+            const open = expanded.has(r.player_id)
             return (
             <Fragment key={r.player_id}>
             <tr
-              onClick={() => setExpanded(open ? null : r.player_id)}
+              onClick={() => toggle(r.player_id)}
               tabIndex={0}
               role="button"
               aria-expanded={open}
-              onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && setExpanded(open ? null : r.player_id)}
+              onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && toggle(r.player_id)}
               className="group cursor-pointer border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50"
             >
               <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap sticky left-0 z-10 bg-white dark:bg-gray-800 group-hover:bg-gray-50 dark:group-hover:bg-gray-700/50 border-r border-gray-200 dark:border-gray-700">
@@ -246,7 +256,7 @@ function RoleBadge({ badge }: { badge: string | null }) {
 function UsageTable({ items, filters, windowDays }: { items: UsageRoleItem[]; filters: Filters; windowDays: number }) {
   const [sortCol, setSortCol] = useState('delta')
   const [sortAsc, setSortAsc] = useState(false)
-  const [expanded, setExpanded] = useState<number | null>(null)
+  const { open: expanded, toggle } = useExpandedSet()
 
   const rows = useMemo(() => {
     const filtered = items.filter(r => passesShared(r, filters))
@@ -287,15 +297,15 @@ function UsageTable({ items, filters, windowDays }: { items: UsageRoleItem[]; fi
           <tbody>
             {rows.length === 0 && <EmptyRow colSpan={9} />}
             {rows.map(r => {
-              const open = expanded === r.player_id
+              const open = expanded.has(r.player_id)
               return (
               <Fragment key={r.player_id}>
               <tr
-                onClick={() => setExpanded(open ? null : r.player_id)}
+                onClick={() => toggle(r.player_id)}
                 tabIndex={0}
                 role="button"
                 aria-expanded={open}
-                onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && setExpanded(open ? null : r.player_id)}
+                onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && toggle(r.player_id)}
                 className="group cursor-pointer border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50"
               >
                 <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap sticky left-0 z-10 bg-white dark:bg-gray-800 group-hover:bg-gray-50 dark:group-hover:bg-gray-700/50 border-r border-gray-200 dark:border-gray-700"><Caret open={open} />{r.player_name}</td>
@@ -352,7 +362,14 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
   const [sortCol, setSortCol] = useState('dev')
   const [sortAsc, setSortAsc] = useState(false)
   const [statFilter, setStatFilter] = useState<'all' | '3P%' | 'FT%' | 'FG%'>('all')
-  const [expanded, setExpanded] = useState<{ playerId: number; stat: RegressionStat } | null>(null)
+  const [expanded, setExpanded] = useState<Record<number, RegressionStat>>({})
+
+  const toggleStat = (playerId: number, stat: RegressionStat) => setExpanded(prev => {
+    const next = { ...prev }
+    if (next[playerId] === stat) delete next[playerId]
+    else next[playerId] = stat
+    return next
+  })
 
   const groups = useMemo(() => {
     const filtered = items
@@ -424,13 +441,12 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
           <tbody>
             {groups.length === 0 && <EmptyRow colSpan={10} />}
             {groups.map(({ group, stats }) => {
-              const groupOpen = expanded?.playerId === group.player_id
-              const toggle = (stat: RegressionStat) =>
-                setExpanded(groupOpen && expanded?.stat === stat ? null : { playerId: group.player_id, stat })
+              const openStat = expanded[group.player_id]
+              const toggle = (stat: RegressionStat) => toggleStat(group.player_id, stat)
               return (
               <Fragment key={group.player_id}>
               {stats.map((s, i) => {
-                const active = groupOpen && expanded?.stat === s.stat
+                const active = openStat === s.stat
                 return (
                 <tr
                   key={`${group.player_id}-${s.stat}`}
@@ -444,7 +460,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
                   {i === 0 && (
                     <>
                       <td rowSpan={stats.length} className="align-top px-1.5 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap sticky left-0 z-10 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700">
-                        <Caret open={groupOpen} />{group.player_name}
+                        <Caret open={openStat !== undefined} />{group.player_name}
                       </td>
                       <td rowSpan={stats.length} className="hidden sm:table-cell align-top px-3 py-2 text-gray-500 dark:text-gray-400">{group.pro_team}</td>
                       <td rowSpan={stats.length} className="hidden sm:table-cell align-top px-3 py-2 text-gray-700 dark:text-gray-300">{group.games_last_15d}</td>
@@ -461,7 +477,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
                   {i === 0 && <td rowSpan={stats.length} className="align-top px-1.5 sm:px-3 py-1.5 sm:py-2"><StatusBadge fantasyStatus={group.fantasy_status} /></td>}
                 </tr>
               )})}
-              {groupOpen && expanded && (
+              {openStat !== undefined && (
                 <ExpandRow colSpan={10}>
                   <TrendGameLogChart
                     playerId={group.player_id}
@@ -469,9 +485,9 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
                     mode="shooting"
                     windowDays={windowDays}
                     baselineSeasons={baselineSeasons}
-                    stat={expanded.stat}
+                    stat={openStat}
                     availableStats={stats.map(s => s.stat)}
-                    onStatChange={stat => setExpanded({ playerId: group.player_id, stat })}
+                    onStatChange={stat => setExpanded(prev => ({ ...prev, [group.player_id]: stat }))}
                   />
                 </ExpandRow>
               )}
@@ -496,7 +512,7 @@ export default function Trends() {
   const [position, setPosition] = useState<string | null>(null)
   const [windowDays, setWindowDays] = useState<number>(15)
   const [minGames, setMinGames] = useState(3)
-  const [ownership, setOwnership] = useState<Ownership>('fa')
+  const [ownership, setOwnership] = useState<Ownership>('all')
   const [fantasyTeam, setFantasyTeam] = useState<string | null>(null)
   const [baselineSeasons, setBaselineSeasons] = useState(2)
 

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -16,8 +16,8 @@ type Ownership = 'all' | 'fa' | 'rostered'
 const ALL_POSITIONS = ['PG', 'SG', 'SF', 'PF', 'C']
 
 const BASELINE_OPTIONS: [number, string, string][] = [
-  [2, 'vs prior 2 seasons', 'Compare this season against the two seasons before it, attempt-weighted. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
-  [1, 'vs last season', 'Compare this season against last season only. Reacts faster to a real change, noisier for low-volume shooters.'],
+  [2, 'Prior 2 seasons', 'This season measured against the two seasons before it, attempt-weighted. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
+  [1, 'Last season only', 'This season measured against last season alone. Reacts faster to a real change, noisier for low-volume shooters.'],
 ]
 
 const OWNERSHIP_OPTIONS: [Ownership, string][] = [
@@ -596,7 +596,9 @@ export default function Trends() {
               {teamOptions.map(t => <option key={t} value={t}>{t}</option>)}
             </select>
             {tab === 'regression' && (
-              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Which past seasons this season's shooting is measured against. The current season is always what is being measured — it is the Current% column.">
+              <label className="inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300" title="This season's shooting is always what gets measured (the Current% column). This picks the past period it is measured against.">
+              Compare this season to
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
                 {BASELINE_OPTIONS.map(([value, label, help]) => (
                   <button
                     key={value}
@@ -608,6 +610,7 @@ export default function Trends() {
                   </button>
                 ))}
               </div>
+              </label>
             )}
             <label className="inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300">
               Min games

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import {
   useGetTrendsMinutesQuery,
   useGetTrendsUsageQuery,
@@ -6,26 +6,75 @@ import {
 } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
-import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem } from '../types/api'
+import TrendGameLogChart from '../components/TrendGameLogChart'
+import { BASELINE_LABEL } from '../utils/trendBaseline'
+import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat } from '../types/api'
 
 type TabKey = 'minutes' | 'usage' | 'regression'
+type Ownership = 'all' | 'fa' | 'rostered'
 
 const ALL_POSITIONS = ['PG', 'SG', 'SF', 'PF', 'C']
+
+const BASELINE_OPTIONS: [number, string, string][] = [
+  [2, 'Prior 2 seasons', 'Attempt-weighted % across the two seasons before this one. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
+  [1, 'Last season', 'Attempt-weighted % for last season only. Reacts faster to a real change, noisier for low-volume shooters.'],
+]
+
+const OWNERSHIP_OPTIONS: [Ownership, string][] = [
+  ['all', 'All players'],
+  ['fa', 'Free agents'],
+  ['rostered', 'Rostered'],
+]
+
+interface Filters {
+  nameFilter: string
+  position: string | null
+  minG15: number
+  ownership: Ownership
+  fantasyTeam: string | null
+}
 
 interface SharedFilterable {
   player_name: string
   position: string
+  fantasy_status: string
   games_last_15d: number
 }
 
 function passesShared<T extends SharedFilterable>(
   row: T,
-  { nameFilter, position, minG15 }: { nameFilter: string; position: string | null; minG15: number }
+  { nameFilter, position, minG15, ownership, fantasyTeam }: Filters
 ): boolean {
   if (position && row.position !== position) return false
   if (row.games_last_15d < minG15) return false
+  if (ownership === 'fa' && row.fantasy_status !== 'FA') return false
+  if (ownership === 'rostered' && row.fantasy_status === 'FA') return false
+  if (fantasyTeam && row.fantasy_status !== fantasyTeam) return false
   if (nameFilter.trim() && !row.player_name.toLowerCase().includes(nameFilter.trim().toLowerCase())) return false
   return true
+}
+
+function ExpandRow({ colSpan, children }: { colSpan: number; children: React.ReactNode }) {
+  return (
+    <tr className="bg-gray-50/70 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-700">
+      <td colSpan={colSpan} className="p-0">
+        {/* sticky-left so the chart stays on screen however far the table is scrolled */}
+        <div className="sticky left-0 px-2 sm:px-4 py-3" style={{ width: 'min(100%, calc(100vw - 3.5rem))' }}>{children}</div>
+      </td>
+    </tr>
+  )
+}
+
+function Caret({ open }: { open: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 8 10"
+      aria-hidden="true"
+      className={`inline-block w-2 h-2.5 mr-1.5 align-[-1px] transition-transform ${open ? 'rotate-90 text-blue-500' : 'text-gray-400 dark:text-gray-500'}`}
+    >
+      <path d="M0 0 L8 5 L0 10 Z" fill="currentColor" />
+    </svg>
+  )
 }
 
 function StatusBadge({ fantasyStatus }: { fantasyStatus: string }) {
@@ -97,9 +146,10 @@ const MIN_SORT_VAL: Record<string, (r: MinutesMoverItem) => number | string> = {
   g15: r => r.games_last_15d,
 }
 
-function MinutesTable({ items, filters, windowDays }: { items: MinutesMoverItem[]; filters: { nameFilter: string; position: string | null; minG15: number }; windowDays: number }) {
+function MinutesTable({ items, filters, windowDays }: { items: MinutesMoverItem[]; filters: Filters; windowDays: number }) {
   const [sortCol, setSortCol] = useState('delta')
   const [sortAsc, setSortAsc] = useState(false)
+  const [expanded, setExpanded] = useState<number | null>(null)
 
   const rows = useMemo(() => {
     const filtered = items.filter(r => passesShared(r, filters))
@@ -126,17 +176,28 @@ function MinutesTable({ items, filters, windowDays }: { items: MinutesMoverItem[
             <Th col="pos" label="Pos" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="Position" />
             <Th col="season" label="Season MPG" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Minutes per game, full season" />
             <Th col="l5" label={`${windowDays}d MPG`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Minutes per game over the last ${windowDays} days`} />
-            <Th col="delta" label="Δ MPG" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Change: ${windowDays}d MPG minus season MPG`} />
+            <Th col="delta" label="Δ MPG vs season" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Change: ${windowDays}d MPG minus season MPG`} />
             <Th col="gp" label="GP" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="Games played this season" />
             <Th col="g15" label={`G(${windowDays}d)`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title={`Games played in the last ${windowDays} days`} />
-            <th className="px-1.5 sm:px-3 py-2 text-left text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400" title="Fantasy owner, or FA if unrostered">Status</th>
+            <th className="px-1.5 sm:px-3 py-2 text-left text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400" title="Fantasy owner, or FA if unrostered">Owner</th>
           </tr>
         </thead>
         <tbody>
           {rows.length === 0 && <EmptyRow colSpan={9} />}
-          {rows.map(r => (
-            <tr key={`${r.player_name}-${r.pro_team}`} className="group border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+          {rows.map(r => {
+            const open = expanded === r.player_id
+            return (
+            <Fragment key={r.player_id}>
+            <tr
+              onClick={() => setExpanded(open ? null : r.player_id)}
+              tabIndex={0}
+              role="button"
+              aria-expanded={open}
+              onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && setExpanded(open ? null : r.player_id)}
+              className="group cursor-pointer border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+            >
               <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap sticky left-0 z-10 bg-white dark:bg-gray-800 group-hover:bg-gray-50 dark:group-hover:bg-gray-700/50 border-r border-gray-200 dark:border-gray-700">
+                <Caret open={open} />
                 {r.player_name}
                 {r.low_sample && <span className="ml-1.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">partial</span>}
               </td>
@@ -149,7 +210,13 @@ function MinutesTable({ items, filters, windowDays }: { items: MinutesMoverItem[
               <td className="hidden sm:table-cell px-3 py-2 text-gray-700 dark:text-gray-300">{r.games_last_15d}</td>
               <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><StatusBadge fantasyStatus={r.fantasy_status} /></td>
             </tr>
-          ))}
+            {open && (
+              <ExpandRow colSpan={9}>
+                <TrendGameLogChart playerId={r.player_id} playerName={r.player_name} mode="minutes" windowDays={windowDays} />
+              </ExpandRow>
+            )}
+            </Fragment>
+          )})}
         </tbody>
       </table>
     </div>
@@ -176,9 +243,10 @@ function RoleBadge({ badge }: { badge: string | null }) {
   )
 }
 
-function UsageTable({ items, filters, windowDays }: { items: UsageRoleItem[]; filters: { nameFilter: string; position: string | null; minG15: number }; windowDays: number }) {
+function UsageTable({ items, filters, windowDays }: { items: UsageRoleItem[]; filters: Filters; windowDays: number }) {
   const [sortCol, setSortCol] = useState('delta')
   const [sortAsc, setSortAsc] = useState(false)
+  const [expanded, setExpanded] = useState<number | null>(null)
 
   const rows = useMemo(() => {
     const filtered = items.filter(r => passesShared(r, filters))
@@ -199,7 +267,7 @@ function UsageTable({ items, filters, windowDays }: { items: UsageRoleItem[]; fi
     <div>
       <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
         <b>Role ↑/↓</b> = minutes AND usage moved together (≥4 MPG and ≥2pp usage). <b>Minutes ↑/↓</b> = minutes moved, usage didn't.{' '}
-        <b>Usage ↑/↓</b> = usage moved on flat minutes. Δ USG / Δ MPG columns show the raw numbers behind each label.
+        <b>Usage ↑/↓</b> = usage moved on flat minutes. Δ USG / Δ MPG columns show the raw numbers behind each label. Click any row for the game-by-game chart.
       </p>
       <div className="overflow-x-auto rounded-lg">
         <table className="w-full text-xs sm:text-sm">
@@ -209,28 +277,44 @@ function UsageTable({ items, filters, windowDays }: { items: UsageRoleItem[]; fi
               <Th col="team" label="Team" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="NBA team" />
               <Th col="season" label="Season USG%" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Usage rate (% of team plays used by this player while on court), full season" />
               <Th col="l5" label={`${windowDays}d USG%`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Usage rate over the last ${windowDays} days`} />
-              <Th col="delta" label="Δ USG" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Change: ${windowDays}d usage rate minus season usage rate, in percentage points`} />
+              <Th col="delta" label="Δ USG vs season" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Change: ${windowDays}d usage rate minus season usage rate, in percentage points (not a relative change)`} />
               <Th col="dmpg" label="Δ MPG" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title={`Change: ${windowDays}d MPG minus season MPG`} />
               <Th col="g15" label={`G(${windowDays}d)`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title={`Games played in the last ${windowDays} days`} />
               <th className="px-1.5 sm:px-3 py-2 text-left text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400" title="Role change label based on ΔUSG and ΔMPG thresholds — see note above">Role</th>
-              <th className="px-1.5 sm:px-3 py-2 text-left text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400" title="Fantasy owner, or FA if unrostered">Status</th>
+              <th className="px-1.5 sm:px-3 py-2 text-left text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400" title="Fantasy owner, or FA if unrostered">Owner</th>
             </tr>
           </thead>
           <tbody>
             {rows.length === 0 && <EmptyRow colSpan={9} />}
-            {rows.map(r => (
-              <tr key={`${r.player_name}-${r.pro_team}`} className="group border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap sticky left-0 z-10 bg-white dark:bg-gray-800 group-hover:bg-gray-50 dark:group-hover:bg-gray-700/50 border-r border-gray-200 dark:border-gray-700">{r.player_name}</td>
+            {rows.map(r => {
+              const open = expanded === r.player_id
+              return (
+              <Fragment key={r.player_id}>
+              <tr
+                onClick={() => setExpanded(open ? null : r.player_id)}
+                tabIndex={0}
+                role="button"
+                aria-expanded={open}
+                onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && setExpanded(open ? null : r.player_id)}
+                className="group cursor-pointer border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              >
+                <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap sticky left-0 z-10 bg-white dark:bg-gray-800 group-hover:bg-gray-50 dark:group-hover:bg-gray-700/50 border-r border-gray-200 dark:border-gray-700"><Caret open={open} />{r.player_name}</td>
                 <td className="hidden sm:table-cell px-3 py-2 text-gray-500 dark:text-gray-400">{r.pro_team}</td>
                 <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{r.season_usg.toFixed(1)}%</td>
                 <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{r.l5_usg.toFixed(1)}%</td>
-                <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><DeltaPill value={r.delta_usg} unit="pp" /></td>
+                <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><DeltaPill value={r.delta_usg} unit="%" /></td>
                 <td className="hidden sm:table-cell px-3 py-2 text-gray-700 dark:text-gray-300">{r.delta_mpg >= 0 ? '+' : ''}{r.delta_mpg.toFixed(1)}mpg</td>
                 <td className="hidden sm:table-cell px-3 py-2 text-gray-700 dark:text-gray-300">{r.games_last_15d}</td>
                 <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><RoleBadge badge={r.role_badge} /></td>
                 <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><StatusBadge fantasyStatus={r.fantasy_status} /></td>
               </tr>
-            ))}
+              {open && (
+                <ExpandRow colSpan={9}>
+                  <TrendGameLogChart playerId={r.player_id} playerName={r.player_name} mode="usage" windowDays={windowDays} />
+                </ExpandRow>
+              )}
+              </Fragment>
+            )})}
           </tbody>
         </table>
       </div>
@@ -247,17 +331,28 @@ const REG_SORT_VAL: Record<string, (s: RegressionStatItem) => number | string> =
   drift: s => s.drift_score,
 }
 
-function expectedDriftText(stat: RegressionStatItem): string {
-  if (stat.stat === '3P%') {
-    return `${(stat.attempts_per_game * (-stat.dev) / 100).toFixed(2)} 3PM/g`
-  }
-  return `${Math.abs(stat.dev).toFixed(1)}pp on ${stat.attempts_per_game.toFixed(1)}/g`
+const MAKES_LABEL: Record<RegressionStat, string> = { '3P%': '3PM', 'FT%': 'FTM', 'FG%': 'FGM' }
+
+// Expected change in makes per game if the stat snaps back to the baseline, at
+// current attempt volume — same unit for all three stats so they compare.
+function normalizeDelta(stat: RegressionStatItem): number {
+  return (-stat.dev / 100) * stat.attempts_per_game
 }
 
-function RegressionTable({ items, filters, windowDays }: { items: RegressionPlayerGroup[]; filters: { nameFilter: string; position: string | null; minG15: number }; windowDays: number }) {
+function NormalizePill({ stat }: { stat: RegressionStatItem }) {
+  const delta = normalizeDelta(stat)
+  return (
+    <span className={`whitespace-nowrap ${delta >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>
+      {delta >= 0 ? '+' : ''}{delta.toFixed(2)} {MAKES_LABEL[stat.stat]}/g
+    </span>
+  )
+}
+
+function RegressionTable({ items, filters, windowDays, baselineSeasons }: { items: RegressionPlayerGroup[]; filters: Filters; windowDays: number; baselineSeasons: number }) {
   const [sortCol, setSortCol] = useState('dev')
   const [sortAsc, setSortAsc] = useState(false)
   const [statFilter, setStatFilter] = useState<'all' | '3P%' | 'FT%' | 'FG%'>('all')
+  const [expanded, setExpanded] = useState<{ playerId: number; stat: RegressionStat } | null>(null)
 
   const groups = useMemo(() => {
     const filtered = items
@@ -319,21 +414,38 @@ function RegressionTable({ items, filters, windowDays }: { items: RegressionPlay
               <Th col="g15" label={`G(${windowDays}d)`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title={`Games played in the last ${windowDays} days`} />
               <Th col="stat" label="Stat" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting category: 3P%, FT%, or FG%" />
               <Th col="cur" label="Current%" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting % this season to date" />
-              <Th col="base" label="Baseline%" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Career shooting % over the prior 2 seasons, attempt-weighted" />
-              <Th col="dev" label="Dev vs history (pp)" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Deviation: current% minus baseline%, in percentage points. Negative = cold (buy-low), positive = hot (sell-high)" />
+              <Th col="base" label={`Baseline (${BASELINE_LABEL[baselineSeasons]})`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Attempt-weighted shooting % over the ${BASELINE_LABEL[baselineSeasons]} before this one. Excludes this season.`} />
+              <Th col="dev" label="Δ vs baseline" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Current% minus baseline%, in percentage points (not a relative change). Negative = cold (buy-low), positive = hot (sell-high)" />
               <Th col="att" label="Att/g" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="Attempts per game this season" />
-              <Th col="drift" label="If reverts to baseline" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Expected change if this stat reverts to the player's own baseline %" />
-              <th className="px-1.5 sm:px-3 py-2 text-left text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400" title="Fantasy owner, or FA if unrostered">Status</th>
+              <Th col="drift" label="If it normalizes" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Expected change in makes per game if this stat returns to the player's baseline %, at current attempt volume" />
+              <th className="px-1.5 sm:px-3 py-2 text-left text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400" title="Fantasy owner, or FA if unrostered">Owner</th>
             </tr>
           </thead>
           <tbody>
             {groups.length === 0 && <EmptyRow colSpan={10} />}
-            {groups.map(({ group, stats }) => (
-              stats.map((s, i) => (
-                <tr key={`${group.player_name}-${s.stat}`} className={`border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 ${i > 0 ? 'bg-gray-50/50 dark:bg-gray-900/30' : ''}`}>
+            {groups.map(({ group, stats }) => {
+              const groupOpen = expanded?.playerId === group.player_id
+              const toggle = (stat: RegressionStat) =>
+                setExpanded(groupOpen && expanded?.stat === stat ? null : { playerId: group.player_id, stat })
+              return (
+              <Fragment key={group.player_id}>
+              {stats.map((s, i) => {
+                const active = groupOpen && expanded?.stat === s.stat
+                return (
+                <tr
+                  key={`${group.player_id}-${s.stat}`}
+                  onClick={() => toggle(s.stat)}
+                  tabIndex={0}
+                  role="button"
+                  aria-expanded={active}
+                  onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && toggle(s.stat)}
+                  className={`cursor-pointer border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 ${active ? 'bg-blue-50 dark:bg-blue-900/20' : i > 0 ? 'bg-gray-50/50 dark:bg-gray-900/30' : ''}`}
+                >
                   {i === 0 && (
                     <>
-                      <td rowSpan={stats.length} className="align-top px-1.5 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap sticky left-0 z-10 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700">{group.player_name}</td>
+                      <td rowSpan={stats.length} className="align-top px-1.5 sm:px-3 py-1.5 sm:py-2 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap sticky left-0 z-10 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700">
+                        <Caret open={groupOpen} />{group.player_name}
+                      </td>
                       <td rowSpan={stats.length} className="hidden sm:table-cell align-top px-3 py-2 text-gray-500 dark:text-gray-400">{group.pro_team}</td>
                       <td rowSpan={stats.length} className="hidden sm:table-cell align-top px-3 py-2 text-gray-700 dark:text-gray-300">{group.games_last_15d}</td>
                     </>
@@ -343,17 +455,35 @@ function RegressionTable({ items, filters, windowDays }: { items: RegressionPlay
                   </td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{s.current_pct.toFixed(1)}%</td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{s.baseline_pct.toFixed(1)}%</td>
-                  <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><DeltaPill value={s.dev} unit="pp" /></td>
+                  <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><DeltaPill value={s.dev} unit="%" /></td>
                   <td className="hidden sm:table-cell px-3 py-2 text-gray-700 dark:text-gray-300">{s.attempts_per_game.toFixed(1)}</td>
-                  <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-400 dark:text-gray-500">{expectedDriftText(s)}</td>
+                  <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><NormalizePill stat={s} /></td>
                   {i === 0 && <td rowSpan={stats.length} className="align-top px-1.5 sm:px-3 py-1.5 sm:py-2"><StatusBadge fantasyStatus={group.fantasy_status} /></td>}
                 </tr>
-              ))
-            ))}
+              )})}
+              {groupOpen && expanded && (
+                <ExpandRow colSpan={10}>
+                  <TrendGameLogChart
+                    playerId={group.player_id}
+                    playerName={group.player_name}
+                    mode="shooting"
+                    windowDays={windowDays}
+                    baselineSeasons={baselineSeasons}
+                    stat={expanded.stat}
+                    availableStats={stats.map(s => s.stat)}
+                    onStatChange={stat => setExpanded({ playerId: group.player_id, stat })}
+                  />
+                </ExpandRow>
+              )}
+              </Fragment>
+            )})}
           </tbody>
         </table>
       </div>
-      <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-2">Buy-low = negative dev (cold vs own last-2-season history). Sell-high = positive dev (hot vs own history).</p>
+      <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-2">
+        Buy-low = negative Δ (cold vs the player's own {BASELINE_LABEL[baselineSeasons]}). Sell-high = positive Δ (hot vs their own history).
+        Δ is in percentage points, not a relative change. Click any stat row for the game-by-game chart.
+      </p>
     </div>
   )
 }
@@ -366,20 +496,28 @@ export default function Trends() {
   const [position, setPosition] = useState<string | null>(null)
   const [windowDays, setWindowDays] = useState<number>(15)
   const [minGames, setMinGames] = useState(3)
+  const [ownership, setOwnership] = useState<Ownership>('fa')
+  const [fantasyTeam, setFantasyTeam] = useState<string | null>(null)
+  const [baselineSeasons, setBaselineSeasons] = useState(2)
 
   const minutesQuery = useGetTrendsMinutesQuery({ windowDays }, { skip: tab !== 'minutes' })
   const usageQuery = useGetTrendsUsageQuery({ windowDays }, { skip: tab !== 'usage' })
-  const regressionQuery = useGetTrendsRegressionQuery({ windowDays }, { skip: tab !== 'regression' })
+  const regressionQuery = useGetTrendsRegressionQuery({ windowDays, baselineSeasons }, { skip: tab !== 'regression' })
 
-  const filters = { nameFilter, position, minG15: minGames }
+  const filters: Filters = { nameFilter, position, minG15: minGames, ownership, fantasyTeam }
 
   const activeQuery = tab === 'minutes' ? minutesQuery : tab === 'usage' ? usageQuery : regressionQuery
+
+  const teamOptions = useMemo(() => {
+    const items = minutesQuery.data?.items ?? usageQuery.data?.items ?? regressionQuery.data?.items ?? []
+    return [...new Set(items.map(i => i.fantasy_status).filter(t => t !== 'FA'))].sort()
+  }, [minutesQuery.data, usageQuery.data, regressionQuery.data])
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
       <div className="max-w-screen-2xl mx-auto">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">📈 Trends</h1>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">Whose situation just changed — minutes, usage, shooting regression. Free agents only.</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">Whose situation just changed — minutes, usage, shooting regression. Click any player for their game-by-game chart.</p>
 
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-3 sm:p-4 mb-6 space-y-3">
           <div className="flex flex-wrap gap-2 items-center">
@@ -425,6 +563,40 @@ export default function Trends() {
                 </button>
               ))}
             </div>
+            <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Which players to show: everyone, free agents only, or rostered only">
+              {OWNERSHIP_OPTIONS.map(([key, label]) => (
+                <button
+                  key={key}
+                  onClick={() => { setOwnership(key); if (key === 'fa') setFantasyTeam(null) }}
+                  className={`px-2.5 py-1.5 whitespace-nowrap ${ownership === key ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <select
+              value={fantasyTeam ?? ''}
+              onChange={e => { setFantasyTeam(e.target.value || null); if (e.target.value) setOwnership('all') }}
+              title="Show only players on one fantasy team"
+              className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm max-w-[170px]"
+            >
+              <option value="">All fantasy teams</option>
+              {teamOptions.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+            {tab === 'regression' && (
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
+                {BASELINE_OPTIONS.map(([value, label, help]) => (
+                  <button
+                    key={value}
+                    onClick={() => setBaselineSeasons(value)}
+                    title={help}
+                    className={`px-2.5 py-1.5 whitespace-nowrap ${baselineSeasons === value ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
             <label className="inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300">
               Min games
               <input
@@ -445,7 +617,7 @@ export default function Trends() {
             <>
               {tab === 'minutes' && minutesQuery.data && <MinutesTable items={minutesQuery.data.items} filters={filters} windowDays={windowDays} />}
               {tab === 'usage' && usageQuery.data && <UsageTable items={usageQuery.data.items} filters={filters} windowDays={windowDays} />}
-              {tab === 'regression' && regressionQuery.data && <RegressionTable items={regressionQuery.data.items} filters={filters} windowDays={windowDays} />}
+              {tab === 'regression' && regressionQuery.data && <RegressionTable items={regressionQuery.data.items} filters={filters} windowDays={windowDays} baselineSeasons={regressionQuery.data.baseline_seasons} />}
             </>
           )}
         </div>

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -8,7 +8,7 @@ import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import TrendGameLogChart from '../components/TrendGameLogChart'
 import { BASELINE_LABEL } from '../utils/trendBaseline'
-import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat } from '../types/api'
+import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat, RegressionMode } from '../types/api'
 
 type TabKey = 'minutes' | 'usage' | 'regression'
 type Ownership = 'all' | 'fa' | 'rostered'
@@ -18,6 +18,11 @@ const ALL_POSITIONS = ['PG', 'SG', 'SF', 'PF', 'C']
 const BASELINE_OPTIONS: [number, string, string][] = [
   [2, 'Prior 2 seasons', 'This season measured against the two seasons before it, attempt-weighted. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
   [1, 'Last season only', 'This season measured against last season alone. Reacts faster to a real change, noisier for low-volume shooters.'],
+]
+
+const REGRESSION_MODES: [RegressionMode, string, string][] = [
+  ['season', 'Season outlier', "Whose season shooting line is out of step with their history — the number that will look different by the time you trade them."],
+  ['form', 'Hot or cold now', "Who is genuinely shooting above or below their own level right now, judged against everything outside the recency window. Small samples are filtered out by significance, not by a fixed attempt count."],
 ]
 
 const OWNERSHIP_OPTIONS: [Ownership, string][] = [
@@ -357,6 +362,8 @@ const REG_SORT_VAL: Record<string, (s: RegressionStatItem) => number | string> =
   dev: s => s.dev,
   att: s => s.attempts_per_game,
   drift: s => s.drift_score,
+  z: s => Math.abs(s.z ?? 0),  // magnitude, so an ice-cold stretch ranks with a red-hot one
+  impact: s => normalizeDelta(s),
 }
 
 const MAKES_LABEL: Record<RegressionStat, string> = { '3P%': '3PM', 'FT%': 'FTM', 'FG%': 'FGM' }
@@ -376,8 +383,18 @@ function NormalizePill({ stat }: { stat: RegressionStatItem }) {
   )
 }
 
-function RegressionTable({ items, filters, windowDays, baselineSeasons }: { items: RegressionPlayerGroup[]; filters: Filters; windowDays: number; baselineSeasons: number }) {
-  const [sortCol, setSortCol] = useState('dev')
+function ZCell({ z }: { z: number | null }) {
+  if (z === null) return <span className="text-gray-400 dark:text-gray-500">—</span>
+  return (
+    <span className="whitespace-nowrap text-gray-700 dark:text-gray-300 tabular-nums">
+      {z >= 0 ? '+' : ''}{z.toFixed(2)}
+    </span>
+  )
+}
+
+function RegressionTable({ items, filters, windowDays, baselineSeasons, mode }: { items: RegressionPlayerGroup[]; filters: Filters; windowDays: number; baselineSeasons: number; mode: RegressionMode }) {
+  const isForm = mode === 'form'
+  const [sortCol, setSortCol] = useState(isForm ? 'z' : 'dev')
   const [sortAsc, setSortAsc] = useState(false)
   const [statFilter, setStatFilter] = useState<'all' | '3P%' | 'FT%' | 'FG%'>('all')
   const [expanded, setExpanded] = useState<Record<number, RegressionStat>>({})
@@ -399,7 +416,9 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
     const identityCol = sortCol === 'stat' ? false : ['player', 'team', 'g15'].includes(sortCol)
 
     const withKey = filtered.map(g => {
-      const sortedStats = [...g.stats].sort((a, b) => Math.abs(b.dev) - Math.abs(a.dev))
+      const sortedStats = [...g.stats].sort((a, b) => (
+        isForm ? b.drift_score - a.drift_score : Math.abs(b.dev) - Math.abs(a.dev)
+      ))
       let key: number | string
       if (identityCol) {
         key = sortCol === 'player' ? g.player_name : sortCol === 'team' ? g.pro_team : g.games_last_15d
@@ -416,7 +435,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
     })
 
     return withKey
-  }, [items, filters, statFilter, sortCol, sortAsc])
+  }, [items, filters, statFilter, sortCol, sortAsc, isForm])
 
   const handleSort = (col: string) => {
     if (col === sortCol) setSortAsc(a => !a)
@@ -438,7 +457,9 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
         </select>
       </div>
       <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-        Filter: fantasy-relevant swing ≥ 0.35 makes/g-equivalent (attempts/g × |dev|), volume-weighted. Grouped by player: worst-offending stat surfaces first.
+        {isForm
+          ? `Filter: at least 10 attempts in the last ${windowDays} days, 50 in the baseline, and a gap of at least 1.5 standard errors — so a hot night on thin volume never lists. Ranked by z: the least likely to be luck first.`
+          : 'Filter: fantasy-relevant swing ≥ 0.35 makes/g-equivalent (attempts/g × |dev|), volume-weighted. Grouped by player: worst-offending stat surfaces first.'}
       </p>
       <div className="overflow-x-auto rounded-lg">
         <table className="w-full text-xs sm:text-sm">
@@ -448,12 +469,25 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
               <Th col="team" label="Team" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="NBA team" />
               <Th col="g15" label={`G(${windowDays}d)`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title={`Games played in the last ${windowDays} days`} />
               <Th col="stat" label="Stat" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting category: 3P%, FT%, or FG%" />
-              <Th col="cur" label="Season%" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting % across the whole season to date. This is the number compared against the baseline." />
-              <Th col="win" label={`${windowDays}d %`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Shooting % over the last ${windowDays} days only. Shows whether the correction has already started. Greyed with * when the window holds fewer than ${LOW_WINDOW_ATT} attempts.`} />
-              <Th col="base" label={`Baseline (${BASELINE_LABEL[baselineSeasons]})`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Attempt-weighted shooting % over the ${BASELINE_LABEL[baselineSeasons]} before this one. Excludes this season.`} />
-              <Th col="dev" label="Δ vs baseline" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Current% minus baseline%, in percentage points (not a relative change). Negative = cold (buy-low), positive = hot (sell-high)" />
-              <Th col="att" label="Att/g" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="Attempts per game this season" />
-              <Th col="drift" label="If it normalizes" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Expected change in makes per game if this stat returns to the player's baseline %, at current attempt volume" />
+              {isForm ? (
+                <>
+                  <Th col="cur" label={`Last ${windowDays}d %`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Shooting % over the last ${windowDays} days only — the stretch being judged.`} />
+                  <Th col="base" label="Baseline %" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`What he normally shoots: the ${BASELINE_LABEL[baselineSeasons]} before this one pooled with this season up to the last ${windowDays} days. Excludes the window itself.`} />
+                  <Th col="dev" label="Gap" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Last-window % minus baseline %, in percentage points. Negative = ice cold right now, positive = red hot." />
+                  <Th col="z" label="z" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="How many standard errors the gap sits from zero. Above 1.5 is more than the sample size alone would produce — the bigger the number, the less likely it is luck. Sorts by size, so hot and cold rank together; sort by Gap to separate them." />
+                  <Th col="att" label="Att/g" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title={`Attempts per game over the last ${windowDays} days`} />
+                  <Th col="impact" label="If it normalizes" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Expected change in makes per game going forward if he returns to his baseline %, at his current attempt volume" />
+                </>
+              ) : (
+                <>
+                  <Th col="cur" label="Season%" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting % across the whole season to date. This is the number compared against the baseline." />
+                  <Th col="win" label={`${windowDays}d %`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Shooting % over the last ${windowDays} days only. Shows whether the correction has already started. Greyed with * when the window holds fewer than ${LOW_WINDOW_ATT} attempts.`} />
+                  <Th col="base" label={`Baseline (${BASELINE_LABEL[baselineSeasons]})`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Attempt-weighted shooting % over the ${BASELINE_LABEL[baselineSeasons]} before this one. Excludes this season.`} />
+                  <Th col="dev" label="Δ vs baseline" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Current% minus baseline%, in percentage points (not a relative change). Negative = cold (buy-low), positive = hot (sell-high)" />
+                  <Th col="att" label="Att/g" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="Attempts per game this season" />
+                  <Th col="drift" label="If it normalizes" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Expected change in makes per game if this stat returns to the player's baseline %, at current attempt volume" />
+                </>
+              )}
               <th className="px-1.5 sm:px-3 py-2 text-left text-[10px] sm:text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400" title="Fantasy owner, or FA if unrostered">Owner</th>
             </tr>
           </thead>
@@ -489,9 +523,10 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
                     {i > 0 && <span className="text-gray-400 dark:text-gray-500">↳ </span>}{s.stat}
                   </td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{s.current_pct.toFixed(1)}%</td>
-                  <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><WindowPct stat={s} windowDays={windowDays} /></td>
+                  {!isForm && <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><WindowPct stat={s} windowDays={windowDays} /></td>}
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{s.baseline_pct.toFixed(1)}%</td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><DeltaPill value={s.dev} unit="%" /></td>
+                  {isForm && <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><ZCell z={s.z} /></td>}
                   <td className="hidden sm:table-cell px-3 py-2 text-gray-700 dark:text-gray-300">{s.attempts_per_game.toFixed(1)}</td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><NormalizePill stat={s} /></td>
                   {i === 0 && <td rowSpan={stats.length} className="align-top px-1.5 sm:px-3 py-1.5 sm:py-2"><StatusBadge fantasyStatus={group.fantasy_status} /></td>}
@@ -503,9 +538,11 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
                     playerId={group.player_id}
                     playerName={group.player_name}
                     mode="shooting"
+                    regressionMode={mode}
                     windowDays={windowDays}
                     baselineSeasons={baselineSeasons}
                     stat={openStat}
+                    zScore={stats.find(s => s.stat === openStat)?.z ?? null}
                     qualifiedStats={stats.map(s => s.stat)}
                     onStatChange={stat => setExpanded(prev => ({ ...prev, [group.player_id]: stat }))}
                   />
@@ -531,10 +568,11 @@ export default function Trends() {
   const [ownership, setOwnership] = useState<Ownership>('all')
   const [fantasyTeam, setFantasyTeam] = useState<string | null>(null)
   const [baselineSeasons, setBaselineSeasons] = useState(2)
+  const [regressionMode, setRegressionMode] = useState<RegressionMode>('season')
 
   const minutesQuery = useGetTrendsMinutesQuery({ windowDays }, { skip: tab !== 'minutes' })
   const usageQuery = useGetTrendsUsageQuery({ windowDays }, { skip: tab !== 'usage' })
-  const regressionQuery = useGetTrendsRegressionQuery({ windowDays, baselineSeasons }, { skip: tab !== 'regression' })
+  const regressionQuery = useGetTrendsRegressionQuery({ windowDays, baselineSeasons, mode: regressionMode }, { skip: tab !== 'regression' })
 
   const filters: Filters = { nameFilter, position, minG15: minGames, ownership, fantasyTeam }
 
@@ -549,7 +587,7 @@ export default function Trends() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
       <div className="max-w-screen-2xl mx-auto">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">📈 Trends</h1>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">Whose situation just changed — minutes, usage, shooting regression. Click any player for their game-by-game chart.</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">Whose situation just changed — minutes, usage, shooting. Click any player for their game-by-game chart.</p>
 
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-3 sm:p-4 mb-6 space-y-3">
           <div className="flex flex-wrap gap-2 items-center">
@@ -557,7 +595,7 @@ export default function Trends() {
               {([
                 ['minutes', 'Minutes Movers'],
                 ['usage', 'Usage & Role'],
-                ['regression', 'Shooting Regression'],
+                ['regression', 'Shooting'],
               ] as [TabKey, string][]).map(([key, label]) => (
                 <button
                   key={key}
@@ -616,6 +654,20 @@ export default function Trends() {
               {teamOptions.map(t => <option key={t} value={t}>{t}</option>)}
             </select>
             {tab === 'regression' && (
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
+                {REGRESSION_MODES.map(([value, label, help]) => (
+                  <button
+                    key={value}
+                    onClick={() => setRegressionMode(value)}
+                    title={help}
+                    className={`px-2.5 py-1.5 whitespace-nowrap ${regressionMode === value ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
+            {tab === 'regression' && (
               <label className="inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300" title="This season's shooting is always what gets measured (the Current% column). This picks the past period it is measured against.">
               Compare this season to
               <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
@@ -652,7 +704,16 @@ export default function Trends() {
             <>
               {tab === 'minutes' && minutesQuery.data && <MinutesTable items={minutesQuery.data.items} filters={filters} windowDays={windowDays} />}
               {tab === 'usage' && usageQuery.data && <UsageTable items={usageQuery.data.items} filters={filters} windowDays={windowDays} />}
-              {tab === 'regression' && regressionQuery.data && <RegressionTable items={regressionQuery.data.items} filters={filters} windowDays={windowDays} baselineSeasons={regressionQuery.data.baseline_seasons} />}
+              {tab === 'regression' && regressionQuery.data && (
+                <RegressionTable
+                  key={regressionQuery.data.mode}
+                  items={regressionQuery.data.items}
+                  filters={filters}
+                  windowDays={windowDays}
+                  baselineSeasons={regressionQuery.data.baseline_seasons}
+                  mode={regressionQuery.data.mode}
+                />
+              )}
             </>
           )}
         </div>

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -28,8 +28,16 @@ const TAB_MODE: Partial<Record<TabKey, RegressionMode>> = {
 const ALL_POSITIONS = ['PG', 'SG', 'SF', 'PF', 'C']
 
 const BASELINE_OPTIONS: [number, string, string][] = [
-  [2, 'Prior 2 seasons', 'This season measured against the two seasons before it, attempt-weighted. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
-  [1, 'Last season only', 'This season measured against last season alone. Reacts faster to a real change, noisier for low-volume shooters.'],
+  [2, 'Prior 2 seasons', 'Measured against the two seasons before this one, attempt-weighted. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
+  [1, 'Last season only', 'Measured against last season alone. Reacts faster to a real change, noisier for low-volume shooters.'],
+]
+
+// mode='form' only: no prior seasons at all, so the window is judged against
+// this season alone. Right when a player's level has genuinely moved (new role,
+// new team, second-year jump) and his older seasons no longer describe him.
+const FORM_BASELINE_OPTIONS: [number, string, string][] = [
+  [0, 'This season', 'The window measured against the rest of this season only. Follows a player whose level has actually changed; ignores who he used to be.'],
+  ...BASELINE_OPTIONS.map(([v, l, h]) => [v, l, `${h} Pooled with this season up to the window.`] as [number, string, string]),
 ]
 
 const OWNERSHIP_OPTIONS: [Ownership, string][] = [
@@ -434,11 +442,11 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons, mode }: 
 
   return (
     <div>
-      <div className="flex flex-wrap items-center gap-3 mb-2">
+      <div className="flex flex-wrap items-center gap-3 mb-3">
         <select
           value={statFilter}
           onChange={e => setStatFilter(e.target.value as typeof statFilter)}
-          className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-xs"
+          className="w-full sm:w-auto px-2 py-2 sm:py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-xs"
         >
           <option value="all">All stats</option>
           <option value="3P%">3P%</option>
@@ -554,10 +562,16 @@ export default function Trends() {
   const [minGames, setMinGames] = useState(3)
   const [ownership, setOwnership] = useState<Ownership>('all')
   const [fantasyTeam, setFantasyTeam] = useState<string | null>(null)
-  const [baselineSeasons, setBaselineSeasons] = useState(2)
+  // one remembered choice per tab: "prior 2 seasons" is the right default when
+  // judging a season line, "this season" when judging current form
+  const [seasonBaseline, setSeasonBaseline] = useState(2)
+  const [formBaseline, setFormBaseline] = useState(0)
 
   const regressionMode = TAB_MODE[tab]
   const isShooting = regressionMode !== undefined
+  const isFormTab = regressionMode === 'form'
+  const baselineSeasons = isFormTab ? formBaseline : seasonBaseline
+  const setBaselineSeasons = isFormTab ? setFormBaseline : setSeasonBaseline
 
   const minutesQuery = useGetTrendsMinutesQuery({ windowDays }, { skip: tab !== 'minutes' })
   const usageQuery = useGetTrendsUsageQuery({ windowDays }, { skip: tab !== 'usage' })
@@ -581,10 +595,10 @@ export default function Trends() {
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">📈 Trends</h1>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">Whose situation just changed — minutes, usage, shooting. Click any player for their game-by-game chart.</p>
 
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-3 sm:p-4 mb-6 space-y-3">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-4 sm:p-4 mb-6 space-y-4">
           {/* mobile: one control group per full-width row, buttons stretched to a
               common edge; desktop keeps the flowing single row */}
-          <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:gap-x-2 sm:gap-y-3 sm:items-center">
+          <div className="grid grid-cols-2 gap-x-2 gap-y-3 sm:flex sm:flex-wrap sm:gap-x-2 sm:gap-y-3 sm:items-center">
             {/* four tabs overflow one row at 390px, so mobile gets a 2x2 grid */}
             <div className="col-span-2 grid grid-cols-2 sm:flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
               {TABS.map(([key, label, help]) => (
@@ -592,7 +606,7 @@ export default function Trends() {
                   key={key}
                   onClick={() => setTab(key)}
                   title={help}
-                  className={`px-3 py-1.5 whitespace-nowrap ${tab === key ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  className={`px-3 py-2 sm:py-1.5 whitespace-nowrap ${tab === key ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
                   {label}
                 </button>
@@ -603,12 +617,12 @@ export default function Trends() {
               placeholder="Search player…"
               value={nameFilter}
               onChange={e => setNameFilter(e.target.value)}
-              className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm sm:min-w-[150px]"
+              className="px-2 py-2 sm:py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm sm:min-w-[150px]"
             />
             <select
               value={position ?? ''}
               onChange={e => setPosition(e.target.value || null)}
-              className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm"
+              className="px-2 py-2 sm:py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm"
             >
               <option value="">All positions</option>
               {ALL_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
@@ -619,7 +633,7 @@ export default function Trends() {
                 <button
                   key={d}
                   onClick={() => setWindowDays(d)}
-                  className={`flex-1 sm:flex-none px-2.5 py-1.5 whitespace-nowrap ${windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
                   {d}d
                 </button>
@@ -630,7 +644,7 @@ export default function Trends() {
                 <button
                   key={key}
                   onClick={() => { setOwnership(key); if (key === 'fa') setFantasyTeam(null) }}
-                  className={`flex-1 sm:flex-none px-2.5 py-1.5 whitespace-nowrap ${ownership === key ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${ownership === key ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
                   {label}
                 </button>
@@ -640,33 +654,11 @@ export default function Trends() {
               value={fantasyTeam ?? ''}
               onChange={e => { setFantasyTeam(e.target.value || null); if (e.target.value) setOwnership('all') }}
               title="Show only players on one fantasy team"
-              className="col-span-2 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm sm:max-w-[170px]"
+              className="col-span-2 px-2 py-2 sm:py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm sm:max-w-[170px]"
             >
               <option value="">All fantasy teams</option>
               {teamOptions.map(t => <option key={t} value={t}>{t}</option>)}
             </select>
-            {isShooting && (
-              <label
-                className="col-span-2 flex items-center gap-1.5 sm:ml-4 text-xs sm:text-sm text-gray-600 dark:text-gray-300"
-                title={regressionMode === 'form'
-                  ? 'Which past seasons feed the baseline. On this tab the baseline also includes this season up to the start of the window.'
-                  : "Which past seasons this season's shooting is measured against."}
-              >
-                <span className="w-[72px] sm:w-auto shrink-0">Baseline</span>
-                <div className="flex flex-1 sm:flex-none rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
-                  {BASELINE_OPTIONS.map(([value, label, help]) => (
-                    <button
-                      key={value}
-                      onClick={() => setBaselineSeasons(value)}
-                      title={help}
-                      className={`flex-1 sm:flex-none px-2.5 py-1.5 whitespace-nowrap ${baselineSeasons === value ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </label>
-            )}
             <label className="col-span-2 flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300">
               <span className="w-[72px] sm:w-auto shrink-0">Min games</span>
               <input
@@ -675,9 +667,31 @@ export default function Trends() {
                 value={minGames}
                 onChange={e => setMinGames(Math.max(0, Number(e.target.value)))}
                 title={`Minimum games played in the last ${windowDays} days`}
-                className="w-16 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm"
+                className="flex-1 sm:flex-none sm:w-16 px-2 py-2 sm:py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm"
               />
             </label>
+            {isShooting && (
+              <label
+                className="col-span-2 flex flex-col items-stretch gap-1 sm:flex-row sm:items-center sm:gap-1.5 sm:ml-4 text-xs sm:text-sm text-gray-600 dark:text-gray-300"
+                title={isFormTab
+                  ? 'What the last-N-days window is judged against. Whichever past seasons you pick are pooled with this season up to the start of the window — never the window itself.'
+                  : "Which past seasons this season's shooting is measured against."}
+              >
+                <span className="shrink-0">Baseline</span>
+                <div className="flex flex-1 sm:flex-none rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
+                  {(isFormTab ? FORM_BASELINE_OPTIONS : BASELINE_OPTIONS).map(([value, label, help]) => (
+                    <button
+                      key={value}
+                      onClick={() => setBaselineSeasons(value)}
+                      title={help}
+                      className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${baselineSeasons === value ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </label>
+            )}
           </div>
 
           {activeQuery.isLoading && <LoadingSpinner />}

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -496,10 +496,6 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons }: { item
           </tbody>
         </table>
       </div>
-      <p className="text-[11px] text-gray-400 dark:text-gray-500 mt-2">
-        Buy-low = negative Δ (cold vs the player's own {BASELINE_LABEL[baselineSeasons]}). Sell-high = positive Δ (hot vs their own history).
-        Δ is in percentage points, not a relative change. Click any stat row for the game-by-game chart.
-      </p>
     </div>
   )
 }

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -10,19 +10,26 @@ import TrendGameLogChart from '../components/TrendGameLogChart'
 import { BASELINE_LABEL } from '../utils/trendBaseline'
 import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat, RegressionMode } from '../types/api'
 
-type TabKey = 'minutes' | 'usage' | 'regression'
+type TabKey = 'minutes' | 'usage' | 'shooting-season' | 'shooting-form'
 type Ownership = 'all' | 'fa' | 'rostered'
+
+const TABS: [TabKey, string, string][] = [
+  ['minutes', 'Minutes Movers', 'Who is playing more or fewer minutes than their season average'],
+  ['usage', 'Usage & Role', 'Whose share of their team’s possessions has moved'],
+  ['shooting-season', 'Shooting · Season', "Whose season shooting line is out of step with their history — the number that will look different by the time you trade them."],
+  ['shooting-form', 'Shooting · Form', "Who is genuinely shooting above or below their own level right now, judged against everything outside the recency window. Small samples are filtered out by significance, not by a fixed attempt count."],
+]
+
+const TAB_MODE: Partial<Record<TabKey, RegressionMode>> = {
+  'shooting-season': 'season',
+  'shooting-form': 'form',
+}
 
 const ALL_POSITIONS = ['PG', 'SG', 'SF', 'PF', 'C']
 
 const BASELINE_OPTIONS: [number, string, string][] = [
   [2, 'Prior 2 seasons', 'This season measured against the two seasons before it, attempt-weighted. Bigger sample, survives one fluky year, but slow to accept a genuine change in the shooter.'],
   [1, 'Last season only', 'This season measured against last season alone. Reacts faster to a real change, noisier for low-volume shooters.'],
-]
-
-const REGRESSION_MODES: [RegressionMode, string, string][] = [
-  ['season', 'Season outlier', "Whose season shooting line is out of step with their history — the number that will look different by the time you trade them."],
-  ['form', 'Hot or cold now', "Who is genuinely shooting above or below their own level right now, judged against everything outside the recency window. Small samples are filtered out by significance, not by a fixed attempt count."],
 ]
 
 const OWNERSHIP_OPTIONS: [Ownership, string][] = [
@@ -337,27 +344,9 @@ function UsageTable({ items, filters, windowDays }: { items: UsageRoleItem[]; fi
   )
 }
 
-const LOW_WINDOW_ATT = 20  // below this the window % is one hot night, not a trend
-
-function WindowPct({ stat, windowDays }: { stat: RegressionStatItem; windowDays: number }) {
-  if (stat.window_pct === null) {
-    return <span className="text-gray-400 dark:text-gray-500" title={`No attempts in the last ${windowDays} days`}>—</span>
-  }
-  const thin = stat.window_attempts < LOW_WINDOW_ATT
-  return (
-    <span
-      className={thin ? 'text-gray-400 dark:text-gray-500' : 'text-gray-700 dark:text-gray-300'}
-      title={`${stat.window_attempts} attempts in the last ${windowDays} days${thin ? ' — small sample, read loosely' : ''}`}
-    >
-      {stat.window_pct.toFixed(1)}%{thin ? '*' : ''}
-    </span>
-  )
-}
-
 const REG_SORT_VAL: Record<string, (s: RegressionStatItem) => number | string> = {
   stat: s => s.stat,
   cur: s => s.current_pct,
-  win: s => s.window_pct ?? -1,
   base: s => s.baseline_pct,
   dev: s => s.dev,
   att: s => s.attempts_per_game,
@@ -394,6 +383,7 @@ function ZCell({ z }: { z: number | null }) {
 
 function RegressionTable({ items, filters, windowDays, baselineSeasons, mode }: { items: RegressionPlayerGroup[]; filters: Filters; windowDays: number; baselineSeasons: number; mode: RegressionMode }) {
   const isForm = mode === 'form'
+  const colCount = isForm ? 11 : 10
   const [sortCol, setSortCol] = useState(isForm ? 'z' : 'dev')
   const [sortAsc, setSortAsc] = useState(false)
   const [statFilter, setStatFilter] = useState<'all' | '3P%' | 'FT%' | 'FG%'>('all')
@@ -481,7 +471,6 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons, mode }: 
               ) : (
                 <>
                   <Th col="cur" label="Season%" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Shooting % across the whole season to date. This is the number compared against the baseline." />
-                  <Th col="win" label={`${windowDays}d %`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Shooting % over the last ${windowDays} days only. Shows whether the correction has already started. Greyed with * when the window holds fewer than ${LOW_WINDOW_ATT} attempts.`} />
                   <Th col="base" label={`Baseline (${BASELINE_LABEL[baselineSeasons]})`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title={`Attempt-weighted shooting % over the ${BASELINE_LABEL[baselineSeasons]} before this one. Excludes this season.`} />
                   <Th col="dev" label="Δ vs baseline" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} title="Current% minus baseline%, in percentage points (not a relative change). Negative = cold (buy-low), positive = hot (sell-high)" />
                   <Th col="att" label="Att/g" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" title="Attempts per game this season" />
@@ -492,7 +481,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons, mode }: 
             </tr>
           </thead>
           <tbody>
-            {groups.length === 0 && <EmptyRow colSpan={11} />}
+            {groups.length === 0 && <EmptyRow colSpan={colCount} />}
             {groups.map(({ group, stats }) => {
               const openStat = expanded[group.player_id]
               const toggle = (stat: RegressionStat) => toggleStat(group.player_id, stat)
@@ -523,7 +512,6 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons, mode }: 
                     {i > 0 && <span className="text-gray-400 dark:text-gray-500">↳ </span>}{s.stat}
                   </td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{s.current_pct.toFixed(1)}%</td>
-                  {!isForm && <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><WindowPct stat={s} windowDays={windowDays} /></td>}
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-gray-700 dark:text-gray-300">{s.baseline_pct.toFixed(1)}%</td>
                   <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><DeltaPill value={s.dev} unit="%" /></td>
                   {isForm && <td className="px-1.5 sm:px-3 py-1.5 sm:py-2"><ZCell z={s.z} /></td>}
@@ -533,7 +521,7 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons, mode }: 
                 </tr>
               )})}
               {openStat !== undefined && (
-                <ExpandRow colSpan={11}>
+                <ExpandRow colSpan={colCount}>
                   <TrendGameLogChart
                     playerId={group.player_id}
                     playerName={group.player_name}
@@ -567,11 +555,16 @@ export default function Trends() {
   const [ownership, setOwnership] = useState<Ownership>('all')
   const [fantasyTeam, setFantasyTeam] = useState<string | null>(null)
   const [baselineSeasons, setBaselineSeasons] = useState(2)
-  const [regressionMode, setRegressionMode] = useState<RegressionMode>('season')
+
+  const regressionMode = TAB_MODE[tab]
+  const isShooting = regressionMode !== undefined
 
   const minutesQuery = useGetTrendsMinutesQuery({ windowDays }, { skip: tab !== 'minutes' })
   const usageQuery = useGetTrendsUsageQuery({ windowDays }, { skip: tab !== 'usage' })
-  const regressionQuery = useGetTrendsRegressionQuery({ windowDays, baselineSeasons, mode: regressionMode }, { skip: tab !== 'regression' })
+  const regressionQuery = useGetTrendsRegressionQuery(
+    { windowDays, baselineSeasons, mode: regressionMode ?? 'season' },
+    { skip: !isShooting },
+  )
 
   const filters: Filters = { nameFilter, position, minG15: minGames, ownership, fantasyTeam }
 
@@ -590,15 +583,13 @@ export default function Trends() {
 
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-3 sm:p-4 mb-6 space-y-3">
           <div className="flex flex-wrap gap-2 items-center">
-            <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
-              {([
-                ['minutes', 'Minutes Movers'],
-                ['usage', 'Usage & Role'],
-                ['regression', 'Shooting'],
-              ] as [TabKey, string][]).map(([key, label]) => (
+            {/* four tabs overflow one row at 390px, so mobile gets a 2x2 grid */}
+            <div className="grid grid-cols-2 sm:flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
+              {TABS.map(([key, label, help]) => (
                 <button
                   key={key}
                   onClick={() => setTab(key)}
+                  title={help}
                   className={`px-3 py-1.5 whitespace-nowrap ${tab === key ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
                   {label}
@@ -652,21 +643,7 @@ export default function Trends() {
               <option value="">All fantasy teams</option>
               {teamOptions.map(t => <option key={t} value={t}>{t}</option>)}
             </select>
-            {tab === 'regression' && (
-              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
-                {REGRESSION_MODES.map(([value, label, help]) => (
-                  <button
-                    key={value}
-                    onClick={() => setRegressionMode(value)}
-                    title={help}
-                    className={`px-2.5 py-1.5 whitespace-nowrap ${regressionMode === value ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
-            )}
-            {tab === 'regression' && (
+            {isShooting && (
               <label className="inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300" title="This season's shooting is always what gets measured (the Current% column). This picks the past period it is measured against.">
               Compare this season to
               <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
@@ -703,7 +680,7 @@ export default function Trends() {
             <>
               {tab === 'minutes' && minutesQuery.data && <MinutesTable items={minutesQuery.data.items} filters={filters} windowDays={windowDays} />}
               {tab === 'usage' && usageQuery.data && <UsageTable items={usageQuery.data.items} filters={filters} windowDays={windowDays} />}
-              {tab === 'regression' && regressionQuery.data && (
+              {isShooting && regressionQuery.data && (
                 <RegressionTable
                   key={regressionQuery.data.mode}
                   items={regressionQuery.data.items}

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -582,9 +582,11 @@ export default function Trends() {
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">Whose situation just changed — minutes, usage, shooting. Click any player for their game-by-game chart.</p>
 
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-3 sm:p-4 mb-6 space-y-3">
-          <div className="flex flex-wrap gap-2 items-center">
+          {/* mobile: one control group per full-width row, buttons stretched to a
+              common edge; desktop keeps the flowing single row */}
+          <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:gap-x-2 sm:gap-y-3 sm:items-center">
             {/* four tabs overflow one row at 390px, so mobile gets a 2x2 grid */}
-            <div className="grid grid-cols-2 sm:flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
+            <div className="col-span-2 grid grid-cols-2 sm:flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
               {TABS.map(([key, label, help]) => (
                 <button
                   key={key}
@@ -601,9 +603,8 @@ export default function Trends() {
               placeholder="Search player…"
               value={nameFilter}
               onChange={e => setNameFilter(e.target.value)}
-              className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm min-w-[150px]"
+              className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm sm:min-w-[150px]"
             />
-            <span className="flex-1" />
             <select
               value={position ?? ''}
               onChange={e => setPosition(e.target.value || null)}
@@ -612,23 +613,24 @@ export default function Trends() {
               <option value="">All positions</option>
               {ALL_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
             </select>
-            <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
+            <span className="hidden sm:block flex-1" />
+            <div className="col-span-2 flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
               {WINDOW_OPTIONS.map(d => (
                 <button
                   key={d}
                   onClick={() => setWindowDays(d)}
-                  className={`px-2.5 py-1.5 whitespace-nowrap ${windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  className={`flex-1 sm:flex-none px-2.5 py-1.5 whitespace-nowrap ${windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
                   {d}d
                 </button>
               ))}
             </div>
-            <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Which players to show: everyone, free agents only, or rostered only">
+            <div className="col-span-2 flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Which players to show: everyone, free agents only, or rostered only">
               {OWNERSHIP_OPTIONS.map(([key, label]) => (
                 <button
                   key={key}
                   onClick={() => { setOwnership(key); if (key === 'fa') setFantasyTeam(null) }}
-                  className={`px-2.5 py-1.5 whitespace-nowrap ${ownership === key ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  className={`flex-1 sm:flex-none px-2.5 py-1.5 whitespace-nowrap ${ownership === key ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
                   {label}
                 </button>
@@ -638,30 +640,35 @@ export default function Trends() {
               value={fantasyTeam ?? ''}
               onChange={e => { setFantasyTeam(e.target.value || null); if (e.target.value) setOwnership('all') }}
               title="Show only players on one fantasy team"
-              className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm max-w-[170px]"
+              className="col-span-2 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm sm:max-w-[170px]"
             >
               <option value="">All fantasy teams</option>
               {teamOptions.map(t => <option key={t} value={t}>{t}</option>)}
             </select>
             {isShooting && (
-              <label className="inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300" title="This season's shooting is always what gets measured (the Current% column). This picks the past period it is measured against.">
-              Compare this season to
-              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
-                {BASELINE_OPTIONS.map(([value, label, help]) => (
-                  <button
-                    key={value}
-                    onClick={() => setBaselineSeasons(value)}
-                    title={help}
-                    className={`px-2.5 py-1.5 whitespace-nowrap ${baselineSeasons === value ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
+              <label
+                className="col-span-2 flex items-center gap-1.5 sm:ml-4 text-xs sm:text-sm text-gray-600 dark:text-gray-300"
+                title={regressionMode === 'form'
+                  ? 'Which past seasons feed the baseline. On this tab the baseline also includes this season up to the start of the window.'
+                  : "Which past seasons this season's shooting is measured against."}
+              >
+                <span className="w-[72px] sm:w-auto shrink-0">Baseline</span>
+                <div className="flex flex-1 sm:flex-none rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm">
+                  {BASELINE_OPTIONS.map(([value, label, help]) => (
+                    <button
+                      key={value}
+                      onClick={() => setBaselineSeasons(value)}
+                      title={help}
+                      className={`flex-1 sm:flex-none px-2.5 py-1.5 whitespace-nowrap ${baselineSeasons === value ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
               </label>
             )}
-            <label className="inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300">
-              Min games
+            <label className="col-span-2 flex items-center gap-1.5 text-xs sm:text-sm text-gray-600 dark:text-gray-300">
+              <span className="w-[72px] sm:w-auto shrink-0">Min games</span>
               <input
                 type="number"
                 min={0}

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -542,7 +542,6 @@ function RegressionTable({ items, filters, windowDays, baselineSeasons, mode }: 
                     windowDays={windowDays}
                     baselineSeasons={baselineSeasons}
                     stat={openStat}
-                    zScore={stats.find(s => s.stat === openStat)?.z ?? null}
                     qualifiedStats={stats.map(s => s.stat)}
                     onStatChange={stat => setExpanded(prev => ({ ...prev, [group.player_id]: stat }))}
                   />

--- a/frontend/src/store/api/fantasyApi.ts
+++ b/frontend/src/store/api/fantasyApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import type { LeagueRankings, TeamDetail, LeagueSummary, HeatmapData, LeagueShotsData, TeamPlayers, Team, TradeSuggestionsResponse, PaginatedPlayers, TimePeriod, RankingsOverTimeResponse, OverTimeSource, NbaTeamInfo, TeamDepthChart, PlayerMatchup, ProjectionStats, PlayersListResponse, PlayerStoreState, TeamsListResponse, TeamStoreState, DraftReport, MinutesResponse, UsageResponse, RegressionResponse, GameLogResponse } from '../../types/api';
+import type { LeagueRankings, TeamDetail, LeagueSummary, HeatmapData, LeagueShotsData, TeamPlayers, Team, TradeSuggestionsResponse, PaginatedPlayers, TimePeriod, RankingsOverTimeResponse, OverTimeSource, NbaTeamInfo, TeamDepthChart, PlayerMatchup, ProjectionStats, PlayersListResponse, PlayerStoreState, TeamsListResponse, TeamStoreState, DraftReport, MinutesResponse, UsageResponse, RegressionResponse, RegressionMode, GameLogResponse } from '../../types/api';
 import type { EstimatorResults } from '../../types/estimator';
 
 export const fantasyApi = createApi({
@@ -114,16 +114,16 @@ export const fantasyApi = createApi({
     getTrendsUsage: builder.query<UsageResponse, { windowDays?: number }>({
       query: ({ windowDays = 15 } = {}) => ({ url: '/trends/usage', params: { window_days: windowDays } }),
     }),
-    getTrendsRegression: builder.query<RegressionResponse, { windowDays?: number; baselineSeasons?: number }>({
-      query: ({ windowDays = 15, baselineSeasons = 2 } = {}) => ({
+    getTrendsRegression: builder.query<RegressionResponse, { windowDays?: number; baselineSeasons?: number; mode?: RegressionMode }>({
+      query: ({ windowDays = 15, baselineSeasons = 2, mode = 'season' } = {}) => ({
         url: '/trends/regression',
-        params: { window_days: windowDays, baseline_seasons: baselineSeasons },
+        params: { window_days: windowDays, baseline_seasons: baselineSeasons, mode },
       }),
     }),
-    getTrendGameLog: builder.query<GameLogResponse, { playerId: number; windowDays?: number; baselineSeasons?: number }>({
-      query: ({ playerId, windowDays = 15, baselineSeasons = 2 }) => ({
+    getTrendGameLog: builder.query<GameLogResponse, { playerId: number; windowDays?: number; baselineSeasons?: number; mode?: RegressionMode }>({
+      query: ({ playerId, windowDays = 15, baselineSeasons = 2, mode = 'season' }) => ({
         url: `/trends/player/${playerId}/gamelog`,
-        params: { window_days: windowDays, baseline_seasons: baselineSeasons },
+        params: { window_days: windowDays, baseline_seasons: baselineSeasons, mode },
       }),
       keepUnusedDataFor: 600,
     }),

--- a/frontend/src/store/api/fantasyApi.ts
+++ b/frontend/src/store/api/fantasyApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import type { LeagueRankings, TeamDetail, LeagueSummary, HeatmapData, LeagueShotsData, TeamPlayers, Team, TradeSuggestionsResponse, PaginatedPlayers, TimePeriod, RankingsOverTimeResponse, OverTimeSource, NbaTeamInfo, TeamDepthChart, PlayerMatchup, ProjectionStats, PlayersListResponse, PlayerStoreState, TeamsListResponse, TeamStoreState, DraftReport, MinutesResponse, UsageResponse, RegressionResponse } from '../../types/api';
+import type { LeagueRankings, TeamDetail, LeagueSummary, HeatmapData, LeagueShotsData, TeamPlayers, Team, TradeSuggestionsResponse, PaginatedPlayers, TimePeriod, RankingsOverTimeResponse, OverTimeSource, NbaTeamInfo, TeamDepthChart, PlayerMatchup, ProjectionStats, PlayersListResponse, PlayerStoreState, TeamsListResponse, TeamStoreState, DraftReport, MinutesResponse, UsageResponse, RegressionResponse, GameLogResponse } from '../../types/api';
 import type { EstimatorResults } from '../../types/estimator';
 
 export const fantasyApi = createApi({
@@ -114,8 +114,18 @@ export const fantasyApi = createApi({
     getTrendsUsage: builder.query<UsageResponse, { windowDays?: number }>({
       query: ({ windowDays = 15 } = {}) => ({ url: '/trends/usage', params: { window_days: windowDays } }),
     }),
-    getTrendsRegression: builder.query<RegressionResponse, { windowDays?: number }>({
-      query: ({ windowDays = 15 } = {}) => ({ url: '/trends/regression', params: { window_days: windowDays } }),
+    getTrendsRegression: builder.query<RegressionResponse, { windowDays?: number; baselineSeasons?: number }>({
+      query: ({ windowDays = 15, baselineSeasons = 2 } = {}) => ({
+        url: '/trends/regression',
+        params: { window_days: windowDays, baseline_seasons: baselineSeasons },
+      }),
+    }),
+    getTrendGameLog: builder.query<GameLogResponse, { playerId: number; windowDays?: number; baselineSeasons?: number }>({
+      query: ({ playerId, windowDays = 15, baselineSeasons = 2 }) => ({
+        url: `/trends/player/${playerId}/gamelog`,
+        params: { window_days: windowDays, baseline_seasons: baselineSeasons },
+      }),
+      keepUnusedDataFor: 600,
     }),
   }),
 });
@@ -148,4 +158,5 @@ export const {
   useGetTrendsMinutesQuery,
   useGetTrendsUsageQuery,
   useGetTrendsRegressionQuery,
+  useGetTrendGameLogQuery,
 } = fantasyApi;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -378,6 +378,7 @@ export interface TeamStoreState {
 }
 
 export interface MinutesMoverItem {
+  player_id: number;
   player_name: string;
   pro_team: string;
   position: string;
@@ -398,6 +399,7 @@ export interface MinutesResponse {
 }
 
 export interface UsageRoleItem {
+  player_id: number;
   player_name: string;
   pro_team: string;
   position: string;
@@ -432,6 +434,7 @@ export interface RegressionStatItem {
 }
 
 export interface RegressionPlayerGroup {
+  player_id: number;
   player_name: string;
   pro_team: string;
   position: string;
@@ -443,5 +446,34 @@ export interface RegressionPlayerGroup {
 export interface RegressionResponse {
   items: RegressionPlayerGroup[];
   window_days: number;
+  baseline_seasons: number;
   last_updated: string;
+}
+
+export interface GameLogEntry {
+  game_date: string;
+  matchup: string;
+  min: number;
+  usg: number;
+  fgm: number;
+  fga: number;
+  ftm: number;
+  fta: number;
+  fg3m: number;
+  fg3a: number;
+}
+
+export interface GameLogResponse {
+  player_id: number;
+  player_name: string;
+  season: string;
+  window_days: number;
+  window_start: string;
+  season_gp: number;
+  season_mpg: number;
+  season_usg: number;
+  season_pct: Partial<Record<RegressionStat, number>>;
+  baseline_pct: Partial<Record<RegressionStat, number>>;
+  baseline_seasons: number;
+  games: GameLogEntry[];
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -483,6 +483,8 @@ export interface GameLogResponse {
   season_usg: number;
   season_pct: Partial<Record<RegressionStat, number>>;
   baseline_pct: Partial<Record<RegressionStat, number>>;
+  league_pct: Partial<Record<RegressionStat, number>>;
+  league_usg: number | null;
   baseline_seasons: number;
   games: GameLogEntry[];
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -433,7 +433,13 @@ export interface RegressionStatItem {
   drift_score: number;
   window_pct: number | null;
   window_attempts: number;
+  z: number | null;
 }
+
+/** 'season' compares this season to prior seasons; 'form' compares the recency
+ * window to a baseline that excludes it. Same fields, different meanings — see
+ * RegressionStatItem in backend/app/models/trend_models.py. */
+export type RegressionMode = 'season' | 'form';
 
 export interface RegressionPlayerGroup {
   player_id: number;
@@ -449,6 +455,7 @@ export interface RegressionResponse {
   items: RegressionPlayerGroup[];
   window_days: number;
   baseline_seasons: number;
+  mode: RegressionMode;
   last_updated: string;
 }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -431,6 +431,8 @@ export interface RegressionStatItem {
   dev: number;
   attempts_per_game: number;
   drift_score: number;
+  window_pct: number | null;
+  window_attempts: number;
 }
 
 export interface RegressionPlayerGroup {

--- a/frontend/src/utils/trendBaseline.ts
+++ b/frontend/src/utils/trendBaseline.ts
@@ -1,0 +1,1 @@
+export const BASELINE_LABEL: Record<number, string> = { 1: 'last season', 2: 'prior 2 seasons' }

--- a/frontend/src/utils/trendBaseline.ts
+++ b/frontend/src/utils/trendBaseline.ts
@@ -1,1 +1,1 @@
-export const BASELINE_LABEL: Record<number, string> = { 1: 'last season', 2: 'prior 2 seasons' }
+export const BASELINE_LABEL: Record<number, string> = { 0: 'this season only', 1: 'last season', 2: 'prior 2 seasons' }


### PR DESCRIPTION
## What this does

Two additions to the Trends page, plus the chart legibility work that fell out of building them.

**Per-player game-log charts.** Every row expands into a game-by-game chart — minutes, usage, or shooting — with the selected recency window highlighted. Fetched only on expand, cached 10 min per player.

**A second shooting mode.** The Shooting tab could only answer *is this player's season line fake?* It could not answer *is he hot or cold right now?* Four specific gaps: rookies never appeared (no prior season, no baseline); a player already mid-correction still read as broken, because the impact was measured from a season line that still carried the cold stretch; the recency column was descriptive only, so nobody ranked on it; and small samples were handled by an attempt-count asterisk that cannot suit free throws and field goals alike.

The tab is now two: **Shooting · Season** (unchanged behaviour) and **Shooting · Form**.

## The part worth reviewing carefully

The naive fix — compare the window against the season — is wrong. The season *contains* the window, so the two are correlated by construction and every gap is systematically shrunk toward zero.

Form mode instead builds a baseline that shares **no games** with the window:

```
baseline = (prior-season makes + this-season-before-window makes) / (same attempts)
form     = window makes / window attempts
gap      = form - baseline

p̂  = pooled proportion
SE = sqrt( p̂(1-p̂) × (1/att_win + 1/att_baseline) )
z  = gap / SE
```

Gates: `att_win ≥ 10`, `att_baseline ≥ 50`, `|z| ≥ 1.5`, ranked by `|z|`.

Three consequences, all intended:

- **Rookies qualify automatically** — with no prior seasons the baseline is just this season before the window.
- **The z gate replaces the asterisk.** A 10pp gap on 13 attempts scores z ≈ 0.7 and never lists; the same gap on 90 attempts scores z ≈ 1.9 and ranks. Free throws and field goals self-calibrate with no per-stat threshold to tune.
- **`att/g` denominators differ per mode deliberately** — Season projects a correction against season volume, Form projects forward against current volume.

`_form_stat` in `backend/app/services/trend_service.py` is the code to read.

## Verified against live data, not just unit tests

- **87 players** in season mode, **91** in form, **only 16 in both** — the modes genuinely answer different questions.
- Season mode output is **byte-identical** to before this branch (Tari Eason FG%: season 41.8, baseline 48.1).
- Eason **drops out of form mode entirely** — his recent shooting is no longer distinguishable from his baseline. That is exactly the mid-correction overstatement the change set out to fix.
- Gates hold across the whole payload: min `|z|` returned 1.505, min window attempts 10, every `z` null in season mode.
- Rookies (Ace Bailey, Dylan Harper, Ryan Kalkbrenner) appear in form only.
- League reference values land where they should: 3P 35.98%, FT 78.29%, FG 47.10%, USG 19.87%.

Two bugs were found this way rather than by reading code: the table sorted on **signed** `z`, burying the coldest players (Collin Gillespie at −2.76 ranked nowhere), and the chart's stat block printed **total** window attempts where the table printed per-game.

## Also in here

- **NBA reference line** on shooting and usage charts. Answers what a player's own history cannot — whether he helps or hurts the category at all. On usage it sits at the structural ~20% (five players split every possession); it does not move, which is what makes it a usable anchor. One cached pull shared across every chart.
- **Ownership filters** (All / Free agents / Rostered + a fantasy-team dropdown) are now client-side, so one cached payload per window serves every combination.
- **Selectable baseline.** Form mode defaults to "This season" — see the open question below. Each tab remembers its own choice.
- **Chart scale fix:** the floor is always the true data minimum; the ceiling backs off only when max > 1.35 × p95, and points above are capped and marked, never clipped. USG% is a per-minute rate, so a 2-minute cameo computes past 100.
- **Mobile:** four tabs overflow one row at 390px (339px of labels into a 334px strip), so the tab group is a 2×2 grid below `sm`. Controls stack full-width to shared edges. One real clipping bug fixed — the baseline group was 256px wide but needed 287px, silently cutting "Last season only" under `overflow-hidden`.

## Reviewer notes

- **No new database queries or migrations.** `pre = season − window` is exact integer subtraction; `get_shooting_aggregate` already returned the makes columns.
- **`mode` defaults to `season`**, so existing clients are unaffected. `mode=season&baseline_seasons=0` is coerced rather than returning an empty table.
- **`RegressionStatItem` keeps one shape for both modes** and only per-field *meaning* shifts (documented on the model). The design originally called for a nested `FormMetrics`; four of its five fields turned out to be existing fields renamed, and `impact` is the identical expression the frontend already applied. `z` is the one genuinely new number.
- **Open question, my call and arguable:** making "This season" the Form default. It is the more responsive reference, but it has a shorter memory — a player cold all season who returns to normal reads as "hot." Flipping the default is a one-line change if it proves noisy.
- Design doc lives at `docs/superpowers/specs/2026-07-25-trends-shooting-modes-design.md`, which is gitignored, so it is not in this diff.

## Testing

- `uv run pytest -q` — **446 passed** (10 new, covering baseline/window disjointness, rookie handling, the z gate at 13 vs 90 attempts, the zero-baseline path, and a guard that season-mode output is unchanged)
- `npm run test -- --run` — **114 passed**, 3 skipped
- `tsc --noEmit` — clean
- `npm run lint` — 3 errors, all pre-existing in `MatchupDisplay.tsx` / `DraftReport.tsx` / `Projections.tsx`, none in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
