### PR TITLE
Persist user display preferences to localStorage

### DIFF
--- a/frontend/src/hooks/usePersistedState.ts
+++ b/frontend/src/hooks/usePersistedState.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect, type Dispatch, type SetStateAction } from 'react';
+
+const PREFIX = 'fw:';
+
+function readStorage<T>(key: string, defaultValue: T): T {
+  try {
+    const raw = localStorage.getItem(PREFIX + key);
+    return raw === null ? defaultValue : (JSON.parse(raw) as T);
+  } catch {
+    return defaultValue;
+  }
+}
+
+function writeStorage<T>(key: string, value: T): void {
+  try {
+    localStorage.setItem(PREFIX + key, JSON.stringify(value));
+  } catch {
+    // private browsing / quota exceeded — persistence is best-effort
+  }
+}
+
+/**
+ * Like useState, but the value is read from localStorage on mount and
+ * written back on every change. Falls back to defaultValue when storage
+ * is unavailable or corrupted.
+ */
+export function usePersistedState<T>(
+  key: string,
+  defaultValue: T
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() => readStorage(key, defaultValue));
+
+  useEffect(() => {
+    writeStorage(key, value);
+  }, [key, value]);
+
+  return [value, setValue];
+}
+
+/**
+ * Set<T> variant of usePersistedState — Sets don't survive JSON.stringify,
+ * so this stores/reads them as arrays under the hood.
+ */
+export function usePersistedSetState<T>(
+  key: string,
+  defaultValue: Set<T>
+): [Set<T>, Dispatch<SetStateAction<Set<T>>>] {
+  const [value, setValue] = useState<Set<T>>(
+    () => new Set(readStorage<T[]>(key, [...defaultValue]))
+  );
+
+  useEffect(() => {
+    writeStorage(key, [...value]);
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/frontend/src/pages/DraftReport.tsx
+++ b/frontend/src/pages/DraftReport.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useRef } from 'react'
+import { usePersistedState } from '../hooks/usePersistedState'
 import { useGetDraftReportQuery, useGetAllPlayersQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
@@ -36,8 +37,8 @@ function heatColor(p: ScoredPick): string {
 }
 
 export default function DraftReport() {
-  const [calcMode, setCalcMode] = useState<'totals' | 'per_game'>('per_game')
-  const [includeLowGp, setIncludeLowGp] = useState(false)
+  const [calcMode, setCalcMode] = usePersistedState<'totals' | 'per_game'>('draftReport.calcMode', 'per_game')
+  const [includeLowGp, setIncludeLowGp] = usePersistedState('draftReport.includeLowGp', false)
   const minGp = includeLowGp ? LOW_GP_MIN : MIN_GP_FOR_RANK
   const { data: draftReport, isLoading: draftLoading, error: draftError } = useGetDraftReportQuery()
   // Same pool Player Rankings uses (season, full ESPN universe) — keeps the

--- a/frontend/src/pages/NbaTeams.tsx
+++ b/frontend/src/pages/NbaTeams.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { usePersistedState, usePersistedSetState } from '../hooks/usePersistedState';
 import { useGetNbaTeamsListQuery, useGetNbaTeamDepthChartQuery } from '../store/api/fantasyApi';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorMessage from '../components/ErrorMessage';
@@ -95,8 +96,8 @@ function FilterCheckbox({
 
 function DepthChartView({ teamId }: { teamId: string }) {
   const { data, isLoading, error } = useGetNbaTeamDepthChartQuery(teamId);
-  const [excludedStatuses, setExcludedStatuses] = useState<Set<string>>(new Set());
-  const [removeDuplicates, setRemoveDuplicates] = useState(false);
+  const [excludedStatuses, setExcludedStatuses] = usePersistedSetState<string>(`nbaTeams.${teamId}.excludedStatuses`, new Set());
+  const [removeDuplicates, setRemoveDuplicates] = usePersistedState(`nbaTeams.${teamId}.removeDuplicates`, false);
 
   if (isLoading) return <LoadingSpinner />;
   if (error) return <ErrorMessage message="Failed to load depth chart" />;

--- a/frontend/src/pages/PlayerRankings.tsx
+++ b/frontend/src/pages/PlayerRankings.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useEffect, useTransition } from 'react'
+import { usePersistedState } from '../hooks/usePersistedState'
 import { useGetAllPlayersQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
@@ -45,12 +46,12 @@ export default function PlayerRankings() {
     [allPlayers]
   )
 
-  const [calcMode, setCalcMode] = useState<'totals' | 'per_game'>('per_game')
-  const [displayMode, setDisplayMode] = useState<'totals' | 'per_game'>('per_game')
-  const [minGp, setMinGp] = useState(0)
-  const [minMin, setMinMin] = useState(0)
-  const [position, setPosition] = useState<string | null>(null)
-  const [weights, setWeights] = useState<Record<RankingCategory, number>>({ ...DEFAULT_WEIGHTS })
+  const [calcMode, setCalcMode] = usePersistedState<'totals' | 'per_game'>('playerRankings.calcMode', 'per_game')
+  const [displayMode, setDisplayMode] = usePersistedState<'totals' | 'per_game'>('playerRankings.displayMode', 'per_game')
+  const [minGp, setMinGp] = usePersistedState('playerRankings.minGp', 0)
+  const [minMin, setMinMin] = usePersistedState('playerRankings.minMin', 0)
+  const [position, setPosition] = usePersistedState<string | null>('playerRankings.position', null)
+  const [weights, setWeights] = usePersistedState<Record<RankingCategory, number>>('playerRankings.weights', { ...DEFAULT_WEIGHTS })
   const [displayLimit, setDisplayLimit] = useState<number | null>(null)
   const [sliderResetKey, setSliderResetKey] = useState(0)
   const [sortCol, setSortCol] = useState<SortCol>('totalZ')

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { usePersistedState } from '../hooks/usePersistedState';
 import { useGetAllPlayersQuery, useGetTeamsListQuery } from '../store/api/fantasyApi';
 import { useGetMatchupsTodayQuery, useGetMatchupDatesQuery, useGetUpcomingDatesQuery, useGetCurrentSlateDateQuery } from '../store/api/fantasyApi';
 import type { PlayerFilters, Player, StatFilter, TimePeriod, ComparisonOperator, PlayerStats, CustomDateRange } from '../types/api';
@@ -12,10 +13,10 @@ import './Players.css';
 
 const Players = () => {
   const [filters, setFilters] = useState<PlayerFilters>({});
-  const [showAverages, setShowAverages] = useState(true);
+  const [showAverages, setShowAverages] = usePersistedState('players.showAverages', true);
   const [timePeriod, setTimePeriod] = useState<TimePeriod>('season');
   const [customRange, setCustomRange] = useState<CustomDateRange | null>(null);
-  const [integerMode, setIntegerMode] = useState(true);
+  const [integerMode, setIntegerMode] = usePersistedState('players.integerMode', true);
 
   const { data, isLoading, error } = useGetAllPlayersQuery({
     page: 1,

--- a/frontend/src/pages/Projections.tsx
+++ b/frontend/src/pages/Projections.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePersistedState } from '../hooks/usePersistedState';
 import { useGetMatchupsTodayQuery, useGetMatchupDatesQuery, useGetUpcomingDatesQuery, useGetCurrentSlateDateQuery, usePredictProjectionMutation, useGetAllPlayersQuery, useGetTeamsListQuery } from '../store/api/fantasyApi';
 import { FF_PAST_SLATES } from '../config/featureFlags';
 import type { PlayerMatchup, ProjectionStats } from '../types/api';
@@ -149,7 +150,7 @@ export default function Projections() {
   const { data: matchups = [], isLoading, error } = useGetMatchupsTodayQuery(
     slateDate ? slateDate.replaceAll('-', '') : undefined
   );
-  const [integerMode, setIntegerMode] = useState(true);
+  const [integerMode, setIntegerMode] = usePersistedState('projections.integerMode', true);
   const [search, setSearch] = useState('');
   const [nbaTeam, setNbaTeam] = useState('');
   const [fantasyTeamId, setFantasyTeamId] = useState('');

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate } from 'react-router'
 import { useState, useMemo, useEffect } from 'react'
 import React from 'react'
+import { usePersistedState } from '../hooks/usePersistedState'
 import { useGetTeamDetailQuery, useGetLeagueSummaryQuery, useGetMatchupsTodayQuery } from '../store/api/fantasyApi'
 import type { TimePeriod, PlayerMatchup, CustomDateRange } from '../types/api'
 import LoadingSpinner from '../components/LoadingSpinner'
@@ -38,8 +39,8 @@ const TeamDetail = () => {
   }, [timePeriod, customRange, team_detail])
   const [sortBy, setSortBy] = useState<string | null>(null)
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
-  const [showAverages, setShowAverages] = useState(true)
-  const [integerMode, setIntegerMode] = useState(true)
+  const [showAverages, setShowAverages] = usePersistedState('teamDetail.showAverages', true)
+  const [integerMode, setIntegerMode] = usePersistedState('teamDetail.integerMode', true)
   const [includedPlayers, setIncludedPlayers] = useState<Set<string> | null>(null)
   const { data: liveMatchups = [] } = useGetMatchupsTodayQuery(undefined, { skip: !FF_MATCHUP_QUALITY })
   const matchupMap = useMemo(() => {

--- a/frontend/src/pages/TradeSuggestions/index.tsx
+++ b/frontend/src/pages/TradeSuggestions/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { usePersistedState } from '../../hooks/usePersistedState';
 import { TeamSelector } from './components/TeamSelector';
 import { TradeSuggestionCard } from './components/TradeSuggestionCard';
 import { useGetTradeSuggestionsQuery } from '../../store/api/fantasyApi';
@@ -31,7 +32,7 @@ const getErrorMessage = (error: unknown): string => {
 
 export const TradeSuggestions: React.FC = () => {
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
-  const [viewMode, setViewMode] = useState<ViewMode>('totals');
+  const [viewMode, setViewMode] = usePersistedState<ViewMode>('tradeSuggestions.viewMode', 'totals');
   const [shouldFetch, setShouldFetch] = useState<boolean>(false);
 
   const {

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useMemo, useState } from 'react'
+import { usePersistedState } from '../hooks/usePersistedState'
 import {
   useGetTrendsMinutesQuery,
   useGetTrendsUsageQuery,
@@ -558,14 +559,14 @@ export default function Trends() {
   const [tab, setTab] = useState<TabKey>('minutes')
   const [nameFilter, setNameFilter] = useState('')
   const [position, setPosition] = useState<string | null>(null)
-  const [windowDays, setWindowDays] = useState<number>(15)
-  const [minGames, setMinGames] = useState(3)
-  const [ownership, setOwnership] = useState<Ownership>('all')
+  const [windowDays, setWindowDays] = usePersistedState<number>('trends.windowDays', 15)
+  const [minGames, setMinGames] = usePersistedState('trends.minGames', 3)
+  const [ownership, setOwnership] = usePersistedState<Ownership>('trends.ownership', 'all')
   const [fantasyTeam, setFantasyTeam] = useState<string | null>(null)
   // one remembered choice per tab: "prior 2 seasons" is the right default when
   // judging a season line, "this season" when judging current form
-  const [seasonBaseline, setSeasonBaseline] = useState(2)
-  const [formBaseline, setFormBaseline] = useState(0)
+  const [seasonBaseline, setSeasonBaseline] = usePersistedState('trends.seasonBaseline', 2)
+  const [formBaseline, setFormBaseline] = usePersistedState('trends.formBaseline', 0)
 
   const regressionMode = TAB_MODE[tab]
   const isShooting = regressionMode !== undefined

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,6 +4,7 @@ import { cleanup } from '@testing-library/react';
 
 afterEach(() => {
   cleanup();
+  localStorage.clear();
 });
 
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
## Summary
- Step 1 of the user-data/login strategy: no accounts, no backend changes — just remembering per-browser display preferences that currently reset every visit.
- Adds `usePersistedState`/`usePersistedSetState` hooks (`frontend/src/hooks/usePersistedState.ts`) that wrap `useState` with a `localStorage`-backed read on mount and write-through on change, namespaced under `fw:` keys, with try/catch fallbacks for private browsing / quota errors.
- Wires these into 9 pages, persisting only standing preferences (calc modes, display toggles, ranker weights, filter thresholds) — not view-of-the-moment state like sort column, search text, or date ranges:
  - `PlayerRankings.tsx` — category weights, calc/display mode, min GP/MIN, position filter
  - `Players.tsx`, `TeamDetail.tsx` — show-averages / integer-mode toggles
  - `NbaTeams.tsx` — excluded injury statuses and dedupe toggle, **keyed per team** so switching teams still starts fresh
  - `DraftReport.tsx` — calc mode, include-low-GP toggle
  - `Trends.tsx` — window days, min games, ownership filter, season/form baseline
  - `Projections.tsx` — integer mode
  - `TradeSuggestions/index.tsx` — view mode
- Added `localStorage.clear()` to the shared test `afterEach` (`frontend/src/test/setup.ts`) — without it, persisted state leaks between test cases within the same file (caught this via a real `NbaTeams.test.tsx` failure).

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 17 files / 114 passed, 3 skipped (same skip count as before)
- [x] `npm run lint` — same 3 pre-existing errors/2 warnings as on `dev` (verified via `git stash`), none introduced by this change
- [x] Manually traced NbaTeams test failure to cross-test localStorage leakage and fixed at the shared setup level rather than papering over it


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJcdBYLCs1NEHYuppMGoFv)_