### PR TITLE
feat(nav): regroup reorg nav into League/Players/Insights/Tools/NBA

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -152,53 +152,63 @@ interface NavLeaf {
   icon: string
 }
 
-const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
+interface NavGroupDef {
+  key: string
+  label: string
+  icon: string
+  items: NavLeaf[]
+}
+
+const desktopItemClass = (active: boolean) =>
+  `inline-flex items-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium whitespace-nowrap transition-all duration-200 ${
+    active
+      ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 shadow-sm'
+      : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
+  }`
+
+const mobileItemClass = (active: boolean) =>
+  `inline-flex items-center px-4 py-3 rounded-md text-base font-medium transition-all duration-200 ${
+    active
+      ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 shadow-sm'
+      : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
+  }`
+
+interface DesktopNavGroupProps {
+  group: NavGroupDef
+  openKey: string | null
+  setOpenKey: (key: string | null) => void
+  isActive: boolean
+}
+
+const DesktopNavGroup = ({ group, openKey, setOpenKey, isActive }: DesktopNavGroupProps) => {
   const location = useLocation()
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [mobileToolsOpen, setMobileToolsOpen] = useState(false)
-  const [toolsOpen, setToolsOpen] = useState(false)
-  const toolsRef = useRef<HTMLDivElement>(null)
-  const toolsButtonRef = useRef<HTMLButtonElement>(null)
-  const toolsMenuRef = useRef<HTMLDivElement>(null)
-  const [toolsMenuPos, setToolsMenuPos] = useState<{ top: number; right: number } | null>(null)
-
-  const toolsItems: NavLeaf[] = [
-    ...(FF_PROJECTIONS ? [{ path: '/projections', label: 'Projections', icon: '🔭' }] : []),
-    { path: '/estimator', label: 'Estimator', icon: '🔮' },
-    { path: '/trade', label: 'Trade', icon: '🔄' },
-    ...(FF_FEATURE_STORE ? [{ path: '/feature-store', label: 'Feature Store', icon: '🗄️' }] : []),
-    ...(FF_DRAFT_REPORT ? [{ path: '/draft-report', label: 'Draft Report', icon: '📝' }] : []),
-    ...(FF_TRENDS ? [{ path: '/trends', label: 'Trends', icon: '📈' }] : []),
-  ]
-
-  const isToolsActive = toolsItems.some((item) => item.path === location.pathname)
-
-  const closeMobileMenu = () => {
-    setMobileMenuOpen(false)
-    setMobileToolsOpen(false)
-  }
+  const groupRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null)
+  const isOpen = openKey === group.key
 
   useEffect(() => {
-    if (!toolsOpen) return
+    if (!isOpen) return
     const handleClickOutside = (e: MouseEvent) => {
       if (
-        toolsRef.current &&
-        !toolsRef.current.contains(e.target as Node) &&
-        !toolsMenuRef.current?.contains(e.target as Node)
+        groupRef.current &&
+        !groupRef.current.contains(e.target as Node) &&
+        !menuRef.current?.contains(e.target as Node)
       ) {
-        setToolsOpen(false)
+        setOpenKey(null)
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [toolsOpen])
+  }, [isOpen, setOpenKey])
 
   useEffect(() => {
-    if (!toolsOpen) return
+    if (!isOpen) return
     const updatePos = () => {
-      const rect = toolsButtonRef.current?.getBoundingClientRect()
+      const rect = buttonRef.current?.getBoundingClientRect()
       if (rect) {
-        setToolsMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right })
+        setMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right })
       }
     }
     updatePos()
@@ -208,45 +218,193 @@ const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
       window.removeEventListener('resize', updatePos)
       window.removeEventListener('scroll', updatePos, true)
     }
-  }, [toolsOpen])
+  }, [isOpen])
 
-  const handleToolsKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+  const handleButtonKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === 'Escape') {
-      setToolsOpen(false)
-      toolsButtonRef.current?.focus()
+      setOpenKey(null)
+      buttonRef.current?.focus()
     } else if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setToolsOpen(true)
+      setOpenKey(group.key)
       requestAnimationFrame(() => {
-        const firstLink = toolsMenuRef.current?.querySelector('a')
+        const firstLink = menuRef.current?.querySelector('a')
         ;(firstLink as HTMLAnchorElement | null)?.focus()
       })
     } else if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
-      setToolsOpen((o) => !o)
+      setOpenKey(isOpen ? null : group.key)
     }
   }
 
-  const handleToolsMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Escape') {
-      setToolsOpen(false)
-      toolsButtonRef.current?.focus()
+      setOpenKey(null)
+      buttonRef.current?.focus()
     }
   }
 
