### PR TITLE
feat(backend): clamp trend window_days instead of snapping to preset

### DIFF
--- a/backend/app/routes/trends.py
+++ b/backend/app/routes/trends.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
 from app.models.trend_models import (
     GameLogResponse,
@@ -12,6 +12,8 @@ from app.services.trend_service import (
     DEFAULT_BASELINE_SEASONS,
     DEFAULT_RECENCY_WINDOW_DAYS,
     DEFAULT_REGRESSION_MODE,
+    MAX_RECENCY_WINDOW_DAYS,
+    MIN_RECENCY_WINDOW_DAYS,
     TrendService,
 )
 
@@ -23,7 +25,7 @@ _data_provider = DataProvider()
 
 @router.get('/regression', response_model=RegressionResponse)
 async def get_shooting_regression(
-    window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
     mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> RegressionResponse:
@@ -32,13 +34,17 @@ async def get_shooting_regression(
 
 
 @router.get('/minutes', response_model=MinutesResponse)
-async def get_minutes_movers(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> MinutesResponse:
+async def get_minutes_movers(
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
+) -> MinutesResponse:
     players_df = await _data_provider.get_players_df()
     return await _trend_service.get_minutes_movers(players_df, window_days)
 
 
 @router.get('/usage', response_model=UsageResponse)
-async def get_usage_role(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> UsageResponse:
+async def get_usage_role(
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
+) -> UsageResponse:
     players_df = await _data_provider.get_players_df()
     return await _trend_service.get_usage_role(players_df, window_days)
 
@@ -46,7 +52,7 @@ async def get_usage_role(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> Usag
 @router.get('/player/{player_id}/gamelog', response_model=GameLogResponse)
 async def get_player_game_log(
     player_id: int,
-    window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
     mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> GameLogResponse:

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 DRIFT_THRESHOLD = 0.35  # makes/g-equivalent, provisional — see trends_page_plan.md
 DEFAULT_RECENCY_WINDOW_DAYS = 15
 VALID_RECENCY_WINDOWS_DAYS = (7, 15, 30)
+MIN_RECENCY_WINDOW_DAYS = 5
+MAX_RECENCY_WINDOW_DAYS = 60
 _TREND_CACHE_TTL = timedelta(hours=6)
 
 # current_min_att / baseline_min_att: sample-size gates below which a pct is
@@ -495,7 +497,7 @@ def build_game_log(
 
 
 def _normalize_window_days(window_days: int) -> int:
-    return window_days if window_days in VALID_RECENCY_WINDOWS_DAYS else DEFAULT_RECENCY_WINDOW_DAYS
+    return max(MIN_RECENCY_WINDOW_DAYS, min(MAX_RECENCY_WINDOW_DAYS, window_days))
 
 
 def _normalize_baseline_seasons(baseline_seasons: int, mode: RegressionMode = DEFAULT_REGRESSION_MODE) -> int:

--- a/backend/tests/routes/test_trends_route.py
+++ b/backend/tests/routes/test_trends_route.py
@@ -231,3 +231,27 @@ def test_get_game_log_404_when_no_rows(mock_services):
     resp = client.get('/api/trends/player/999/gamelog')
 
     assert resp.status_code == 404
+
+
+@pytest.mark.parametrize('endpoint', [
+    '/api/trends/regression',
+    '/api/trends/minutes',
+    '/api/trends/usage',
+    '/api/trends/player/1630245/gamelog',
+])
+@pytest.mark.parametrize('window_days', [0, 4, 61, 500])
+def test_out_of_range_window_days_returns_422(mock_services, endpoint, window_days):
+    client = TestClient(app)
+    resp = client.get(f'{endpoint}?window_days={window_days}')
+
+    assert resp.status_code == 422
+
+
+def test_in_range_off_preset_window_days_is_honoured(mock_services):
+    svc, _ = mock_services
+    client = TestClient(app)
+    resp = client.get('/api/trends/minutes?window_days=21')
+
+    assert resp.status_code == 200
+    svc.get_minutes_movers.assert_awaited_once()
+    assert svc.get_minutes_movers.call_args.args[1] == 21

--- a/backend/tests/services/test_trend_service.py
+++ b/backend/tests/services/test_trend_service.py
@@ -8,8 +8,11 @@ import pytest
 from app.config import settings
 from app.services import trend_service
 from app.services.trend_service import (
+    MAX_RECENCY_WINDOW_DAYS,
+    MIN_RECENCY_WINDOW_DAYS,
     TrendService,
     _normalize_baseline_seasons,
+    _normalize_window_days,
     _TTLLRUCache,
     build_game_log,
     classify_role_badge,
@@ -958,6 +961,23 @@ class TestCachePresetResponse:
         svc._cache_preset_response(cache, 15, 15, 'response')
 
         assert cache[15]['data'] == 'response'
+
+
+class TestNormalizeWindowDays:
+    def test_below_min_clamps_up(self):
+        assert _normalize_window_days(1) == MIN_RECENCY_WINDOW_DAYS
+
+    def test_above_max_clamps_down(self):
+        assert _normalize_window_days(500) == MAX_RECENCY_WINDOW_DAYS
+
+    def test_off_preset_value_is_honoured(self):
+        assert _normalize_window_days(21) == 21
+
+    def test_min_boundary_passes_through(self):
+        assert _normalize_window_days(MIN_RECENCY_WINDOW_DAYS) == MIN_RECENCY_WINDOW_DAYS
+
+    def test_max_boundary_passes_through(self):
+        assert _normalize_window_days(MAX_RECENCY_WINDOW_DAYS) == MAX_RECENCY_WINDOW_DAYS
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Stacked on #167 (P1) — merge that first.
- `_normalize_window_days` silently rewrote any requested `window_days` to the nearest of `{7, 15, 30}`. Replaces with `MIN_RECENCY_WINDOW_DAYS=5` / `MAX_RECENCY_WINDOW_DAYS=60` clamp so arbitrary windows are honoured.
- Adds `Query(..., ge=5, le=60)` to `window_days` on all four trends routes — out-of-range input now 422s at the edge instead of being silently rewritten.
- P1's preset-only response caching guard is untouched — non-preset windows still skip `_minutes_cache`/`_usage_cache`/`_regression_cache` and compute fresh.
- Phase P3 of `trends_implementation_plan.html`. "Natural checkpoint" per the plan — after this the backend fully supports arbitrary windows; frontend still shows only 3 preset buttons until P4.

## Test plan
- [x] Full pytest suite: 489 passed
- [x] Live curl verification: `window_days=21` → 200 real computation (not snapped); `window_days=0` and `window_days=500` → 422; `window_days=15` preset still works; 422 confirmed on all 4 routes including the player gamelog route

🤖 Generated with [Claude Code](https://claude.com/claude-code)