### PR TITLE
feat(teams): rate, max and estimated games per roster slot

### DIFF
--- a/backend/app/services/data_transformer.py
+++ b/backend/app/services/data_transformer.py
@@ -9,7 +9,8 @@ from app.config import settings
 
 
 SLOT_MAP = {0: 'PG', 1: 'SG', 2: 'SF', 3: 'PF', 4: 'C', 5: 'G', 6: 'F', 11: 'UTIL'}
-SLOT_CAPS = {'PG': 82, 'SG': 82, 'SF': 82, 'PF': 82, 'C': 82, 'G': 82, 'F': 82, 'UTIL': 246}
+# UTIL is three roster slots plus two spare games (3 * 82 + 2).
+SLOT_CAPS = {'PG': 82, 'SG': 82, 'SF': 82, 'PF': 82, 'C': 82, 'G': 82, 'F': 82, 'UTIL': 248}
 
 
 class DataTransformer:

--- a/frontend/src/components/SlotUsageTable.tsx
+++ b/frontend/src/components/SlotUsageTable.tsx
@@ -1,0 +1,183 @@
+import type { SlotUsage } from '../types/api'
+import {
+  SLOT_NAMES,
+  TONE_CLASS,
+  canColor,
+  estimatedTone,
+  formatCap,
+  formatRateDelta,
+  formatSlotNumber,
+  maxTone,
+  projectSlot,
+  rateTone,
+  type PaceContext,
+} from '../utils/slotProjection'
+
+interface SlotUsageTableProps {
+  slotUsage: Record<string, SlotUsage>
+  avgPace?: number | null
+  gameDaysLeft?: number | null
+}
+
+const ROW_LABELS = {
+  rate: 'Rate',
+  max: 'Max',
+  estimated: 'Est.',
+} as const
+
+function LegendSwatch({ className, label }: { className: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className={`w-3 h-3 rounded-sm inline-block ${className}`} />
+      <span>{label}</span>
+    </span>
+  )
+}
+
+export default function SlotUsageTable({ slotUsage, avgPace, gameDaysLeft }: SlotUsageTableProps) {
+  const pace: PaceContext = { avgPace, gameDaysLeft }
+  const colored = canColor(pace)
+
+  const columns = SLOT_NAMES.map(slot => {
+    const usage = slotUsage[slot]
+    return { slot, usage, projection: usage ? projectSlot(usage.games_used, slot, pace) : null }
+  })
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-4 mb-4">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Slot Usage</h2>
+          <p className="text-xs text-gray-500 mt-1">
+            Rate is per slot vs the NBA rate. Max and Est. cover the whole column — UTIL is 3
+            slots, cap (246+2).
+          </p>
+        </div>
+        <div className="text-xs text-gray-500 space-y-1 sm:text-right">
+          {typeof avgPace === 'number' && (
+            <div>
+              NBA avg: <span className="font-medium text-gray-700">{avgPace.toFixed(1)} GP/team</span>
+              {typeof gameDaysLeft === 'number' && (
+                <span> · <span className="font-medium text-gray-700">{gameDaysLeft}</span> game days left</span>
+              )}
+            </div>
+          )}
+          {!colored && (
+            <div className="text-gray-400">Too early to judge pace — colors start above 10 GP/team.</div>
+          )}
+        </div>
+      </div>
+
+      {colored && (
+        <div className="space-y-1 text-xs text-gray-600 mb-4">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="font-semibold text-gray-500 w-10">Rate</span>
+            <LegendSwatch className="bg-green-100" label="within 5%" />
+            <LegendSwatch className="bg-yellow-100" label="5–10% off" />
+            <LegendSwatch className="bg-orange-100" label="10–15% off" />
+            <LegendSwatch className="bg-red-100" label="15%+ off" />
+            <span className="text-gray-400">games ahead of / behind the NBA rate</span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="font-semibold text-gray-500 w-10">Max</span>
+            <LegendSwatch className="bg-green-100" label="full season still reachable" />
+            <LegendSwatch className="bg-red-100" label="no longer reachable" />
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="font-semibold text-gray-500 w-10">Est.</span>
+            <LegendSwatch className="bg-green-100" label="82+ per slot" />
+            <LegendSwatch className="bg-yellow-100" label="80–82" />
+            <LegendSwatch className="bg-orange-100" label="78–80" />
+            <LegendSwatch className="bg-red-100" label="under 78" />
+          </div>
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse">
+          <thead>
+            <tr>
+              <th className="px-3 py-2 text-left text-xs font-semibold text-gray-500 uppercase border border-gray-200 bg-gray-50" />
+              {columns.map(({ slot }) => (
+                <th
+                  key={slot}
+                  className="px-4 py-2 text-center text-xs font-semibold text-gray-500 uppercase border border-gray-200 bg-gray-50"
+                >
+                  {slot}
+                  {slot === 'UTIL' && (
+                    <div className="text-gray-400 font-normal normal-case">×3 slots</div>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th className="px-3 py-3 text-left text-xs font-semibold text-gray-600 border border-gray-200 bg-gray-50 whitespace-nowrap">
+                {ROW_LABELS.rate}
+                <div className="font-normal text-gray-400 normal-case">used · vs NBA rate</div>
+              </th>
+              {columns.map(({ slot, projection }) => {
+                if (!projection) return <EmptyCell key={slot} />
+                const tone = rateTone(projection.rate, pace)
+                return (
+                  <td
+                    key={slot}
+                    className={`px-4 py-3 text-center text-sm font-medium border border-gray-200 ${TONE_CLASS[tone]}`}
+                  >
+                    <div>{formatSlotNumber(projection.used)}</div>
+                    <div className="text-xs font-normal opacity-80">
+                      {formatRateDelta(projection.used, avgPace)}
+                    </div>
+                  </td>
+                )
+              })}
+            </tr>
+            <tr>
+              <th className="px-3 py-3 text-left text-xs font-semibold text-gray-600 border border-gray-200 bg-gray-50 whitespace-nowrap">
+                {ROW_LABELS.max}
+                <div className="font-normal text-gray-400 normal-case">most still reachable</div>
+              </th>
+              {columns.map(({ slot, projection }) => {
+                if (!projection) return <EmptyCell key={slot} />
+                const tone = maxTone(projection.maxGamesTotal, slot, pace)
+                return (
+                  <td
+                    key={slot}
+                    className={`px-4 py-3 text-center text-sm font-medium border border-gray-200 ${TONE_CLASS[tone]}`}
+                  >
+                    {formatSlotNumber(projection.maxGamesTotal)}
+                    <span className="opacity-50">/{formatCap(slot)}</span>
+                  </td>
+                )
+              })}
+            </tr>
+            <tr>
+              <th className="px-3 py-3 text-left text-xs font-semibold text-gray-600 border border-gray-200 bg-gray-50 whitespace-nowrap">
+                {ROW_LABELS.estimated}
+                <div className="font-normal text-gray-400 normal-case">projected finish</div>
+              </th>
+              {columns.map(({ slot, projection }) => {
+                if (!projection) return <EmptyCell key={slot} />
+                const tone = estimatedTone(projection.estimatedRounded, slot, pace)
+                return (
+                  <td
+                    key={slot}
+                    className={`px-4 py-3 text-center text-sm font-medium border border-gray-200 ${TONE_CLASS[tone]}`}
+                  >
+                    {formatSlotNumber(projection.estimatedRounded)}
+                    <span className="opacity-50">/{formatCap(slot)}</span>
+                  </td>
+                )
+              })}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function EmptyCell() {
+  return <td className="px-4 py-3 text-center text-gray-400 border border-gray-200">-</td>
+}

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -12,6 +12,7 @@ import DataDateBadge from '../components/DataDateBadge'
 import { aggregatePlayerAverages } from '../utils/statsUtils'
 import { MatchupCell, MatchupExpandRow } from '../components/MatchupDisplay'
 import InjuryBadge from '../components/InjuryBadge'
+import SlotUsageTable from '../components/SlotUsageTable'
 import { FF_MATCHUP_QUALITY, FF_PROJECTIONS } from '../config/featureFlags'
 
 const TeamDetail = () => {
@@ -354,58 +355,11 @@ const TeamDetail = () => {
         </div>
       </div>
       {team_detail.slot_usage && Object.keys(team_detail.slot_usage).length > 0 && (
-        <div className="bg-white rounded-lg shadow p-6">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-4 mb-4">
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
-              <h2 className="text-2xl font-bold text-gray-900">Slot Usage</h2>
-              <p className="text-xs text-gray-500 flex items-center gap-2 flex-wrap">
-                <span>*</span>
-                <span className="inline-flex items-center gap-1"><span className="w-3 h-3 rounded-sm bg-red-200 inline-block"></span><span className="text-red-700">5%+ out of pace (above or below)</span></span>
-                <span className="inline-flex items-center gap-1"><span className="w-3 h-3 rounded-sm bg-gray-200 inline-block"></span><span className="text-gray-600">within range</span></span>
-              </p>
-            </div>
-            {leagueSummary?.nba_avg_pace && (
-              <span className="text-xs text-gray-500">NBA avg: <span className="font-medium text-gray-700">{leagueSummary.nba_avg_pace.toFixed(1)} GP/team</span></span>
-            )}
-          </div>
-          <div className="overflow-x-auto">
-            <table className="min-w-full border-collapse">
-              <thead>
-                <tr>
-                  {(['PG', 'SG', 'SF', 'PF', 'C', 'G', 'F', 'UTIL'] as const).map(slot => (
-                    <th key={slot} className="px-4 py-2 text-center text-xs font-semibold text-gray-500 uppercase border border-gray-200 bg-gray-50">
-                      {slot}
-                      {slot === 'UTIL' && <div className="text-gray-400 font-normal normal-case">per slot in ()</div>}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  {(['PG', 'SG', 'SF', 'PF', 'C', 'G', 'F', 'UTIL'] as const).map(slot => {
-                    const usage = team_detail.slot_usage[slot]
-                    if (!usage) return <td key={slot} className="px-4 py-3 text-center border border-gray-200">-</td>
-                    const nbaAvg = leagueSummary?.nba_avg_pace ?? null
-                    let cellClass = 'bg-gray-100 text-gray-800'
-                    if (nbaAvg && nbaAvg > 0) {
-                      const effective = slot === 'UTIL' ? usage.games_used / 3 : usage.games_used
-                      const deviation = Math.abs((effective - nbaAvg) / nbaAvg)
-                      if (deviation >= 0.05) cellClass = 'bg-red-100 text-red-800'
-                      else cellClass = 'bg-gray-100 text-gray-700'
-                    }
-                    const perSlotVal = usage.games_used / 3
-                    const perSlot = slot === 'UTIL' ? ` (${Number.isInteger(perSlotVal) ? perSlotVal : perSlotVal.toFixed(1)}/82)` : ''
-                    return (
-                      <td key={slot} className={`px-4 py-3 text-center text-sm font-medium border border-gray-200 ${cellClass}`}>
-                        {usage.games_used}/{usage.cap}{perSlot}
-                      </td>
-                    )
-                  })}
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <SlotUsageTable
+          slotUsage={team_detail.slot_usage}
+          avgPace={leagueSummary?.nba_avg_pace}
+          gameDaysLeft={leagueSummary?.nba_game_days_left}
+        />
       )}
 
       <div className="bg-white rounded-lg shadow p-6">

--- a/frontend/src/utils/__tests__/slotProjection.test.ts
+++ b/frontend/src/utils/__tests__/slotProjection.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest'
+import {
+  projectSlot,
+  rateTone,
+  formatRateDelta,
+  maxTone,
+  estimatedTone,
+  canColor,
+  formatCap,
+  formatSlotNumber,
+  slotCeiling,
+  SLOT_CAPS,
+  GAMES_PER_SLOT,
+} from '../slotProjection'
+
+const midSeason = { avgPace: 41, gameDaysLeft: 80 }
+
+describe('slotCeiling', () => {
+  it('is 82 for single slots', () => {
+    expect(slotCeiling('PG')).toBe(82)
+  })
+
+  it('spreads the UTIL cap of 248 over three slots', () => {
+    expect(SLOT_CAPS.UTIL).toBe(248)
+    expect(slotCeiling('UTIL')).toBeCloseTo(248 / 3, 6)
+  })
+})
+
+describe('projectSlot', () => {
+  it('normalises UTIL games to a single slot', () => {
+    const { used } = projectSlot(120, 'UTIL', midSeason)
+    expect(used).toBe(40)
+  })
+
+  it('leaves single slots as-is', () => {
+    const { used } = projectSlot(40, 'PG', midSeason)
+    expect(used).toBe(40)
+  })
+
+  it('reports rate as games used per NBA game elapsed', () => {
+    const { rate } = projectSlot(41, 'PG', midSeason)
+    expect(rate).toBeCloseTo(1, 6)
+  })
+
+  it('flags a slot that is behind with a rate under 1', () => {
+    const { rate } = projectSlot(30, 'PG', midSeason)
+    expect(rate).toBeCloseTo(30 / 41, 6)
+  })
+
+  it('caps max games at the slot ceiling', () => {
+    const { maxGames } = projectSlot(40, 'PG', { avgPace: 41, gameDaysLeft: 80 })
+    expect(maxGames).toBe(82)
+  })
+
+  it('reports a max under 82 once game days run short', () => {
+    const { maxGames } = projectSlot(40, 'PG', { avgPace: 41, gameDaysLeft: 30 })
+    expect(maxGames).toBe(70)
+  })
+
+  it('counts UTIL max across all three slots, capped at 248', () => {
+    const { maxGamesTotal } = projectSlot(120, 'UTIL', { avgPace: 41, gameDaysLeft: 80 })
+    expect(maxGamesTotal).toBe(248)
+  })
+
+  it('gains three UTIL games per remaining game day', () => {
+    const { maxGamesTotal } = projectSlot(120, 'UTIL', { avgPace: 41, gameDaysLeft: 30 })
+    expect(maxGamesTotal).toBe(120 + 30 * 3)
+  })
+
+  it('leaves single-slot max totals on the 82 scale', () => {
+    const { maxGamesTotal } = projectSlot(40, 'PG', { avgPace: 41, gameDaysLeft: 30 })
+    expect(maxGamesTotal).toBe(70)
+  })
+
+  it('matches the backend blend formula', () => {
+    const used = 40
+    const avgPace = 41
+    const daysLeft = 41
+    const m1 = Math.min(used * (82 / avgPace), 82)
+    const m2 = Math.min(used + (used / avgPace) * daysLeft, 82)
+    const w2 = avgPace / 82
+    const expected = (1 - w2) * m1 + w2 * m2
+
+    const { estimated } = projectSlot(used, 'PG', { avgPace, gameDaysLeft: daysLeft })
+    expect(estimated).toBeCloseTo(expected, 6)
+  })
+
+  it('rounds an estimate of 81.7 up to a full 82', () => {
+    const ctx = { avgPace: 41.3, gameDaysLeft: 82 }
+    const { estimated, estimatedRounded } = projectSlot(41, 'PG', ctx)
+    expect(estimated).toBeCloseTo(81.7, 1)
+    expect(estimatedRounded).toBe(82)
+  })
+
+  it('rounds an estimate of 81.1 down to 81', () => {
+    const ctx = { avgPace: 60.4, gameDaysLeft: 44 }
+    const { estimated, estimatedRounded } = projectSlot(58, 'PG', ctx)
+    expect(estimated).toBeCloseTo(81.1, 1)
+    expect(estimatedRounded).toBe(81)
+  })
+
+  it('grades the rounded estimate, so 81.7 counts as a full season', () => {
+    const ctx = { avgPace: 41.3, gameDaysLeft: 82 }
+    const { estimatedRounded } = projectSlot(41, 'PG', ctx)
+    expect(estimatedTone(estimatedRounded, 'PG', ctx)).toBe('green')
+  })
+
+  it('still grades 81.1 as short of a full season', () => {
+    const ctx = { avgPace: 60.4, gameDaysLeft: 44 }
+    const { estimatedRounded } = projectSlot(58, 'PG', ctx)
+    expect(estimatedTone(estimatedRounded, 'PG', ctx)).toBe('yellow')
+  })
+
+  it('projects UTIL as a whole column, capped at 248', () => {
+    const { estimated, estimatedPerSlot } = projectSlot(248, 'UTIL', { avgPace: 80, gameDaysLeft: 20 })
+    expect(estimated).toBeCloseTo(248, 6)
+    expect(estimatedPerSlot).toBeCloseTo(248 / 3, 6)
+    expect(estimated!).toBeGreaterThan(GAMES_PER_SLOT)
+  })
+
+  it('matches the backend UTIL projection, which works on the 248 cap', () => {
+    const usedTotal = 120
+    const avgPace = 41
+    const daysLeft = 41
+    const m1 = Math.min(usedTotal * (82 / avgPace), 248)
+    const m2 = Math.min(usedTotal + (usedTotal / avgPace) * daysLeft, 248)
+    const w2 = avgPace / 82
+    const expected = (1 - w2) * m1 + w2 * m2
+
+    const { estimated } = projectSlot(usedTotal, 'UTIL', { avgPace, gameDaysLeft: daysLeft })
+    expect(estimated).toBeCloseTo(expected, 6)
+  })
+
+  it('returns nulls when pace is unavailable', () => {
+    const p = projectSlot(40, 'PG', { avgPace: null, gameDaysLeft: 40 })
+    expect(p.rate).toBeNull()
+    expect(p.maxGames).toBeNull()
+    expect(p.estimated).toBeNull()
+  })
+
+  it('returns nulls when pace is zero', () => {
+    const p = projectSlot(40, 'PG', { avgPace: 0, gameDaysLeft: 40 })
+    expect(p.estimated).toBeNull()
+  })
+
+  it('falls back to pace extrapolation when game days are unknown', () => {
+    const { estimated, maxGames } = projectSlot(40, 'PG', { avgPace: 41, gameDaysLeft: null })
+    expect(maxGames).toBeNull()
+    expect(estimated).toBeCloseTo(80, 6)
+  })
+})
+
+describe('canColor', () => {
+  it('stays off while the season is young', () => {
+    expect(canColor({ avgPace: 8, gameDaysLeft: 120 })).toBe(false)
+    expect(canColor({ avgPace: 10, gameDaysLeft: 120 })).toBe(false)
+  })
+
+  it('turns on past 10 games per team', () => {
+    expect(canColor({ avgPace: 11, gameDaysLeft: 120 })).toBe(true)
+  })
+
+  it('stays off without a pace', () => {
+    expect(canColor({ avgPace: null, gameDaysLeft: 120 })).toBe(false)
+  })
+})
+
+describe('rateTone', () => {
+  it('is green inside the 5% band, either way', () => {
+    expect(rateTone(1.02, midSeason)).toBe('green')
+    expect(rateTone(0.98, midSeason)).toBe('green')
+  })
+
+  it('grades a slot burning games too fast by how far off it is', () => {
+    expect(rateTone(1.06, midSeason)).toBe('yellow')
+    expect(rateTone(1.12, midSeason)).toBe('orange')
+    expect(rateTone(1.2, midSeason)).toBe('red')
+  })
+
+  it('grades a slot falling behind the same way', () => {
+    expect(rateTone(0.94, midSeason)).toBe('yellow')
+    expect(rateTone(0.88, midSeason)).toBe('orange')
+    expect(rateTone(0.8, midSeason)).toBe('red')
+  })
+
+  it('stays neutral early in the season', () => {
+    expect(rateTone(1.5, { avgPace: 6, gameDaysLeft: 140 })).toBe('neutral')
+    expect(rateTone(0.2, { avgPace: 6, gameDaysLeft: 140 })).toBe('neutral')
+  })
+})
+
+describe('formatRateDelta', () => {
+  it('counts the games behind the NBA rate', () => {
+    expect(formatRateDelta(69, 69.3)).toBe('−0.3')
+  })
+
+  it('counts the games ahead of it', () => {
+    expect(formatRateDelta(74, 69.6)).toBe('+4.4')
+  })
+
+  it('says so when the slot sits on the rate', () => {
+    expect(formatRateDelta(69.3, 69.3)).toBe('on pace')
+  })
+
+  it('renders a dash without a rate', () => {
+    expect(formatRateDelta(40, null)).toBe('-')
+  })
+
+  it('leaves the colour to rateTone, which still grades in percent', () => {
+    // 69 against 69.3 is only 0.4% off, so it stays green despite the visible −0.3.
+    expect(rateTone(69 / 69.3, { avgPace: 69.3, gameDaysLeft: 25 })).toBe('green')
+  })
+})
+
+describe('maxTone', () => {
+  it('is green while the full column is still reachable', () => {
+    expect(maxTone(82, 'PG', midSeason)).toBe('green')
+  })
+
+  it('is red once the column can no longer be filled', () => {
+    expect(maxTone(81.5, 'PG', midSeason)).toBe('red')
+  })
+
+  it('judges UTIL against 248, not 82', () => {
+    expect(maxTone(248, 'UTIL', midSeason)).toBe('green')
+    expect(maxTone(247, 'UTIL', midSeason)).toBe('red')
+    expect(maxTone(90, 'UTIL', midSeason)).toBe('red')
+  })
+
+  it('only ever returns green or red', () => {
+    for (const value of [0, 40, 82, 200]) {
+      expect(['green', 'red']).toContain(maxTone(value, 'PG', midSeason))
+    }
+  })
+
+  it('stays neutral early in the season', () => {
+    expect(maxTone(40, 'PG', { avgPace: 6, gameDaysLeft: 140 })).toBe('neutral')
+  })
+})
+
+describe('estimatedTone', () => {
+  it('is green at 82 and above', () => {
+    expect(estimatedTone(82, 'PG', midSeason)).toBe('green')
+    expect(estimatedTone(82.6, 'PG', midSeason)).toBe('green')
+  })
+
+  it('is yellow between 80 and 82', () => {
+    expect(estimatedTone(81.9, 'PG', midSeason)).toBe('yellow')
+    expect(estimatedTone(80, 'PG', midSeason)).toBe('yellow')
+  })
+
+  it('is orange between 78 and 80', () => {
+    expect(estimatedTone(79.9, 'PG', midSeason)).toBe('orange')
+    expect(estimatedTone(78, 'PG', midSeason)).toBe('orange')
+  })
+
+  it('is red under 78', () => {
+    expect(estimatedTone(77.9, 'PG', midSeason)).toBe('red')
+  })
+
+  it('scales every band by three for UTIL', () => {
+    expect(estimatedTone(246, 'UTIL', midSeason)).toBe('green')
+    expect(estimatedTone(245, 'UTIL', midSeason)).toBe('yellow')
+    expect(estimatedTone(239, 'UTIL', midSeason)).toBe('orange')
+    expect(estimatedTone(233, 'UTIL', midSeason)).toBe('red')
+  })
+
+  it('does not read a full UTIL column as a failing single slot', () => {
+    expect(estimatedTone(248, 'UTIL', midSeason)).toBe('green')
+  })
+
+  it('stays neutral early in the season', () => {
+    expect(estimatedTone(20, 'PG', { avgPace: 6, gameDaysLeft: 140 })).toBe('neutral')
+  })
+})
+
+describe('formatCap', () => {
+  it('is a plain 82 for single slots', () => {
+    expect(formatCap('PG')).toBe('82')
+  })
+
+  it('splits the UTIL cap so the two spare ESPN games stay visible', () => {
+    expect(formatCap('UTIL')).toBe('(246+2)')
+  })
+})
+
+describe('formatSlotNumber', () => {
+  it('keeps whole numbers clean', () => {
+    expect(formatSlotNumber(82)).toBe('82')
+  })
+
+  it('rounds fractions to one place', () => {
+    expect(formatSlotNumber(82.666)).toBe('82.7')
+  })
+
+  it('renders a dash for missing values', () => {
+    expect(formatSlotNumber(null)).toBe('-')
+  })
+})

--- a/frontend/src/utils/slotProjection.ts
+++ b/frontend/src/utils/slotProjection.ts
@@ -1,0 +1,212 @@
+/**
+ * Per-slot pace maths for the Slot Usage table.
+ *
+ * The `estimated` blend mirrors SlotGamesEstimator.estimate() in
+ * backend/app/services/slot_games_estimator.py — keep the two in sync.
+ *
+ * Everything here is expressed *per slot*: UTIL is three roster slots, so its
+ * raw games-used is divided by 3 and compared against the same 82-game ceiling
+ * as every other slot.
+ */
+
+export const SLOT_NAMES = ['PG', 'SG', 'SF', 'PF', 'C', 'G', 'F', 'UTIL'] as const
+export type SlotName = (typeof SLOT_NAMES)[number]
+
+/** How many roster slots each column represents. */
+export const SLOT_MULTIPLICITY: Record<SlotName, number> = {
+  PG: 1, SG: 1, SF: 1, PF: 1, C: 1, G: 1, F: 1, UTIL: 3,
+}
+
+/**
+ * Season allowance per column. UTIL is three slots plus two spare games (3 * 82 + 2):
+ * an ESPN quirk lets you leave one UTIL open on the last game week and still play all
+ * three afterwards.
+ */
+export const SLOT_CAPS: Record<SlotName, number> = {
+  PG: 82, SG: 82, SF: 82, PF: 82, C: 82, G: 82, F: 82, UTIL: 248,
+}
+
+/** A single slot can be filled on at most 82 NBA game days. */
+export const GAMES_PER_SLOT = 82
+
+/** The cap a single slot of this column may reach — 82 everywhere, 82.67 for UTIL. */
+export function slotCeiling(slot: SlotName): number {
+  return SLOT_CAPS[slot] / SLOT_MULTIPLICITY[slot]
+}
+
+/** Below this NBA pace the season is too young for any of these signals to mean anything. */
+export const MIN_PACE_FOR_COLOR = 10
+
+/**
+ * Estimate bands, per slot: at 82 you finish the season, under 78 you have lost real games.
+ * Scaled by the column's slot count before comparing, so UTIL is judged against 3 × these.
+ */
+export const EST_GREEN = 82
+export const EST_YELLOW = 80
+export const EST_ORANGE = 78
+
+/** Rate bands, as absolute drift away from 1.0 — in either direction. */
+export const RATE_GREEN = 0.05
+export const RATE_YELLOW = 0.1
+export const RATE_ORANGE = 0.15
+
+export type SlotTone = 'neutral' | 'green' | 'yellow' | 'orange' | 'red'
+
+export interface SlotProjection {
+  /** Games used, normalised to a single slot (UTIL divided by 3). */
+  used: number
+  /** Games used across the whole column — for UTIL this is all three slots. */
+  usedTotal: number
+  /** Games used per NBA game elapsed. 1.0 is exactly on pace. */
+  rate: number | null
+  /** Most games this slot can still finish on, per slot. */
+  maxGames: number | null
+  /** Most games the whole column can still finish on — UTIL counts all three slots, out of 248. */
+  maxGamesTotal: number | null
+  /**
+   * Blended season-end projection for the whole column — UTIL counts all three slots,
+   * out of 248. This is the direct mirror of proj_<slot> in the backend estimator.
+   */
+  estimated: number | null
+  /**
+   * The projection as a whole number of games, which is what it really is — you either
+   * play a game in the slot or you do not. Both the display and the colour use this, so
+   * a projection of 81.7 reads 82 and grades as 82.
+   */
+  estimatedRounded: number | null
+  /** The same projection divided back down to a single slot. */
+  estimatedPerSlot: number | null
+}
+
+export interface PaceContext {
+  avgPace: number | null | undefined
+  gameDaysLeft: number | null | undefined
+}
+
+/** Colours are meaningless in the first couple of weeks — everything is 0/82 then. */
+export function canColor({ avgPace }: PaceContext): boolean {
+  return typeof avgPace === 'number' && avgPace > MIN_PACE_FOR_COLOR
+}
+
+export function projectSlot(
+  gamesUsed: number,
+  slot: SlotName,
+  { avgPace, gameDaysLeft }: PaceContext,
+): SlotProjection {
+  const multiplicity = SLOT_MULTIPLICITY[slot]
+  const cap = SLOT_CAPS[slot]
+  const used = gamesUsed / multiplicity
+  const ceiling = slotCeiling(slot)
+
+  if (typeof avgPace !== 'number' || avgPace <= 0) {
+    return {
+      used,
+      usedTotal: gamesUsed,
+      rate: null,
+      maxGames: null,
+      maxGamesTotal: null,
+      estimated: null,
+      estimatedRounded: null,
+      estimatedPerSlot: null,
+    }
+  }
+
+  const rate = used / avgPace
+
+  const daysLeft = typeof gameDaysLeft === 'number' ? gameDaysLeft : null
+  const maxGames = daysLeft === null ? null : Math.min(used + daysLeft, ceiling)
+  // Every remaining game day can fill each slot in the column, so UTIL gains three a day.
+  const maxGamesTotal =
+    daysLeft === null ? null : Math.min(gamesUsed + daysLeft * multiplicity, SLOT_CAPS[slot])
+
+  // Worked on the column total against the column cap, exactly as the backend estimator does.
+  // Method 1 — extrapolate the current rate over a full 82-game season.
+  const m1 = Math.min(gamesUsed * (GAMES_PER_SLOT / avgPace), cap)
+  // Method 2 — apply the current rate to the game days actually left.
+  const m2 = daysLeft === null ? null : Math.min(gamesUsed + (gamesUsed / avgPace) * daysLeft, cap)
+
+  // Method 2 takes over as the season progresses.
+  const w2 = avgPace / GAMES_PER_SLOT
+  const estimated = m2 === null ? m1 : (1 - w2) * m1 + w2 * m2
+
+  return {
+    used,
+    usedTotal: gamesUsed,
+    rate,
+    maxGames,
+    maxGamesTotal,
+    estimated,
+    estimatedRounded: Math.round(estimated),
+    estimatedPerSlot: estimated / multiplicity,
+  }
+}
+
+/**
+ * Rate is graded on how far off pace the slot is, in either direction — burning games
+ * too fast is as much of a problem as falling behind. The arrow carries the direction.
+ */
+export function rateTone(rate: number | null, ctx: PaceContext): SlotTone {
+  if (rate === null || !canColor(ctx)) return 'neutral'
+  const drift = Math.abs(rate - 1)
+  if (drift < RATE_GREEN) return 'green'
+  if (drift < RATE_YELLOW) return 'yellow'
+  if (drift < RATE_ORANGE) return 'orange'
+  return 'red'
+}
+
+/**
+ * How many games the slot is off the NBA rate, signed: 69 used against a rate of 69.3
+ * reads −0.3. The colour still comes from rateTone, which grades the gap in percent.
+ */
+export function formatRateDelta(used: number, avgPace: number | null | undefined): string {
+  if (typeof avgPace !== 'number' || !Number.isFinite(avgPace)) return '-'
+  const delta = used - avgPace
+  if (Math.abs(delta) < 0.05) return 'on pace'
+  return `${delta > 0 ? '+' : '−'}${Math.abs(delta).toFixed(1)}`
+}
+
+/**
+ * Binary: either the column can still be filled out completely, or it cannot.
+ * Compared against the whole column's cap, so UTIL is judged against 248 rather than 82.
+ */
+export function maxTone(maxGamesTotal: number | null, slot: SlotName, ctx: PaceContext): SlotTone {
+  if (maxGamesTotal === null || !canColor(ctx)) return 'neutral'
+  return maxGamesTotal < SLOT_CAPS[slot] ? 'red' : 'green'
+}
+
+/** Takes the column total, so UTIL is graded against 3 × each band. */
+export function estimatedTone(estimated: number | null, slot: SlotName, ctx: PaceContext): SlotTone {
+  if (estimated === null || !canColor(ctx)) return 'neutral'
+  const slots = SLOT_MULTIPLICITY[slot]
+  if (estimated >= EST_GREEN * slots) return 'green'
+  if (estimated >= EST_YELLOW * slots) return 'yellow'
+  if (estimated >= EST_ORANGE * slots) return 'orange'
+  return 'red'
+}
+
+export const TONE_CLASS: Record<SlotTone, string> = {
+  neutral: 'bg-gray-100 text-gray-600',
+  green: 'bg-green-100 text-green-800',
+  yellow: 'bg-yellow-100 text-yellow-800',
+  orange: 'bg-orange-100 text-orange-800',
+  red: 'bg-red-100 text-red-800',
+}
+
+
+/**
+ * The cap as a denominator. UTIL is written (246+2) rather than 248 so the two spare
+ * games stay visible as the oddity they are, instead of hiding inside a round total.
+ */
+export function formatCap(slot: SlotName): string {
+  const slots = SLOT_MULTIPLICITY[slot]
+  if (slots === 1) return String(SLOT_CAPS[slot])
+  const base = GAMES_PER_SLOT * slots
+  const spare = SLOT_CAPS[slot] - base
+  return spare === 0 ? String(base) : `(${base}+${spare})`
+}
+
+/** Trims a trailing `.0` so whole numbers stay readable in a dense table. */
+export function formatSlotNumber(value: number | null, digits = 1): string {
+  if (value === null || !Number.isFinite(value)) return '-'
+  return Number.isInteger(value) ? String(value) : value.toFixed(digits)
+}


### PR DESCRIPTION
## What

Slot Usage on the team page showed one number per slot — games used against the cap — coloured red for any 5% drift from NBA pace. That told you a slot was off pace, but not whether it could still be fixed.

It now shows three rows per slot, each graded on its own logic.

| Row | Value | Colours |
|---|---|---|
| **Rate** | games used per slot, and how many games that is ahead of / behind the NBA rate | 🟢 within 5% · 🟡 5–10% · 🟠 10–15% · 🔴 15%+ — either direction |
| **Max** | most games the column can still finish on | 🟢 full season reachable · 🔴 gone |
| **Est.** | season-end projection | 🟢 82+ · 🟡 80–82 · 🟠 78–80 · 🔴 under 78 |

Every colour stays neutral until NBA pace passes 10 GP/team — before that each slot is near zero and the bands say nothing.

## Notes

- **Est. is the model's method.** It mirrors `SlotGamesEstimator.estimate()` — same blend of pace extrapolation and days-remaining, weighted `pace/82` — applied to the column total against the column cap, so it lines up with `proj_<slot>` rather than approximating it per slot. A test asserts the match for UTIL on its 248 cap.
- **Est. is rounded before grading**, not just for display. A projection of 81.7 reads 82 *and* counts as a full season; otherwise a cell showing 82 could render in a warning colour.
- **UTIL is judged as a whole column**, not a per-slot average, and its cap prints as `(246+2)` so the two spare games stay visible — ESPN lets you leave a UTIL open on the last game week and still play all three afterwards.
- **Rate stays per slot**, since that is what is comparable to the league rate. Note this means the number and the colour do not always move together: the same absolute deficit grades harder late in the season, because 1.4 games out of 60 matters more than out of 20.

## Bug fixed along the way

`data_transformer.SLOT_CAPS` had `UTIL: 246` while `slot_games_estimator.SLOT_CAPS` had `248`. The API serves the transformer's value, so the UI was showing a 246 cap against projections computed on 248. Set to 248.

## Screens

Built against a throwaway preview page with mock data covering each league state. **That preview is not in this PR** — no example code ships. Screenshots only:

**Opening weeks — colours off.** Pace 6.4 GP/team, below the gate, so nothing is graded however far off it is.

![opening weeks](https://raw.githubusercontent.com/AsafShai/fantasyAverageWeb/assets/slot-usage-screenshots/slot-usage/01-opening-weeks-colors-off.jpg)

**Past the gate, and mid-season on pace.** Pace 11.3 then 40.7.

![past the gate](https://raw.githubusercontent.com/AsafShai/fantasyAverageWeb/assets/slot-usage-screenshots/slot-usage/02-past-gate-and-on-pace.jpg)

**Every rate band.** Pace 41.3. Note the slots running ahead all estimate at the cap — burning games fast guarantees you fill the slot; the risk is only running dry.

![rate bands](https://raw.githubusercontent.com/AsafShai/fantasyAverageWeb/assets/slot-usage-screenshots/slot-usage/03-rate-bands.jpg)

**Late season, Max slipping.** Pace 69.6, ~25 game days left. F at −13.6 can no longer be filled out, so Max flips red — and it is the only Est. under 78.

![late season max](https://raw.githubusercontent.com/AsafShai/fantasyAverageWeb/assets/slot-usage-screenshots/slot-usage/04-late-season-max.jpg)

**Season complete.** Pace 82, zero days left — Max equals what was actually used, so anything short of the cap is locked red.

![estimate bands](https://raw.githubusercontent.com/AsafShai/fantasyAverageWeb/assets/slot-usage-screenshots/slot-usage/05-season-complete.jpg)

**Mobile (390px).** The header stack was trimmed for narrow screens — the legend shows the bands alone and the row sublabels are shortened. The table keeps scrolling horizontally, which is right for nine columns on a phone.

<img src="https://raw.githubusercontent.com/AsafShai/fantasyAverageWeb/assets/slot-usage-screenshots/slot-usage/06-mobile-390px.png" width="390" />

## Tests

- 50 new frontend tests in `slotProjection.test.ts` — bands, rounding, UTIL scaling, the backend-formula match
- Backend `test_slot_games_estimator` / `test_data_transformer` / `test_team_service` pass (41)
- `tsc -b` and `eslint` clean on the changed files

⚠️ Heads up, unrelated to this change: `npm test` currently fails for the **whole** frontend suite — `src/test/setup.ts:7` calls `localStorage.clear()` and it is undefined. `coherentRound.test.ts` fails identically on a clean tree; likely Node v26 against `engines: ">=24 <25"`. I ran the new tests through a temporary node-environment config. Worth a separate fix.

## Follow-up worth deciding

The blend formula now exists in both Python and TypeScript. I kept it client-side because `leagueSummary` already carries `nba_avg_pace` and `nba_game_days_left`, so the table costs zero extra requests — the alternative adds two uncached ESPN calls to the team-detail path. Happy to move it server-side with caching if you would rather have one source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