-  const desktopItemClass = (active: boolean) =>
-    `inline-flex items-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium whitespace-nowrap transition-all duration-200 ${
-      active
-        ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 shadow-sm'
-        : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
-    }`
+  return (
+    <div
+      ref={groupRef}
+      className="relative"
+      onMouseEnter={() => setOpenKey(group.key)}
+      onMouseLeave={() => setOpenKey(null)}
+    >
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        onClick={() => setOpenKey(isOpen ? null : group.key)}
+        onKeyDown={handleButtonKeyDown}
+        className={desktopItemClass(isActive)}
+        title={group.label}
+      >
+        <span className="text-sm">{group.icon}</span>
+        <span>{group.label}</span>
+        <span className="text-[10px]">▾</span>
+      </button>
+      {isOpen && menuPos && (
+        <div
+          ref={menuRef}
+          role="menu"
+          onKeyDown={handleMenuKeyDown}
+          onMouseEnter={() => setOpenKey(group.key)}
+          onMouseLeave={() => setOpenKey(null)}
+          style={{ position: 'fixed', top: menuPos.top, right: menuPos.right }}
+          className="min-w-[11rem] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg py-1 z-50"
+        >
+          {group.items.map((item) => (
+            <Link
+              key={item.path}
+              role="menuitem"
+              to={item.path}
+              onClick={() => setOpenKey(null)}
+              className={`flex items-center gap-2 px-3 py-2 text-xs font-medium whitespace-nowrap transition-colors duration-200 ${
+                location.pathname === item.path
+                  ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300'
+                  : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
+              }`}
+            >
+              <span className="text-sm">{item.icon}</span>
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
 
-  const mobileItemClass = (active: boolean) =>
-    `inline-flex items-center px-4 py-3 rounded-md text-base font-medium transition-all duration-200 ${
-      active
-        ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 shadow-sm'
-        : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
-    }`
+interface MobileNavGroupProps {
+  group: NavGroupDef
+  openKey: string | null
+  setOpenKey: (key: string | null) => void
+  isActive: boolean
+  onNavigate: () => void
+}
+
+const MobileNavGroup = ({ group, openKey, setOpenKey, isActive, onNavigate }: MobileNavGroupProps) => {
+  const location = useLocation()
+  const isOpen = openKey === group.key
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpenKey(isOpen ? null : group.key)}
+        aria-expanded={isOpen}
+        className={mobileItemClass(isActive) + ' justify-between w-full'}
+      >
+        <span className="flex items-center">
+          <span className="mr-3 text-xl">{group.icon}</span>
+          {group.label}
+        </span>
+        <span className={`text-sm transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}>▾</span>
+      </button>
+      {isOpen && (
+        <div className="flex flex-col space-y-1 pl-6">
+          {group.items.map((item) => (
+            <Link
+              key={item.path}
+              to={item.path}
+              onClick={onNavigate}
+              className={mobileItemClass(location.pathname === item.path)}
+            >
+              <span className="mr-3 text-xl">{item.icon}</span>
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
+  const location = useLocation()
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [openGroup, setOpenGroup] = useState<string | null>(null)
+  const [mobileOpenGroup, setMobileOpenGroup] = useState<string | null>(null)
+
+  const navGroups: NavGroupDef[] = [
+    {
+      key: 'league',
+      label: 'League',
+      icon: '👥',
+      items: [
+        { path: '/rankings', label: 'League Rankings', icon: '🏆' },
+        { path: '/teams', label: 'Teams', icon: '👥' },
+        ...(FF_DRAFT_REPORT ? [{ path: '/draft-report', label: 'Draft Report', icon: '📝' }] : []),
+      ],
+    },
+    {
+      key: 'players',
+      label: 'Players',
+      icon: '⛹️',
+      items: [
+        { path: '/players', label: 'Players', icon: '⛹️' },
+        ...(FF_PLAYER_RANKINGS ? [{ path: '/player-rankings', label: 'Player Rankings', icon: '📋' }] : []),
+      ],
+    },
+    {
+      key: 'insights',
+      label: 'Insights',
+      icon: '📈',
+      items: [
+        { path: '/analytics', label: 'League Analytics', icon: '📈' },
+        ...(FF_TRENDS ? [{ path: '/trends', label: 'Player Trends', icon: '📉' }] : []),
+        ...(FF_PROJECTIONS ? [{ path: '/projections', label: 'Projections', icon: '🔭' }] : []),
+        { path: '/estimator', label: 'Standings Estimator', icon: '🔮' },
+        ...(FF_FEATURE_STORE ? [{ path: '/feature-store', label: 'Feature Store', icon: '🗄️' }] : []),
+      ],
+    },
+    {
+      key: 'tools',
+      label: 'Tools',
+      icon: '🛠️',
+      items: [
+        { path: '/trade', label: 'Trade Analyzer', icon: '🔄' },
+      ],
+    },
+    {
+      key: 'nba',
+      label: 'NBA',
+      icon: '🏀',
+      items: [
+        { path: '/nba-teams', label: 'NBA Depth Charts', icon: '🏀' },
+        { path: '/injuries', label: 'Injuries', icon: '🩺' },
+      ],
+    },
+  ]
+
+  const closeMobileMenu = () => {
+    setMobileMenuOpen(false)
+    setMobileOpenGroup(null)
+  }
+
+  const isGroupActive = (group: NavGroupDef) => group.items.some((item) => item.path === location.pathname)
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 flex flex-col">
@@ -262,91 +420,15 @@ const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
 
             {/* Desktop Navigation */}
             <div className="hidden md:flex items-center gap-0.5 overflow-x-auto">
-              <Link to="/teams" className={desktopItemClass(location.pathname === '/teams')} title="Teams">
-                <span className="text-xl xl:text-sm">👥</span>
-                <span className="hidden xl:inline">Teams</span>
-              </Link>
-              <Link to="/rankings" className={desktopItemClass(location.pathname === '/rankings')} title="League Rankings">
-                <span className="text-xl xl:text-sm">🏆</span>
-                <span className="hidden xl:inline">League Rankings</span>
-              </Link>
-              {FF_PLAYER_RANKINGS && (
-                <Link
-                  to="/player-rankings"
-                  className={desktopItemClass(location.pathname === '/player-rankings')}
-                  title="Player Rankings"
-                >
-                  <span className="text-xl xl:text-sm">📋</span>
-                  <span className="hidden xl:inline">Player Rankings</span>
-                </Link>
-              )}
-              <Link to="/analytics" className={desktopItemClass(location.pathname === '/analytics')} title="Analytics">
-                <span className="text-xl xl:text-sm">📈</span>
-                <span className="hidden xl:inline">Analytics</span>
-              </Link>
-              <Link to="/players" className={desktopItemClass(location.pathname === '/players')} title="Players">
-                <span className="text-xl xl:text-sm">⛹️</span>
-                <span className="hidden xl:inline">Players</span>
-              </Link>
-
-              <div
-                ref={toolsRef}
-                className="relative"
-                onMouseEnter={() => setToolsOpen(true)}
-                onMouseLeave={() => setToolsOpen(false)}
-              >
-                <button
-                  ref={toolsButtonRef}
-                  type="button"
-                  aria-haspopup="menu"
-                  aria-expanded={toolsOpen}
-                  onClick={() => setToolsOpen((o) => !o)}
-                  onKeyDown={handleToolsKeyDown}
-                  className={desktopItemClass(isToolsActive)}
-                  title="Tools"
-                >
-                  <span className="text-xl xl:text-sm">🛠️</span>
-                  <span className="hidden xl:inline">Tools</span>
-                  <span className="hidden xl:inline text-[10px]">▾</span>
-                </button>
-                {toolsOpen && toolsMenuPos && (
-                  <div
-                    ref={toolsMenuRef}
-                    role="menu"
-                    onKeyDown={handleToolsMenuKeyDown}
-                    onMouseEnter={() => setToolsOpen(true)}
-                    onMouseLeave={() => setToolsOpen(false)}
-                    style={{ position: 'fixed', top: toolsMenuPos.top, right: toolsMenuPos.right }}
-                    className="min-w-[10rem] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg py-1 z-50"
-                  >
-                    {toolsItems.map((item) => (
-                      <Link
-                        key={item.path}
-                        role="menuitem"
-                        to={item.path}
-                        onClick={() => setToolsOpen(false)}
-                        className={`flex items-center gap-2 px-3 py-2 text-xs font-medium whitespace-nowrap transition-colors duration-200 ${
-                          location.pathname === item.path
-                            ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300'
-                            : 'text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-gray-800'
-                        }`}
-                      >
-                        <span className="text-sm">{item.icon}</span>
-                        <span>{item.label}</span>
-                      </Link>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <Link to="/injuries" className={desktopItemClass(location.pathname === '/injuries')} title="Injuries">
-                <span className="text-xl xl:text-sm">🩺</span>
-                <span className="hidden xl:inline">Injuries</span>
-              </Link>
-              <Link to="/nba-teams" className={desktopItemClass(location.pathname === '/nba-teams')} title="NBA">
-                <span className="text-xl xl:text-sm">🏀</span>
-                <span className="hidden xl:inline">NBA</span>
-              </Link>
+              {navGroups.map((group) => (
+                <DesktopNavGroup
+                  key={group.key}
+                  group={group}
+                  openKey={openGroup}
+                  setOpenKey={setOpenGroup}
+                  isActive={isGroupActive(group)}
+                />
+              ))}
 
               <div className="mx-3 h-6 w-0.5 bg-gray-300 dark:bg-gray-500 shrink-0 rounded-full" />
               <button
@@ -389,69 +471,16 @@ const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
           {mobileMenuOpen && (
             <div className="md:hidden pb-4">
               <div className="flex flex-col space-y-1">
-                <Link to="/teams" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/teams')}>
-                  <span className="mr-3 text-xl">👥</span>
-                  Teams
-                </Link>
-                <Link to="/rankings" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/rankings')}>
-                  <span className="mr-3 text-xl">🏆</span>
-                  League Rankings
-                </Link>
-                {FF_PLAYER_RANKINGS && (
-                  <Link
-                    to="/player-rankings"
-                    onClick={closeMobileMenu}
-                    className={mobileItemClass(location.pathname === '/player-rankings')}
-                  >
-                    <span className="mr-3 text-xl">📋</span>
-                    Player Rankings
-                  </Link>
-                )}
-                <Link to="/analytics" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/analytics')}>
-                  <span className="mr-3 text-xl">📈</span>
-                  Analytics
-                </Link>
-                <Link to="/players" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/players')}>
-                  <span className="mr-3 text-xl">⛹️</span>
-                  Players
-                </Link>
-
-                <button
-                  type="button"
-                  onClick={() => setMobileToolsOpen((o) => !o)}
-                  aria-expanded={mobileToolsOpen}
-                  className={mobileItemClass(isToolsActive) + ' justify-between w-full'}
-                >
-                  <span className="flex items-center">
-                    <span className="mr-3 text-xl">🛠️</span>
-                    Tools
-                  </span>
-                  <span className={`text-sm transition-transform duration-200 ${mobileToolsOpen ? 'rotate-180' : ''}`}>▾</span>
-                </button>
-                {mobileToolsOpen && (
-                  <div className="flex flex-col space-y-1 pl-6">
-                    {toolsItems.map((item) => (
-                      <Link
-                        key={item.path}
-                        to={item.path}
-                        onClick={closeMobileMenu}
-                        className={mobileItemClass(location.pathname === item.path)}
-                      >
-                        <span className="mr-3 text-xl">{item.icon}</span>
-                        {item.label}
-                      </Link>
-                    ))}
-                  </div>
-                )}
-
-                <Link to="/injuries" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/injuries')}>
-                  <span className="mr-3 text-xl">🩺</span>
-                  Injuries
-                </Link>
-                <Link to="/nba-teams" onClick={closeMobileMenu} className={mobileItemClass(location.pathname === '/nba-teams')}>
-                  <span className="mr-3 text-xl">🏀</span>
-                  NBA
-                </Link>
+                {navGroups.map((group) => (
+                  <MobileNavGroup
+                    key={group.key}
+                    group={group}
+                    openKey={mobileOpenGroup}
+                    setOpenKey={setMobileOpenGroup}
+                    isActive={isGroupActive(group)}
+                    onNavigate={closeMobileMenu}
+                  />
+                ))}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- Behind `VITE_FF_NAV_REORG` (unchanged flag). Replaces the single Tools dropdown in the reorg nav with 5 groups: League, Players, Insights, Tools, NBA — each a generic dropdown (desktop hover/click + mobile accordion) driven by one shared group config instead of a hardcoded `toolsItems` array.
- Groups split by domain (League / Players / NBA) plus two cross-cutting groups: **Insights** (time-series pages + model-output pages — League Analytics, Player Trends, Projections, Standings Estimator, Feature Store) and **Tools** (hypothetical-move workspaces — currently just Trade Analyzer, room for the planned Streaming Planner / Slot Estimator).
- Nav-only label renames: `Analytics` → League Analytics, `Trends` → Player Trends, `Estimator` → Standings Estimator, the NBA child link → NBA Depth Charts (group itself stays `NBA`). Routes and page headings untouched.
- Dropped the icon-only `md`–`xl` compression tier — measured at the real 768px breakpoint, 5 short group labels fit without it (501px used of 717px available).
- Flag-off flat nav (`Layout.tsx` lines 1–151) is untouched — same array, same markup, same behavior.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Verified live at `VITE_FF_NAV_REORG=true` (already set in `.env.local`): all 5 desktop dropdowns open/close correctly, mutual exclusion (opening one closes the others), routes navigate correctly
- [x] Verified real 768px width — desktop nav, full labels, no horizontal overflow
- [x] Verified mobile (390px) — hamburger, accordion groups, thin Tools group (1 item) renders correctly, caret rotates
- [ ] Manual click-through once merged, since this is nav structure and easy to miss a route

🤖 Generated with [Claude Code](https://claude.com/claude-code)