### PR TITLE
fix(serving): cut vector-rebuild memory, and make the rebuild opt-in

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,11 @@ class Settings(BaseSettings):
     database_url: Optional[str] = Field(default=None, alias="DATABASE_URL")
     injury_scheduler_enabled: bool = Field(default=True, alias="INJURY_SCHEDULER_ENABLED")
     model_nightly_enabled: bool = Field(default=False, alias="MODEL_NIGHTLY_ENABLED")
+    # When the deployed models need a feature the stored vectors lack, should the
+    # nightly rebuild them itself? Detection is always on and costs three queries;
+    # the rebuild is what needs memory (~380 MB), so it defaults to OFF and the
+    # nightly just logs what to run. Turn on only where the container can afford it.
+    model_feature_heal_auto: bool = Field(default=False, alias="MODEL_FEATURE_HEAL_AUTO")
     model_config = SettingsConfigDict(
         env_file=".env",             # Loads .env if it exists
         env_file_encoding="utf-8",

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -23,6 +23,22 @@ _RANKINGS_COL_MAP = {
 }
 
 
+def fs_records_to_frame(records) -> pd.DataFrame:
+    """asyncpg rows -> pipeline frame (uppercase columns, Timestamp GAME_DATE).
+
+    Built straight from the records. The obvious ``[dict(r) for r in records]``
+    first costs ~80 MB of transient peak on a full ~96k-row history — the records
+    already hold boxed Python values, so the dicts add pure container overhead for
+    nothing.
+    """
+    if not records:
+        return pd.DataFrame()
+    df = pd.DataFrame.from_records(records, columns=list(records[0].keys()))
+    df.columns = [c.upper() for c in df.columns]
+    df["GAME_DATE"] = pd.to_datetime(df["GAME_DATE"])
+    return df
+
+
 class DBService:
     _instance = None
 
@@ -733,14 +749,19 @@ class DBService:
             logger.error(f"Failed to check fs rows for {game_date}: {e}")
             return None
 
-    async def get_fs_rows_before(self, game_date: date) -> tuple[list[dict], list[dict]]:
+    async def get_fs_rows_before(self, game_date: date) -> tuple[pd.DataFrame, pd.DataFrame]:
         """The model's only read boundary into fs_player_games. The MIN_MINUTES
         gate is enforced here (not at write time): storage keeps every played
         minute for other consumers, but sub-threshold games are DNPs to the
-        feature math — same threshold research/training filters on."""
+        feature math — same threshold research/training filters on.
+
+        Returns pipeline-ready frames rather than dict rows: a full history is
+        ~96k rows, and materializing a dict per row cost ~80 MB of transient peak
+        on top of the records themselves — enough to matter on a small container
+        (see fs_records_to_frame)."""
         pool = await self._get_pool()
         if pool is None:
-            return [], []
+            return pd.DataFrame(), pd.DataFrame()
         try:
             async with pool.acquire() as conn:
                 players = await conn.fetch(
@@ -750,10 +771,10 @@ class DBService:
                 teams = await conn.fetch(
                     "SELECT * FROM fs_team_games WHERE game_date < $1", game_date
                 )
-                return [dict(r) for r in players], [dict(r) for r in teams]
+                return fs_records_to_frame(players), fs_records_to_frame(teams)
         except Exception as e:
             logger.error(f"Failed to fetch fs rows before {game_date}: {e}")
-            return [], []
+            return pd.DataFrame(), pd.DataFrame()
 
     async def aggregate_player_games(
         self, start: date, end: date, season: str

--- a/backend/app/services/model_nightly_service.py
+++ b/backend/app/services/model_nightly_service.py
@@ -63,15 +63,6 @@ _FS_TEAM_COLS = [
 ]
 
 
-def _records_to_frame(records: list[dict]) -> pd.DataFrame:
-    """DB rows (lowercase columns, date game_date) -> pipeline frame (uppercase,
-    Timestamp GAME_DATE)."""
-    df = pd.DataFrame.from_records(records)
-    df.columns = [c.upper() for c in df.columns]
-    df["GAME_DATE"] = pd.to_datetime(df["GAME_DATE"])
-    return df
-
-
 def _frame_to_tuples(df: pd.DataFrame, cols: list[str]) -> list[tuple]:
     out = []
     for row in df[cols].itertuples(index=False):
@@ -239,13 +230,13 @@ class ModelNightlyService:
             )
             return "incomplete_data"
 
-        player_recs, team_recs = await db.get_fs_rows_before(game_date)
-        if not player_recs or not team_recs:
+        players, team_games = await db.get_fs_rows_before(game_date)
+        if players.empty or team_games.empty:
             logger.error("Feature-store tables are empty — run --bootstrap first")
             return "store_not_bootstrapped"
 
         evals, night_players, vectors = await asyncio.to_thread(
-            self._process_sync, player_recs, team_recs, night
+            self._process_sync, players, team_games, night
         )
 
         eval_rows = [_eval_to_tuple(ev, game_date) for ev in evals]
@@ -282,10 +273,10 @@ class ModelNightlyService:
         ``True`` written, ``False`` the write failed, ``None`` there was nothing to
         write (no raw rows — the store is not bootstrapped).
         """
-        player_recs, team_recs = await self._db.get_fs_rows_before(game_date + timedelta(days=1))
-        if not player_recs or not team_recs:
+        players, team_games = await self._db.get_fs_rows_before(game_date + timedelta(days=1))
+        if players.empty or team_games.empty:
             return None
-        vectors = await asyncio.to_thread(self._vectors_from_records, player_recs, team_recs)
+        vectors = await asyncio.to_thread(self._vectors_from_frames, players, team_games)
         return await self._db.upsert_feature_vectors(*vectors)
 
     # --- feature-set drift (self-healing after a deploy) ---------------------
@@ -361,13 +352,12 @@ class ModelNightlyService:
 
     @staticmethod
     def _process_sync(
-        player_recs: list[dict], team_recs: list[dict], night: nightly.NightFetch
+        players: pd.DataFrame, team_games: pd.DataFrame, night: nightly.NightFetch
     ) -> tuple[list[EvalRow], pd.DataFrame, tuple[list, list, list]]:
         """Heavy pandas/sklearn work in a thread: build the pre-night store, score
         the night (leakage-safe), then fold the night in to materialize post-night
         vectors."""
-        players = _records_to_frame(player_recs).sort_values(["PLAYER_ID", "GAME_DATE"])
-        team_games = _records_to_frame(team_recs)
+        players = players.sort_values(["PLAYER_ID", "GAME_DATE"])
         store = FeatureStore.build(
             players.reset_index(drop=True),
             rdata.build_team_allowed(team_games),
@@ -384,18 +374,6 @@ class ModelNightlyService:
         store.update_with_nightly_results(qualifying, night.team_games)
         return evals, night_players, _serialize_vectors(store)
 
-    @staticmethod
-    def _vectors_from_records(
-        player_recs: list[dict], team_recs: list[dict]
-    ) -> tuple[list, list, list]:
-        players = _records_to_frame(player_recs).sort_values(["PLAYER_ID", "GAME_DATE"])
-        team_games = _records_to_frame(team_recs)
-        store = FeatureStore.build(
-            players.reset_index(drop=True),
-            rdata.build_team_allowed(team_games),
-            rdata.build_team_own(team_games),
-        )
-        return _serialize_vectors(store)
 
     # --- serving: resident in-memory store (for a future inference tab) -------
 

--- a/backend/app/services/model_nightly_service.py
+++ b/backend/app/services/model_nightly_service.py
@@ -30,6 +30,7 @@ from zoneinfo import ZoneInfo
 
 import pandas as pd
 
+from app.config import settings
 from app.services.db_service import DBService
 from model_stats_inference.research import config as rconfig
 from model_stats_inference.research import data as rdata
@@ -177,12 +178,12 @@ class ModelNightlyService:
         DB failure): ingesting later days before an earlier day would leave the
         store with a hole under those predictions.
 
-        Runs the feature-drift check first, outside the loop, so a deploy that adds
+        Runs the missing-feature check first, outside the loop, so a deploy that adds
         a feature heals even when no date in the window has games (off-season).
         """
-        drift = await self._ensure_vectors_current()
+        missing = await self._ensure_vectors_current()
         yesterday = (datetime.now(ISRAEL_TZ) - timedelta(days=1)).date()
-        statuses: dict[str, str] = {"feature_drift": drift} if drift else {}
+        statuses: dict[str, str] = {"missing_features": missing} if missing else {}
         for offset in range(CATCHUP_DAYS - 1, -1, -1):
             d = yesterday - timedelta(days=offset)
             status = await self.run_for_date(d)
@@ -279,7 +280,7 @@ class ModelNightlyService:
         vectors = await asyncio.to_thread(self._vectors_from_frames, players, team_games)
         return await self._db.upsert_feature_vectors(*vectors)
 
-    # --- feature-set drift (self-healing after a deploy) ---------------------
+    # --- missing features (heal the store after a deploy) --------------------
 
     @staticmethod
     def _required_stored_features() -> set[str]:
@@ -309,9 +310,10 @@ class ModelNightlyService:
         this on its own, but only on nights that have games: off-nights and the
         whole off-season return early, so a deploy could sit un-healed for months.
 
-        Runs before the catch-up loop, costs one query per vector table when
-        nothing changed, and is self-limiting — once rewritten the keys match and
-        this is a no-op.
+        Runs before the catch-up loop and costs one query per vector table when
+        nothing changed. Whether it *fixes* the gap or only reports it is
+        MODEL_FEATURE_HEAL_AUTO; when it does fix it, it is self-limiting — once
+        rewritten the keys match and this is a no-op.
         """
         stored = await self._db.get_feature_vector_keys()
         if stored is None:
@@ -320,17 +322,32 @@ class ModelNightlyService:
         if not missing:
             return None
 
-        preview = ", ".join(sorted(missing)[:5])
+        preview = ", ".join(sorted(missing)[:5]) + (", ..." if len(missing) > 5 else "")
+
+        # Detection is cheap; the rebuild is not (~380 MB), which is more than a
+        # small container can spare mid-flight — it gets OOM-killed before the
+        # upsert lands, so the gap survives and every later run tries again.
+        # Off by default: say exactly what to run and leave the store alone.
+        if not settings.model_feature_heal_auto:
+            logger.warning(
+                f"Feature vectors are missing {len(missing)} feature(s) the models need "
+                f"({preview}). Auto-heal is off (MODEL_FEATURE_HEAL_AUTO), so the models "
+                f"will read them as NaN until the vectors are rebuilt. Run:\n"
+                f"    cd backend && python scripts/refresh_feature_vectors.py "
+                f"--database-url <url> --expect-feature {sorted(missing)[0]}"
+            )
+            return "manual_refresh_required"
+
         logger.warning(
             f"Feature vectors are missing {len(missing)} feature(s) the models need "
-            f"({preview}{', ...' if len(missing) > 5 else ''}) — rebuilding all vectors"
+            f"({preview}) — rebuilding all vectors"
         )
         written = await self._refresh_vectors_through(datetime.now(ISRAEL_TZ).date())
         if written is None:
-            logger.warning("Feature-drift rebuild skipped: no raw rows to rebuild from")
+            logger.warning("Vector rebuild skipped: no raw rows to rebuild from")
             return "vectors_refresh_skipped"
         if not written:
-            logger.error("Feature-drift rebuild failed; vectors left unchanged")
+            logger.error("Vector rebuild failed; vectors left unchanged")
             return "vectors_refresh_failed"
         self._invalidate_inference_store()
 

--- a/backend/model_stats_inference/research/features.py
+++ b/backend/model_stats_inference/research/features.py
@@ -401,6 +401,12 @@ def feature_columns(matrix: pd.DataFrame) -> list[str]:
 
 # --- Current-state ("as of now") vectors for serving -----------------------
 
+# Players per batch when materializing the serving vectors. Bounds the transient
+# memory of a full rebuild (see build_current_state); output is identical to any
+# other value because every player feature is computed within its own group.
+PLAYER_VECTOR_CHUNK = 100
+
+
 def _asof_features(
     df: pd.DataFrame, group_key: str, stats: list[str], rate_stats: list[str], prefix: str
 ) -> pd.DataFrame:
@@ -450,10 +456,50 @@ def build_current_state(
     if player_bio is None and config.BIO_PATH.exists():
         player_bio = pd.read_parquet(config.BIO_PATH)
 
-    # Same derived-USG step as build_feature_matrix, so train and serve match.
-    players = attach_usage(players, team_own if pace_source is None else pace_source)
+    pace = team_own if pace_source is None else pace_source
 
-    # Player vectors.
+    # Player vectors, computed in batches of PLAYER_VECTOR_CHUNK players.
+    #
+    # Every player feature is derived within a PLAYER_ID group, so batching is
+    # exact (verified identical to one-shot) — but it matters a lot for memory.
+    # One-shot allocates a full-length float array per feature for the entire
+    # league at once: on four seasons that is ~360 MB of transient peak versus
+    # ~110 MB batched, which is the difference between fitting in a small
+    # container and being OOM-killed mid-rebuild.
+    ids = players["PLAYER_ID"].unique()
+    if len(ids) == 0:
+        player_vectors = _player_vectors(players, pace, player_bio)
+    else:
+        batches = [
+            _player_vectors(
+                players[players["PLAYER_ID"].isin(ids[i:i + PLAYER_VECTOR_CHUNK])],
+                pace, player_bio,
+            )
+            for i in range(0, len(ids), PLAYER_VECTOR_CHUNK)
+        ]
+        player_vectors = (
+            batches[0] if len(batches) == 1 else pd.concat(batches, ignore_index=True)
+        )
+
+    # Team vectors (small: 30 teams over ~10k team-games, no batching needed).
+    allowed_cols = [c for c in team_allowed.columns if c.startswith("ALLOWED_")]
+    ta = _asof_features(team_allowed, "TEAM_ID", allowed_cols, [], "OPP_")
+    team_allowed_vectors = ta.drop(columns=["GAME_DATE"])
+
+    own_cols = [c for c in team_own.columns if c.startswith("TEAM_") and c != "TEAM_ID"]
+    to = _asof_features(team_own, "TEAM_ID", own_cols, [], "")
+    team_own_vectors = to.drop(columns=["GAME_DATE"])
+
+    return player_vectors, team_allowed_vectors, team_own_vectors
+
+
+def _player_vectors(
+    players: pd.DataFrame, pace_source: pd.DataFrame, player_bio: pd.DataFrame | None
+) -> pd.DataFrame:
+    """The player half of ``build_current_state`` for one batch of players."""
+    # Same derived-USG step as build_feature_matrix, so train and serve match.
+    players = attach_usage(players, pace_source)
+
     p = _asof_features(players, "PLAYER_ID", config.BASE_STATS, config.RATE_STATS, "")
     hist = p.drop(columns=["PLAYER_ID", "GAME_DATE"])
     eff = _efficiency_features(hist)
@@ -483,15 +529,4 @@ def build_current_state(
         meta = meta.merge(gp["PLAYER_NAME"].last().rename("PLAYER_NAME").reset_index(), on="PLAYER_ID")
     if "POSITION" in players.columns:
         meta = meta.merge(gp["POSITION"].last().rename("POSITION").reset_index(), on="PLAYER_ID")
-    player_vectors = player_vectors.merge(meta, on="PLAYER_ID")
-
-    # Team vectors.
-    allowed_cols = [c for c in team_allowed.columns if c.startswith("ALLOWED_")]
-    ta = _asof_features(team_allowed, "TEAM_ID", allowed_cols, [], "OPP_")
-    team_allowed_vectors = ta.drop(columns=["GAME_DATE"])
-
-    own_cols = [c for c in team_own.columns if c.startswith("TEAM_") and c != "TEAM_ID"]
-    to = _asof_features(team_own, "TEAM_ID", own_cols, [], "")
-    team_own_vectors = to.drop(columns=["GAME_DATE"])
-
-    return player_vectors, team_allowed_vectors, team_own_vectors
+    return player_vectors.merge(meta, on="PLAYER_ID")

--- a/backend/model_stats_inference/serving/README.md
+++ b/backend/model_stats_inference/serving/README.md
@@ -73,7 +73,7 @@ Two consequences:
 - **It does need a re-materialization**, because the vectors are a *precomputed
   cache* rather than something computed per request. This is automatic — see below.
 
-### Deploying is enough: the store self-heals
+### Detecting a stale store
 
 `run_catchup` starts with `_ensure_vectors_current()`, which compares the features
 the deployed models ask for (the union over `training/feature_sets/*.json`, minus the
@@ -81,33 +81,37 @@ ones `_assemble_row` derives per request) against the keys stored across **all t
 vector tables. The union matters: a feature row is composed from the player vector
 plus the `TEAM_*` and `OPP_ALLOWED_*` team vectors, so checking `fs_player_vectors`
 alone would report ~77 team features as permanently missing and rebuild every night.
-If the models need something the store lacks, it rebuilds **all** vectors once,
-exactly like an init:
 
-```bash
-# 1. deploy the branch  (models/*.joblib are git-tracked and ship with it)
-# 2. restart the app
-# 3. nothing — the next nightly detects the new feature and rebuilds the vectors
-```
+Detection always runs and costs three `LIMIT 1` queries. What happens next is
+**`MODEL_FEATURE_HEAL_AUTO`**:
 
-It is self-limiting: after the rebuild the keys match, so every later night costs three
-`LIMIT 1` queries (one per vector table) and does nothing. The rebuild itself is ~2 s
-of compute for ~660 players × ~250 columns. If a feature is *still* absent afterwards
-the run reports `vectors_refresh_incomplete` and logs an error rather than retrying
-nightly — that means the feature sets and the feature engine disagree.
+| | behaviour |
+|---|---|
+| `false` (**default**) | logs which features are missing and the exact command to run; the store is left alone. Status `manual_refresh_required`. |
+| `true` | rebuilds all vectors once, like an init (~2 s compute, **~380 MB peak**). Status `vectors_refreshed`. |
+
+It defaults to off because the rebuild's memory is more than a small container can
+spare mid-flight: it gets OOM-killed *before* the upsert lands, so the gap survives
+and every later run tries again — a crash loop. Turn it on only where the container
+can afford the peak.
+
+With auto on it is self-limiting: after the rebuild the keys match and later nights do
+nothing. If a feature is *still* absent afterwards the run reports
+`vectors_refresh_incomplete` and logs an error rather than retrying nightly — that
+means the feature sets and the feature engine disagree.
 
 Why the check lives in `run_catchup` and not `_run_for_date`: the per-night path
 already rebuilds every vector (`_process_sync` → `FeatureStore.build` over all stored
 rows), but only on nights that **have games**. Off-nights return early at `no_games`,
-so during the off-season nothing would recompute for months. Hoisting the check above
-the loop makes a deploy heal regardless of the calendar.
+so during the off-season nothing would recompute for months.
 
-> Requires `MODEL_NIGHTLY_ENABLED=true` — the scheduler is off by default
-> (`app/config.py`). Without it, use the manual script below.
+> Both need `MODEL_NIGHTLY_ENABLED=true` — the scheduler is off by default
+> (`app/config.py`). Without it nothing is detected either, so run the script after
+> any feature change.
 
-### Manual override
+### Rebuilding the vectors manually
 
-To apply a feature change immediately instead of waiting for the next nightly:
+The supported way to apply a feature change (and the default, given the flag above):
 
 ```bash
 cd backend    # must run from here: pydantic loads .env (SEASON_ID, LEAGUE_ID) from the CWD

--- a/backend/scripts/refresh_feature_vectors.py
+++ b/backend/scripts/refresh_feature_vectors.py
@@ -89,21 +89,21 @@ async def _main(args: argparse.Namespace) -> int:
     # so the upsert result is actually checked — that helper discards it, which would
     # turn a failed write into a silent no-op.
     print(f"\nReading raw rows through {through} ...")
-    player_recs, team_recs = await db.get_fs_rows_before(through + timedelta(days=1))
-    if not player_recs or not team_recs:
+    players, team_games = await db.get_fs_rows_before(through + timedelta(days=1))
+    if players.empty or team_games.empty:
         print(
-            f"ERROR: no raw rows found (players={len(player_recs)}, teams={len(team_recs)}). "
+            f"ERROR: no raw rows found (players={len(players)}, teams={len(team_games)}). "
             "Is fs_player_games populated? Run the bootstrap first.",
             file=sys.stderr,
         )
         await db.close()
         return 1
-    print(f"  {len(player_recs):,} player-games, {len(team_recs):,} team-games")
+    print(f"  {len(players):,} player-games, {len(team_games):,} team-games")
 
     print("Recomputing feature vectors ...")
     t0 = time.perf_counter()
     vectors = await asyncio.to_thread(
-        ModelNightlyService._vectors_from_records, player_recs, team_recs
+        ModelNightlyService._vectors_from_frames, players, team_games
     )
     players_v, allowed_v, own_v = vectors
     print(f"  built {len(players_v):,} player + {len(allowed_v)} allowed + {len(own_v)} own "

--- a/backend/tests/services/test_db_service.py
+++ b/backend/tests/services/test_db_service.py
@@ -162,13 +162,12 @@ async def test_get_fs_rows_before_filters_min_minutes(db_service, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_fs_rows_before_no_pool_returns_empty_lists(db_service, monkeypatch):
+async def test_get_fs_rows_before_no_pool_returns_empty_frames(db_service, monkeypatch):
     monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=None))
 
     players, teams = await db_service.get_fs_rows_before(date(2026, 1, 10))
 
-    assert players == []
-    assert teams == []
+    assert players.empty and teams.empty
 
 
 @pytest.mark.asyncio
@@ -349,3 +348,36 @@ async def test_upsert_rankings_averages_preserves_tie_fraction(db_service, monke
     assert params[4] == 6.5
     assert params[-1] == 52.0
     assert isinstance(params[-1], float)
+
+
+class _FakeRecord(tuple):
+    """Mimics asyncpg.Record: a tuple of values that also exposes .keys()."""
+
+    def __new__(cls, mapping):
+        obj = super().__new__(cls, mapping.values())
+        obj._k = list(mapping)
+        return obj
+
+    def keys(self):
+        return self._k
+
+
+def test_fs_records_to_frame_reads_asyncpg_rows_without_dicts():
+    """Built straight from the records (a dict per row costs ~80 MB on a full
+    history), so it must work on Record objects, not just mappings."""
+    from app.services.db_service import fs_records_to_frame
+
+    df = fs_records_to_frame([
+        _FakeRecord({"player_id": 1, "game_date": date(2026, 1, 5), "min": 31.5}),
+        _FakeRecord({"player_id": 2, "game_date": date(2026, 1, 6), "min": 8.0}),
+    ])
+
+    assert list(df.columns) == ["PLAYER_ID", "GAME_DATE", "MIN"]   # uppercased
+    assert str(df["GAME_DATE"].dtype).startswith("datetime64")     # date -> Timestamp
+    assert df["MIN"].tolist() == [31.5, 8.0]
+
+
+def test_fs_records_to_frame_handles_no_rows():
+    from app.services.db_service import fs_records_to_frame
+
+    assert fs_records_to_frame([]).empty

--- a/backend/tests/services/test_model_nightly_service.py
+++ b/backend/tests/services/test_model_nightly_service.py
@@ -28,8 +28,8 @@ class FakeDB:
     def __init__(self):
         self.run = None
         self.has_date = False
-        self.player_recs = [{"player_id": 1}]
-        self.team_recs = [{"team_id": 10}]
+        self.player_recs = pd.DataFrame([{"PLAYER_ID": 1}])
+        self.team_recs = pd.DataFrame([{"TEAM_ID": 10}])
         self.eval_insert_ok = True
         self.fs_insert_ok = True
         self.vec_insert_ok = True
@@ -113,7 +113,7 @@ def service(monkeypatch):
     )
     # Never build a real store from the fake records in unit tests.
     monkeypatch.setattr(
-        ModelNightlyService, "_vectors_from_records",
+        ModelNightlyService, "_vectors_from_frames",
         staticmethod(lambda p, t: ([], [], [])),
     )
     yield svc
@@ -176,7 +176,7 @@ async def test_incomplete_data_left_unmarked_for_retry(service, monkeypatch):
 @pytest.mark.asyncio
 async def test_empty_store_requires_bootstrap(service, monkeypatch):
     _allow_fetch(monkeypatch, _night())
-    service._db.player_recs = []
+    service._db.player_recs = pd.DataFrame()
     assert await service.run_for_date(GAME_DATE) == "store_not_bootstrapped"
 
 
@@ -418,7 +418,7 @@ async def test_drift_rebuild_without_raw_rows_is_skipped_not_failed(service, mon
     """Tri-state: "nothing to write" must not be reported as a write failure."""
     union, _ = _real_stored_keys()
     service._db.vector_feature_keys = union - {"USG_w10_mean"}
-    service._db.player_recs = []                # store not bootstrapped
+    service._db.player_recs = pd.DataFrame()    # store not bootstrapped
     _allow_fetch(monkeypatch, _night(expected_games=0))
 
     statuses = await service.run_catchup()

--- a/backend/tests/services/test_model_nightly_service.py
+++ b/backend/tests/services/test_model_nightly_service.py
@@ -266,7 +266,7 @@ def test_vector_serialize_roundtrip():
     assert json.loads(prows[1][7])["PTS_global_mean"] is None
 
 
-# --- feature drift: self-healing rebuild after a deploy ---------------------
+# --- missing features: healing the store after a deploy --------------------
 
 
 def _real_stored_keys() -> tuple[set[str], set[str]]:
@@ -294,6 +294,12 @@ def _real_stored_keys() -> tuple[set[str], set[str]]:
     return player | team, player
 
 
+def _auto_heal(monkeypatch, enabled=True):
+    """MODEL_FEATURE_HEAL_AUTO defaults to off, so tests that exercise the
+    rebuild have to opt in."""
+    monkeypatch.setattr(mns.settings, "model_feature_heal_auto", enabled)
+
+
 def _count_refreshes(monkeypatch) -> list:
     """Record every _refresh_vectors_through call while keeping real behaviour."""
     calls = []
@@ -318,7 +324,7 @@ def test_required_stored_features_excludes_request_time_ones():
 
 
 def test_every_required_feature_is_produced_by_some_vector_table():
-    """The drift check must compare against all three tables, not just the player one.
+    """The check must compare against all three tables, not just the player one.
 
     A model's feature row is composed from the player vector plus the OPP_ALLOWED_*
     and TEAM_* team vectors, so checking `fs_player_vectors` alone reports the team
@@ -339,21 +345,22 @@ def test_every_required_feature_is_produced_by_some_vector_table():
 
 
 @pytest.mark.asyncio
-async def test_no_drift_when_store_matches_the_deployed_models(service, monkeypatch):
+async def test_no_rebuild_when_store_matches_the_deployed_models(service, monkeypatch):
     """The realistic case: a store built by the real engine needs no rebuild."""
     service._db.vector_feature_keys, _ = _real_stored_keys()
     _allow_fetch(monkeypatch, _night(expected_games=0))
     calls = _count_refreshes(monkeypatch)
 
     statuses = await service.run_catchup()
-    assert "feature_drift" not in statuses
+    assert "missing_features" not in statuses
     assert calls == []
     assert service._db.vectors_written is None
 
 
 @pytest.mark.asyncio
-async def test_feature_drift_rebuilds_vectors_exactly_once(service, monkeypatch):
+async def test_missing_features_rebuild_vectors_exactly_once(service, monkeypatch):
     """A deploy that adds a feature heals on the next run — and only that run."""
+    _auto_heal(monkeypatch)
     union, _ = _real_stored_keys()
     service._db.vector_feature_keys = union - {"USG_w10_mean"}   # store predates the deploy
     service._db.keys_after_upsert = union                        # the rebuild lands
@@ -363,21 +370,22 @@ async def test_feature_drift_rebuilds_vectors_exactly_once(service, monkeypatch)
     calls = _count_refreshes(monkeypatch)
 
     statuses = await service.run_catchup()
-    assert statuses["feature_drift"] == "vectors_refreshed"
+    assert statuses["missing_features"] == "vectors_refreshed"
     assert len(calls) == 1
     assert service._db.vectors_written is not None
 
     # The stored keys now match, so the next morning is a no-op — no second rebuild.
     service._db.vectors_written = None
     statuses = await service.run_catchup()
-    assert "feature_drift" not in statuses
+    assert "missing_features" not in statuses
     assert len(calls) == 1                       # still one — no second rebuild
     assert service._db.vectors_written is None
 
 
 @pytest.mark.asyncio
-async def test_drift_that_survives_the_rebuild_escalates(service, monkeypatch):
+async def test_missing_features_that_survive_the_rebuild_escalate(service, monkeypatch):
     """A feature the engine cannot produce must be reported, not retried forever."""
+    _auto_heal(monkeypatch)
     union, _ = _real_stored_keys()
     service._db.vector_feature_keys = union - {"USG_w10_mean"}
     # The rebuild "succeeds" but the keys never change (stale feature set / renamed
@@ -386,40 +394,62 @@ async def test_drift_that_survives_the_rebuild_escalates(service, monkeypatch):
     calls = _count_refreshes(monkeypatch)
 
     statuses = await service.run_catchup()
-    assert statuses["feature_drift"] == "vectors_refresh_incomplete"
+    assert statuses["missing_features"] == "vectors_refresh_incomplete"
     assert len(calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_drift_check_skipped_before_bootstrap(service, monkeypatch):
+async def test_missing_feature_check_skipped_before_bootstrap(service, monkeypatch):
     # No vectors materialized yet -> nothing to heal; bootstrap owns that case.
     service._db.vector_feature_keys = None
     _allow_fetch(monkeypatch, _night(expected_games=0))
     calls = _count_refreshes(monkeypatch)
 
     statuses = await service.run_catchup()
-    assert "feature_drift" not in statuses
+    assert "missing_features" not in statuses
     assert calls == []
 
 
 @pytest.mark.asyncio
-async def test_failed_drift_rebuild_is_reported(service, monkeypatch):
+async def test_failed_rebuild_is_reported(service, monkeypatch):
+    _auto_heal(monkeypatch)
     union, _ = _real_stored_keys()
     service._db.vector_feature_keys = union - {"USG_w10_mean"}
     service._db.vec_insert_ok = False           # upsert fails
     _allow_fetch(monkeypatch, _night(expected_games=0))
 
     statuses = await service.run_catchup()
-    assert statuses["feature_drift"] == "vectors_refresh_failed"
+    assert statuses["missing_features"] == "vectors_refresh_failed"
 
 
 @pytest.mark.asyncio
-async def test_drift_rebuild_without_raw_rows_is_skipped_not_failed(service, monkeypatch):
+async def test_rebuild_without_raw_rows_is_skipped_not_failed(service, monkeypatch):
     """Tri-state: "nothing to write" must not be reported as a write failure."""
+    _auto_heal(monkeypatch)
     union, _ = _real_stored_keys()
     service._db.vector_feature_keys = union - {"USG_w10_mean"}
     service._db.player_recs = pd.DataFrame()    # store not bootstrapped
     _allow_fetch(monkeypatch, _night(expected_games=0))
 
     statuses = await service.run_catchup()
-    assert statuses["feature_drift"] == "vectors_refresh_skipped"
+    assert statuses["missing_features"] == "vectors_refresh_skipped"
+
+
+@pytest.mark.asyncio
+async def test_missing_features_reported_not_rebuilt_when_auto_heal_is_off(service, monkeypatch):
+    """Default mode: detect and say what to run, but never rebuild.
+
+    The rebuild needs ~380 MB, which a small container cannot spare mid-flight —
+    it gets OOM-killed before the upsert lands, so the gap survives and every
+    later run tries again. Detection is three queries and stays on.
+    """
+    union, _ = _real_stored_keys()
+    service._db.vector_feature_keys = union - {"USG_w10_mean"}
+    _auto_heal(monkeypatch, enabled=False)
+    _allow_fetch(monkeypatch, _night(expected_games=0))
+    calls = _count_refreshes(monkeypatch)
+
+    statuses = await service.run_catchup()
+    assert statuses["missing_features"] == "manual_refresh_required"
+    assert calls == []                              # nothing rebuilt
+    assert service._db.vectors_written is None      # store untouched


### PR DESCRIPTION
## The incident

The feature check from #147 turned an off-season no-op into a full vector rebuild, which does not fit in the container. It was OOM-killed at **every one of the five morning slots**:

```
06:00:00  Model nightly scheduler triggered
06:00:01  WARNING ... missing 3 feature(s) (USG_global_mean, USG_w10_mean, USG_w5_mean) — rebuilding all vectors
06:00:58  Starting Fantasy League Dashboard API on port 8000     ← process restarted
```

The kill lands *before* the upsert, so the keys never gain `USG_*` → the next slot sees the same gap → rebuilds → dies. **A crash loop that cannot self-resolve.**

## 1. The rebuild is now opt-in — `MODEL_FEATURE_HEAL_AUTO`

Detection and remediation are separated. The check always runs (three `LIMIT 1` queries); rebuilding is a flag:

| `MODEL_FEATURE_HEAL_AUTO` | behaviour |
|---|---|
| **`false` (default)** | logs which features are missing **and the exact command to run**, leaves the store alone. Status `manual_refresh_required`. |
| `true` | rebuilds all vectors once, like an init. Status `vectors_refreshed`. |

This keeps the useful half — you still find out in the logs the morning after a deploy — without the half that takes the process down. **On the current free tier this stays off and rebuilds are manual**, which is fine: a feature change happens once in a long while, not nightly.

## 2. Memory cut anyway, for when it does run

**Batch the player vectors.** `build_current_state` allocated one full-length array per feature for the whole league at once. Every player feature is derived within a `PLAYER_ID` group, so batching is **exact** — verified byte-identical to one-shot across every float column. Batches of 100 players (`PLAYER_VECTOR_CHUNK`), extracted into `_player_vectors()`.

**Skip the dict materialization.** `get_fs_rows_before` built a dict per row before converting to a frame — ~80 MB of transient peak on a 96k-row history, for nothing, since asyncpg records already hold boxed values. It now returns frames via `fs_records_to_frame()`. `_records_to_frame` moves into the DB layer (it couldn't live in `model_nightly_service`, which imports `db_service`), and `_vectors_from_records` collapses into `_vectors_from_frames` — after the change they were the same function.

| | peak |
|---|---|
| original | 664 MB |
| + batched build | 466 MB |
| + no dicts | **444 MB** (~380 MB realistic) |

Measured locally with a simulation that also holds a 63 MB parquet frame production won't. The batching figure is trustworthy (identical code path); the dict figure was measured in isolation. An earlier draft of this PR claimed ~175 MB for the dicts — that was wrong, from a profile that used `to_dict("records")`, which also boxes numpy scalars.

## 3. Renamed "drift" → "missing features"

"Drift" already means something else in ML — data/concept drift, the input distribution shifting over time. This check is a code-vs-data version mismatch: the stored vectors lack features the deployed models ask for. Status key `feature_drift` → `missing_features`.

## No database change

Same query, same rows, same resulting frame. Nothing written, nothing migrated.

## Verified

- **457 tests pass**, including a new one asserting the default mode detects and reports but never rebuilds.
- `fs_records_to_frame` is tested against a **Record-like object** (tuple + `.keys()`), not a mapping — a dict-only implementation would pass tests and fail in production.
- The manual path was run end-to-end on real data: `_vectors_from_frames` over 97,389 player-games / 9,840 team-games → 859 player + 30 + 30 vectors in **4.4 s**, and the serialized JSON carries `USG_w5_mean` / `USG_w10_mean` / `USG_global_mean` with plausible values.

## How to rebuild the vectors

```bash
cd backend      # required: pydantic loads .env (SEASON_ID, LEAGUE_ID) relative to the CWD
uv run python scripts/refresh_feature_vectors.py \
    --database-url postgresql://<user>:<pass>@<host>:5432/<db> \
    --expect-feature USG_w10_mean
```

`DATABASE_URL` is the only variable you supply. The feature engineering runs **wherever the script runs**, not in the database — so run it from your laptop against the server DB and the container's memory limit never enters into it. Non-destructive: reads `fs_player_games`/`fs_team_games`, rebuilds, upserts; no ESPN re-fetch, nothing truncated, safe to re-run.

Verify:

```sql
SELECT player_id, features->>'USG_w10_mean' FROM fs_player_vectors LIMIT 5;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)