### PR TITLE
feat(frontend): global command palette (Ctrl/Cmd+K)

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,181 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+import { useNavigate } from 'react-router'
+import { useGlobalSearch, highlightMatch } from '../hooks/useGlobalSearch'
+import type { SearchResult } from '../hooks/useGlobalSearch'
+
+interface CommandPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const badgeClasses: Record<'fa' | 'out', string> = {
+  fa: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200',
+  out: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200',
+}
+
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  const hl = highlightMatch(text, query)
+  if (!hl) return <>{text}</>
+  return (
+    <>
+      {hl.before}
+      <span className="bg-yellow-200 dark:bg-yellow-700/60 rounded-sm">{hl.match}</span>
+      {hl.after}
+    </>
+  )
+}
+
+/**
+ * One overlay for both desktop (centered, Ctrl/Cmd+K) and mobile (full-screen,
+ * opened from the navbar search icon). Layout.tsx owns the open/close state
+ * and the global Ctrl/Cmd+K listener so both nav variants can trigger it.
+ */
+const CommandPalette = ({ isOpen, onClose }: CommandPaletteProps) => {
+  const navigate = useNavigate()
+  const [query, setQuery] = useState('')
+  const [selected, setSelected] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const previouslyFocused = useRef<HTMLElement | null>(null)
+
+  const { groups } = useGlobalSearch(query)
+  const flatResults = useMemo(() => groups.flatMap((g) => g.items), [groups])
+
+  useEffect(() => {
+    if (isOpen) {
+      previouslyFocused.current = document.activeElement as HTMLElement | null
+      setQuery('')
+      setSelected(0)
+      requestAnimationFrame(() => inputRef.current?.focus())
+    } else {
+      previouslyFocused.current?.focus()
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    setSelected(0)
+  }, [query])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setSelected((s) => Math.min(s + 1, flatResults.length - 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setSelected((s) => Math.max(s - 1, 0))
+      } else if (e.key === 'Enter') {
+        e.preventDefault()
+        const result = flatResults[selected]
+        if (result?.path) {
+          onClose()
+          navigate(result.path)
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, flatResults, selected, onClose, navigate])
+
+  if (!isOpen) return null
+
+  const handleSelect = (result: SearchResult) => {
+    if (!result.path) return
+    onClose()
+    navigate(result.path)
+  }
+
+  let rowIndex = -1
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-start justify-center md:pt-16" onClick={onClose}>
+      <div className="absolute inset-0 bg-slate-900/40" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+        className="relative flex h-full w-full flex-col overflow-hidden bg-white dark:bg-gray-900 md:h-auto md:max-h-[80vh] md:w-[520px] md:rounded-xl md:border md:border-gray-200 md:shadow-2xl md:dark:border-gray-700"
+      >
+        <div className="flex items-center gap-2 border-b border-gray-200 dark:border-gray-700 px-3 py-3">
+          <svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0 text-gray-400 dark:text-gray-500">
+            <circle cx="9" cy="9" r="6.5" stroke="currentColor" strokeWidth="1.6" />
+            <path d="M14 14L18 18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+          </svg>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search players, teams, pages…"
+            autoComplete="off"
+            className="flex-1 bg-transparent text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 outline-none"
+          />
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-gray-300 px-1.5 py-0.5 text-[10px] text-gray-400 dark:border-gray-600 dark:text-gray-500"
+          >
+            esc
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-1 md:max-h-[300px] md:flex-none">
+          {flatResults.length === 0 ? (
+            <div className="py-10 text-center text-sm text-gray-400 dark:text-gray-500">
+              {query ? `No matches for "${query}"` : 'Start typing to search'}
+            </div>
+          ) : (
+            groups.map((group) => (
+              <div key={group.group}>
+                <div className="px-2 pt-2 pb-1 text-[10px] font-bold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  {group.group}
+                </div>
+                {group.items.map((result) => {
+                  rowIndex += 1
+                  const isSelected = rowIndex === selected
+                  return (
+                    <div
+                      key={result.key}
+                      onMouseEnter={() => setSelected(rowIndex)}
+                      onClick={() => handleSelect(result)}
+                      className={`flex min-h-[44px] items-center gap-2 rounded-md px-2 py-2 md:min-h-0 ${
+                        result.path ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
+                      } ${isSelected ? 'bg-blue-50 dark:bg-blue-900/40' : ''}`}
+                    >
+                      <span className="w-5 shrink-0 text-center text-sm">{result.icon}</span>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+                          <HighlightedText text={result.title} query={query} />
+                        </div>
+                        <div className="truncate text-xs text-gray-500 dark:text-gray-400">{result.subtitle}</div>
+                      </div>
+                      {result.badge && (
+                        <span
+                          className={`shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide ${badgeClasses[result.badge.tone]}`}
+                        >
+                          {result.badge.label}
+                        </span>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="hidden gap-3 border-t border-gray-200 px-3 py-2 text-[10px] text-gray-400 dark:border-gray-700 dark:text-gray-500 md:flex">
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc close</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CommandPalette

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,14 +1,71 @@
 import { Outlet, Link, useLocation } from 'react-router'
 import { useState, useEffect, useRef } from 'react'
 import Footer from './Footer'
+import CommandPalette from './CommandPalette'
 import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG, FF_DRAFT_REPORT, FF_TRENDS, FF_MINIGAMES } from '../config/featureFlags'
+
+function useGlobalSearchShortcut(setSearchOpen: (open: boolean) => void) {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null
+      const isTyping =
+        !!target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k' && !isTyping) {
+        e.preventDefault()
+        setSearchOpen(true)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [setSearchOpen])
+}
+
+const SearchIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0">
+    <circle cx="9" cy="9" r="6.5" stroke="currentColor" strokeWidth="1.6" />
+    <path d="M14 14L18 18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+)
+
+const SearchButton = ({ onClick }: { onClick: () => void }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    title="Search (Ctrl K)"
+    className="hidden md:flex items-center gap-2 w-40 lg:w-56 rounded-full border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 px-3.5 py-1.5 text-gray-400 dark:text-gray-500 shrink-0 transition-colors hover:border-blue-300 hover:bg-white hover:text-gray-500 dark:hover:border-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+  >
+    <SearchIcon />
+    <span className="flex-1 text-left text-sm truncate">Search…</span>
+    <kbd className="hidden lg:inline rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500">
+      Ctrl K
+    </kbd>
+  </button>
+)
+
+const MobileSearchIconButton = ({ onClick }: { onClick: () => void }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-label="Search"
+    className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+  >
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="9" cy="9" r="6.5" stroke="currentColor" strokeWidth="1.6" />
+      <path d="M14 14L18 18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    </svg>
+  </button>
+)
 
 const Layout = () => {
   const location = useLocation()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
   const [darkMode, setDarkMode] = useState(() => {
     return localStorage.getItem('theme') === 'dark'
   })
+
+  useGlobalSearchShortcut(setSearchOpen)
 
   useEffect(() => {
     if (darkMode) {
@@ -42,11 +99,17 @@ const Layout = () => {
   const closeMobileMenu = () => setMobileMenuOpen(false)
 
   if (FF_NAV_REORG) {
-    return <ReorgLayout darkMode={darkMode} setDarkMode={setDarkMode} />
+    return (
+      <>
+        <CommandPalette isOpen={searchOpen} onClose={() => setSearchOpen(false)} />
+        <ReorgLayout darkMode={darkMode} setDarkMode={setDarkMode} setSearchOpen={setSearchOpen} />
+      </>
+    )
   }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 flex flex-col">
+      <CommandPalette isOpen={searchOpen} onClose={() => setSearchOpen(false)} />
       <nav className="sticky top-0 z-40 bg-white dark:bg-gray-900 shadow-lg border-b border-gray-200 dark:border-gray-700">
         <div className="w-full px-3">
           <div className="flex items-center justify-between h-14 gap-2">
@@ -72,6 +135,7 @@ const Layout = () => {
                 </Link>
               ))}
               <div className="mx-3 h-6 w-0.5 bg-gray-300 dark:bg-gray-500 shrink-0 rounded-full" />
+              <SearchButton onClick={() => setSearchOpen(true)} />
               <button
                 onClick={() => setDarkMode(d => !d)}
                 className="p-1.5 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors shrink-0"
@@ -82,8 +146,9 @@ const Layout = () => {
               </button>
             </div>
 
-            {/* Mobile: dark toggle + hamburger */}
+            {/* Mobile: search + dark toggle + hamburger */}
             <div className="md:hidden flex items-center gap-1">
+              <MobileSearchIconButton onClick={() => setSearchOpen(true)} />
               <button
                 onClick={() => setDarkMode(d => !d)}
                 className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
@@ -145,6 +210,7 @@ const Layout = () => {
 interface ReorgLayoutProps {
   darkMode: boolean
   setDarkMode: React.Dispatch<React.SetStateAction<boolean>>
+  setSearchOpen: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 interface NavLeaf {
@@ -386,7 +452,7 @@ const MobileNavGroup = ({ group, openKey, setOpenKey, isActive, onNavigate }: Mo
   )
 }
 
-const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
+const ReorgLayout = ({ darkMode, setDarkMode, setSearchOpen }: ReorgLayoutProps) => {
   const location = useLocation()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [openGroup, setOpenGroup] = useState<string | null>(null)
@@ -491,6 +557,7 @@ const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
               ))}
 
               <div className="mx-3 h-6 w-0.5 bg-gray-300 dark:bg-gray-500 shrink-0 rounded-full" />
+              <SearchButton onClick={() => setSearchOpen(true)} />
               <button
                 onClick={() => setDarkMode(d => !d)}
                 className="p-1.5 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors shrink-0"
@@ -501,8 +568,9 @@ const ReorgLayout = ({ darkMode, setDarkMode }: ReorgLayoutProps) => {
               </button>
             </div>
 
-            {/* Mobile: dark toggle + hamburger */}
+            {/* Mobile: search + dark toggle + hamburger */}
             <div className="md:hidden flex items-center gap-1">
+              <MobileSearchIconButton onClick={() => setSearchOpen(true)} />
               <button
                 onClick={() => setDarkMode(d => !d)}
                 className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,10 +2,11 @@ import { Outlet, Link, useLocation } from 'react-router'
 import { useState, useEffect, useRef } from 'react'
 import Footer from './Footer'
 import CommandPalette from './CommandPalette'
-import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG, FF_DRAFT_REPORT, FF_TRENDS, FF_MINIGAMES } from '../config/featureFlags'
+import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG, FF_DRAFT_REPORT, FF_TRENDS, FF_MINIGAMES, FF_GLOBAL_SEARCH } from '../config/featureFlags'
 
 function useGlobalSearchShortcut(setSearchOpen: (open: boolean) => void) {
   useEffect(() => {
+    if (!FF_GLOBAL_SEARCH) return
     function handleKeyDown(e: KeyboardEvent) {
       const target = e.target as HTMLElement | null
       const isTyping =
@@ -28,34 +29,40 @@ const SearchIcon = () => (
   </svg>
 )
 
-const SearchButton = ({ onClick }: { onClick: () => void }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    title="Search (Ctrl K)"
-    className="hidden md:flex items-center gap-2 w-40 lg:w-56 rounded-full border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 px-3.5 py-1.5 text-gray-400 dark:text-gray-500 shrink-0 transition-colors hover:border-blue-300 hover:bg-white hover:text-gray-500 dark:hover:border-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-  >
-    <SearchIcon />
-    <span className="flex-1 text-left text-sm truncate">Search…</span>
-    <kbd className="hidden lg:inline rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500">
-      Ctrl K
-    </kbd>
-  </button>
-)
+const SearchButton = ({ onClick }: { onClick: () => void }) => {
+  if (!FF_GLOBAL_SEARCH) return null
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Search (Ctrl K)"
+      className="hidden md:flex items-center gap-2 w-40 lg:w-56 rounded-full border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 px-3.5 py-1.5 text-gray-400 dark:text-gray-500 shrink-0 transition-colors hover:border-blue-300 hover:bg-white hover:text-gray-500 dark:hover:border-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+    >
+      <SearchIcon />
+      <span className="flex-1 text-left text-sm truncate">Search…</span>
+      <kbd className="hidden lg:inline rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500">
+        Ctrl K
+      </kbd>
+    </button>
+  )
+}
 
-const MobileSearchIconButton = ({ onClick }: { onClick: () => void }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    aria-label="Search"
-    className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-  >
-    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <circle cx="9" cy="9" r="6.5" stroke="currentColor" strokeWidth="1.6" />
-      <path d="M14 14L18 18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-    </svg>
-  </button>
-)
+const MobileSearchIconButton = ({ onClick }: { onClick: () => void }) => {
+  if (!FF_GLOBAL_SEARCH) return null
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Search"
+      className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+    >
+      <svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="9" cy="9" r="6.5" stroke="currentColor" strokeWidth="1.6" />
+        <path d="M14 14L18 18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+      </svg>
+    </button>
+  )
+}
 
 const Layout = () => {
   const location = useLocation()
@@ -101,7 +108,7 @@ const Layout = () => {
   if (FF_NAV_REORG) {
     return (
       <>
-        <CommandPalette isOpen={searchOpen} onClose={() => setSearchOpen(false)} />
+        {FF_GLOBAL_SEARCH && <CommandPalette isOpen={searchOpen} onClose={() => setSearchOpen(false)} />}
         <ReorgLayout darkMode={darkMode} setDarkMode={setDarkMode} setSearchOpen={setSearchOpen} />
       </>
     )
@@ -109,7 +116,7 @@ const Layout = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 flex flex-col">
-      <CommandPalette isOpen={searchOpen} onClose={() => setSearchOpen(false)} />
+      {FF_GLOBAL_SEARCH && <CommandPalette isOpen={searchOpen} onClose={() => setSearchOpen(false)} />}
       <nav className="sticky top-0 z-40 bg-white dark:bg-gray-900 shadow-lg border-b border-gray-200 dark:border-gray-700">
         <div className="w-full px-3">
           <div className="flex items-center justify-between h-14 gap-2">

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -11,3 +11,4 @@ export const FF_DRAFT_REPORT = import.meta.env.VITE_FF_DRAFT_REPORT === 'true';
 export const FF_DRAFT_STEALS_BUSTS = import.meta.env.VITE_FF_DRAFT_STEALS_BUSTS === 'true';
 export const FF_TRENDS = import.meta.env.VITE_FF_TRENDS === 'true';
 export const FF_MINIGAMES = import.meta.env.VITE_FF_MINIGAMES === 'true';
+export const FF_GLOBAL_SEARCH = import.meta.env.VITE_FF_GLOBAL_SEARCH === 'true';

--- a/frontend/src/constants/searchablePages.ts
+++ b/frontend/src/constants/searchablePages.ts
@@ -1,0 +1,46 @@
+import {
+  FF_PLAYER_RANKINGS,
+  FF_FEATURE_STORE,
+  FF_PROJECTIONS,
+  FF_DRAFT_REPORT,
+  FF_TRENDS,
+  FF_MINIGAMES,
+} from '../config/featureFlags'
+
+export interface SearchablePage {
+  label: string
+  path: string
+  icon: string
+  group: string
+}
+
+/**
+ * Mirrors the real nav entries in Layout.tsx (both the flat nav and the
+ * ReorgLayout groups) so the command palette never links to a dead route.
+ * Feature-flagged pages are only included when the flag is on for this build.
+ */
+export const SEARCHABLE_PAGES: SearchablePage[] = [
+  { label: 'Dashboard', path: '/', icon: '📊', group: 'League' },
+  { label: 'League Rankings', path: '/rankings', icon: '🏆', group: 'League' },
+  { label: 'Teams', path: '/teams', icon: '👥', group: 'League' },
+  ...(FF_DRAFT_REPORT ? [{ label: 'Draft Report', path: '/draft-report', icon: '📝', group: 'League' }] : []),
+  { label: 'Players', path: '/players', icon: '⛹️', group: 'Players' },
+  ...(FF_PLAYER_RANKINGS ? [{ label: 'Player Rankings', path: '/player-rankings', icon: '📋', group: 'Players' }] : []),
+  { label: 'League Analytics', path: '/analytics', icon: '📈', group: 'Insights' },
+  ...(FF_TRENDS ? [{ label: 'Player Trends', path: '/trends', icon: '📉', group: 'Insights' }] : []),
+  ...(FF_PROJECTIONS ? [{ label: 'Projections', path: '/projections', icon: '🔭', group: 'Insights' }] : []),
+  { label: 'Standings Estimator', path: '/estimator', icon: '🔮', group: 'Insights' },
+  ...(FF_FEATURE_STORE ? [{ label: 'Feature Store', path: '/feature-store', icon: '🗄️', group: 'Insights' }] : []),
+  { label: 'Trade Analyzer', path: '/trade', icon: '🔄', group: 'Tools' },
+  ...(FF_MINIGAMES
+    ? [
+        { label: 'Minigames', path: '/minigames', icon: '🎮', group: 'Minigames' },
+        { label: 'Hangman', path: '/minigames/hangman', icon: '🔤', group: 'Minigames' },
+        { label: 'Who He Play For?', path: '/minigames/who-he-play-for', icon: '🏟️', group: 'Minigames' },
+        { label: 'Who Am I?', path: '/minigames/who-am-i', icon: '🕵️', group: 'Minigames' },
+        { label: 'Now You See Me', path: '/minigames/now-you-see-me', icon: '👁️', group: 'Minigames' },
+      ]
+    : []),
+  { label: 'NBA Depth Charts', path: '/nba-teams', icon: '🏀', group: 'NBA' },
+  { label: 'Injuries', path: '/injuries', icon: '🩺', group: 'NBA' },
+]

--- a/frontend/src/hooks/useGlobalSearch.ts
+++ b/frontend/src/hooks/useGlobalSearch.ts
@@ -1,0 +1,178 @@
+import { useMemo } from 'react'
+import { useGetAllPlayersQuery, useGetTeamsListQuery, useGetNbaTeamsListQuery } from '../store/api/fantasyApi'
+import { SEARCHABLE_PAGES } from '../constants/searchablePages'
+import type { Player, Team, NbaTeamInfo } from '../types/api'
+import type { SearchablePage } from '../constants/searchablePages'
+
+export type SearchResultGroup = 'Players' | 'Fantasy teams' | 'NBA teams' | 'Pages'
+
+export interface SearchResult {
+  group: SearchResultGroup
+  key: string
+  icon: string
+  title: string
+  subtitle: string
+  path: string
+  badge?: { label: string; tone: 'fa' | 'out' }
+}
+
+const MAX_PER_GROUP = 6
+
+/** exact-prefix (3) > word-start match (2) > substring (1) > no match (0) */
+function matchScore(text: string, query: string): number {
+  if (!query) return 1
+  const t = text.toLowerCase()
+  const q = query.toLowerCase()
+  if (t.startsWith(q)) return 3
+  if (t.split(/[\s-]+/).some((word) => word.startsWith(q))) return 2
+  if (t.includes(q)) return 1
+  return 0
+}
+
+function bestScore(texts: string[], query: string): number {
+  return Math.max(0, ...texts.map((t) => matchScore(t, query)))
+}
+
+function rankAndCap<T>(items: Array<{ item: T; score: number }>, cap: number): T[] {
+  return items
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, cap)
+    .map((x) => x.item)
+}
+
+function playerOwnerText(player: Player): string {
+  if (player.status === 'FREEAGENT') return 'Free Agent'
+  if (player.status === 'WAIVERS') return 'Waivers'
+  return player.fantasy_team_name || 'On a team'
+}
+
+function toPlayerResult(player: Player): SearchResult {
+  const badge: SearchResult['badge'] = player.injured
+    ? { label: 'OUT', tone: 'out' }
+    : player.status === 'FREEAGENT'
+      ? { label: 'FA', tone: 'fa' }
+      : undefined
+  return {
+    group: 'Players',
+    key: `player-${player.player_name}`,
+    icon: '🏀',
+    title: player.player_name,
+    subtitle: `${player.pro_team} · ${player.positions.join('/')} · ${playerOwnerText(player)}`,
+    path: player.player_id != null ? `/player/${player.player_id}` : '',
+    badge,
+  }
+}
+
+function toTeamResult(team: Team): SearchResult {
+  return {
+    group: 'Fantasy teams',
+    key: `team-${team.team_id}`,
+    icon: '👥',
+    title: team.team_name,
+    subtitle: `Fantasy team #${team.team_id}`,
+    path: `/team/${team.team_id}`,
+  }
+}
+
+function toNbaTeamResult(team: NbaTeamInfo): SearchResult {
+  return {
+    group: 'NBA teams',
+    key: `nba-${team.team_id}`,
+    icon: '🏟️',
+    title: team.team_name,
+    subtitle: team.abbreviation,
+    path: `/nba-teams?team=${encodeURIComponent(team.team_id)}`,
+  }
+}
+
+function toPageResult(page: SearchablePage): SearchResult {
+  return {
+    group: 'Pages',
+    key: `page-${page.path}`,
+    icon: page.icon,
+    title: page.label,
+    subtitle: page.group,
+    path: page.path,
+  }
+}
+
+/**
+ * Merges players / fantasy teams / NBA teams / static pages into one ranked,
+ * grouped result list. Reuses whatever's already in the RTK Query cache
+ * (same query args as Players.tsx / Teams.tsx / NbaTeams.tsx) rather than
+ * issuing new fetches.
+ */
+export function useGlobalSearch(query: string) {
+  const { data: playersData, isFetching: playersLoading } = useGetAllPlayersQuery({
+    page: 1,
+    limit: 1200,
+    time_period: 'season',
+  })
+  const { data: teams, isFetching: teamsLoading } = useGetTeamsListQuery()
+  const { data: nbaTeams, isFetching: nbaTeamsLoading } = useGetNbaTeamsListQuery()
+
+  const trimmed = query.trim()
+
+  const results = useMemo(() => {
+    const players = playersData?.players ?? []
+
+    const playerResults = rankAndCap(
+      players.map((p) => ({
+        item: p,
+        score: bestScore([p.player_name], trimmed),
+      })),
+      MAX_PER_GROUP
+    ).map(toPlayerResult)
+
+    const teamResults = rankAndCap(
+      (teams ?? []).map((t) => ({
+        item: t,
+        score: bestScore([t.team_name], trimmed),
+      })),
+      MAX_PER_GROUP
+    ).map(toTeamResult)
+
+    const nbaTeamResults = rankAndCap(
+      (nbaTeams ?? []).map((t) => ({
+        item: t,
+        score: bestScore([t.team_name, t.abbreviation], trimmed),
+      })),
+      MAX_PER_GROUP
+    ).map(toNbaTeamResult)
+
+    const pageResults = rankAndCap(
+      SEARCHABLE_PAGES.map((p) => ({
+        item: p,
+        score: bestScore([p.label, p.group], trimmed),
+      })),
+      MAX_PER_GROUP
+    ).map(toPageResult)
+
+    return [...playerResults, ...teamResults, ...nbaTeamResults, ...pageResults]
+  }, [playersData, teams, nbaTeams, trimmed])
+
+  const groups = useMemo(() => {
+    const order: SearchResultGroup[] = ['Players', 'Fantasy teams', 'NBA teams', 'Pages']
+    return order
+      .map((group) => ({ group, items: results.filter((r) => r.group === group) }))
+      .filter((g) => g.items.length > 0)
+  }, [results])
+
+  return {
+    results,
+    groups,
+    isLoading: trimmed.length > 0 && (playersLoading || teamsLoading || nbaTeamsLoading) && results.length === 0,
+  }
+}
+
+export function highlightMatch(text: string, query: string): { before: string; match: string; after: string } | null {
+  if (!query) return null
+  const idx = text.toLowerCase().indexOf(query.toLowerCase())
+  if (idx < 0) return null
+  return {
+    before: text.slice(0, idx),
+    match: text.slice(idx, idx + query.length),
+    after: text.slice(idx + query.length),
+  }
+}

--- a/frontend/src/pages/NbaTeams.tsx
+++ b/frontend/src/pages/NbaTeams.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router';
 import { usePersistedState, usePersistedSetState } from '../hooks/usePersistedState';
 import { useGetNbaTeamsListQuery, useGetNbaTeamDepthChartQuery } from '../store/api/fantasyApi';
 import LoadingSpinner from '../components/LoadingSpinner';
@@ -153,7 +154,13 @@ function DepthChartView({ teamId }: { teamId: string }) {
 
 export default function NbaTeams() {
   const { data: teams, isLoading, error } = useGetNbaTeamsListQuery();
-  const [selectedTeamId, setSelectedTeamId] = useState<string>('');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedTeamId, setSelectedTeamId] = useState<string>(searchParams.get('team') ?? '');
+
+  const handleSelectTeam = (teamId: string) => {
+    setSelectedTeamId(teamId);
+    setSearchParams(teamId ? { team: teamId } : {}, { replace: true });
+  };
 
   return (
     <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -173,7 +180,7 @@ export default function NbaTeams() {
           <div className="mb-6">
             <select
               value={selectedTeamId}
-              onChange={(e) => setSelectedTeamId(e.target.value)}
+              onChange={(e) => handleSelectTeam(e.target.value)}
               className="w-full sm:w-72 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
               <option value="">Select a team...</option>


### PR DESCRIPTION
## Summary
- One overlay searches players, fantasy teams, NBA teams, and pages — opened via Ctrl/Cmd+K or a navbar search bar (mobile gets an icon next to the hamburger, since no global player search existed there at all).
- NBA team results deep-link straight to that team's depth chart (`?team=` param on NbaTeams) instead of the bare list page.
- Search filters on the raw query rather than a debounced one — the debounce bought nothing (pure in-memory filtering) and could let Enter race a stale result set.
- Navbar trigger redesigned as an actual pill-shaped search bar (magnifier icon, muted placeholder) instead of a bordered button.

## Test plan
- [x] `tsc -b` clean
- [x] Manually verified: Ctrl+K opens from any page, typing filters live, arrow keys + Enter navigate, Esc/outside-click closes, mobile icon opens full-screen version, dark mode
- [x] Player/team/NBA-team results confirmed against real loaded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)