### PR TITLE
fix(frontend): local-date helpers instead of UTC-shifted toISOString

### DIFF
--- a/frontend/src/components/DateRangePicker.tsx
+++ b/frontend/src/components/DateRangePicker.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react'
 import type { CustomDateRange } from '../types/api'
-import { validateDateRange, formatShort } from '../utils/dateRange'
-
-const todayIso = () => new Date().toISOString().split('T')[0]
+import { validateDateRange, formatShort, todayIso } from '../utils/dateRange'
 
 interface DateRangePickerProps {
   seasonStart?: string

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -8,6 +8,7 @@ import ShootingStatsSection from '../components/ShootingStatsSection'
 import type { HeatmapData, Team } from '../types/api'
 import { getHeatmapColor, getTextColor } from '../utils/colorUtils'
 import { FF_NAV_REORG } from '../config/featureFlags'
+import { todayIso, getDateNDaysAgo } from '../utils/dateRange'
 
 type AnalyticsTab = 'heatmap' | 'rankingsOverTime' | 'shootingStats'
 
@@ -52,13 +53,7 @@ const Analytics = () => {
   const [dateError, setDateError] = useState<string>('')
   const [appliedDates, setAppliedDates] = useState<{ startDate?: string; endDate?: string }>({})
 
-  const today = new Date().toISOString().split('T')[0]
-
-  function getDateNDaysAgo(n: number): string {
-    const d = new Date();
-    d.setDate(d.getDate() - n);
-    return d.toISOString().split('T')[0];
-  }
+  const today = todayIso()
 
   const { data: heatmapData, error, isLoading } = useGetHeatmapDataQuery(appliedDates)
   const { data: summary } = useGetLeagueSummaryQuery()

--- a/frontend/src/pages/Rankings.tsx
+++ b/frontend/src/pages/Rankings.tsx
@@ -5,6 +5,7 @@ import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import DataDateBadge from '../components/DataDateBadge'
 import type { RankingStats } from '../types/api'
+import { todayIso, getDateNDaysAgo } from '../utils/dateRange'
 
 const formatDate = (d: string) =>
   new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
@@ -18,13 +19,7 @@ const Rankings = () => {
   const [dateError, setDateError] = useState<string>('')
   const [appliedDates, setAppliedDates] = useState<{ startDate?: string; endDate?: string }>({})
 
-  const today = new Date().toISOString().split('T')[0]
-
-  function getDateNDaysAgo(n: number): string {
-    const d = new Date();
-    d.setDate(d.getDate() - n);
-    return d.toISOString().split('T')[0];
-  }
+  const today = todayIso()
 
   const { data, error, isLoading } = useGetRankingsQuery(appliedDates)
   const { data: summary, isLoading: summaryLoading } = useGetLeagueSummaryQuery()

--- a/frontend/src/utils/__tests__/dateRange.test.ts
+++ b/frontend/src/utils/__tests__/dateRange.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
-import { validateDateRange } from '../dateRange'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { daysBetween, toLocalIso, validateDateRange } from '../dateRange'
+
+declare const process: { env: Record<string, string | undefined> }
 
 const SEASON_START = '2025-10-22'
 const TODAY = '2026-07-10'
@@ -33,5 +35,38 @@ describe('validateDateRange', () => {
 
   it('works without a seasonStart bound', () => {
     expect(validateDateRange('2020-01-01', '2026-01-01', undefined, TODAY)).toBeNull()
+  })
+})
+
+describe('toLocalIso / daysBetween (Asia/Jerusalem)', () => {
+  const originalTZ = process.env.TZ
+
+  beforeAll(() => {
+    process.env.TZ = 'Asia/Jerusalem'
+  })
+
+  afterAll(() => {
+    process.env.TZ = originalTZ
+  })
+
+  it('does not roll back a day for a local midnight just past UTC rollover', () => {
+    const localMidnight = new Date(2026, 0, 15, 0, 30)
+    expect(toLocalIso(localMidnight)).toBe('2026-01-15')
+  })
+
+  it('formats a plain local date correctly', () => {
+    expect(toLocalIso(new Date(2026, 6, 4))).toBe('2026-07-04')
+  })
+
+  it('is exact across the spring-forward DST boundary', () => {
+    expect(daysBetween('2026-03-25', '2026-03-30')).toBe(5)
+  })
+
+  it('is exact across the fall-back DST boundary', () => {
+    expect(daysBetween('2025-10-20', '2025-10-27')).toBe(7)
+  })
+
+  it('returns 0 for the same date', () => {
+    expect(daysBetween('2026-01-01', '2026-01-01')).toBe(0)
   })
 })

--- a/frontend/src/utils/dateRange.ts
+++ b/frontend/src/utils/dateRange.ts
@@ -1,4 +1,27 @@
-const todayIso = () => new Date().toISOString().split('T')[0]
+export function toLocalIso(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function daysBetween(startIso: string, endIso: string): number {
+  const [startYear, startMonth, startDay] = startIso.split('-').map(Number)
+  const [endYear, endMonth, endDay] = endIso.split('-').map(Number)
+  const start = new Date(startYear, startMonth - 1, startDay)
+  const end = new Date(endYear, endMonth - 1, endDay)
+  const startUtcMs = Date.UTC(start.getFullYear(), start.getMonth(), start.getDate())
+  const endUtcMs = Date.UTC(end.getFullYear(), end.getMonth(), end.getDate())
+  return Math.round((endUtcMs - startUtcMs) / 86400000)
+}
+
+export function getDateNDaysAgo(n: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return toLocalIso(d)
+}
+
+export const todayIso = () => toLocalIso(new Date())
 
 export const formatShort = (d: string) =>
   new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })


### PR DESCRIPTION
## Summary
- `new Date().toISOString()` returns the UTC date — rolls back a day in Israel (UTC+2/+3) between local midnight and 02:00-03:00.
- Adds `toLocalIso`/`daysBetween`/`getDateNDaysAgo` in `dateRange.ts`, built on local `getFullYear/getMonth/getDate`; `daysBetween` diffs via `Date.UTC` of local components so DST transitions don't skew the count.
- Repoints the 4 known UTC-date call sites: `dateRange.ts` (`todayIso`), `DateRangePicker.tsx`, `Analytics.tsx`, `Rankings.tsx`. Full repo grep for `.toISOString()` in frontend/src confirms no other date-only sites remain.
- Phase P0 of `trends_implementation_plan.html` — ships alone, foundation for the Trends dynamic-window work.

## Test plan
- [x] `npm run build` clean (tsc + vite)
- [x] Full vitest suite: 169 passed | 3 skipped
- [x] New TZ-forced (Asia/Jerusalem) tests: local midnight doesn't roll back a day; `daysBetween` exact across both 2026 DST boundaries
- [x] Browser regression check on Analytics/Rankings presets (daytime only — can't fake system clock for the actual bug window, covered by unit tests instead)
- [x] pre-push tsc --noEmit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)