### PR TITLE
feat(backend): coalesce in-flight trend cache misses

### DIFF
--- a/backend/app/routes/trends.py
+++ b/backend/app/routes/trends.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
 from app.models.trend_models import (
     GameLogResponse,
@@ -12,6 +12,8 @@ from app.services.trend_service import (
     DEFAULT_BASELINE_SEASONS,
     DEFAULT_RECENCY_WINDOW_DAYS,
     DEFAULT_REGRESSION_MODE,
+    MAX_RECENCY_WINDOW_DAYS,
+    MIN_RECENCY_WINDOW_DAYS,
     TrendService,
 )
 
@@ -23,7 +25,7 @@ _data_provider = DataProvider()
 
 @router.get('/regression', response_model=RegressionResponse)
 async def get_shooting_regression(
-    window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
     mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> RegressionResponse:
@@ -32,13 +34,17 @@ async def get_shooting_regression(
 
 
 @router.get('/minutes', response_model=MinutesResponse)
-async def get_minutes_movers(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> MinutesResponse:
+async def get_minutes_movers(
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
+) -> MinutesResponse:
     players_df = await _data_provider.get_players_df()
     return await _trend_service.get_minutes_movers(players_df, window_days)
 
 
 @router.get('/usage', response_model=UsageResponse)
-async def get_usage_role(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> UsageResponse:
+async def get_usage_role(
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
+) -> UsageResponse:
     players_df = await _data_provider.get_players_df()
     return await _trend_service.get_usage_role(players_df, window_days)
 
@@ -46,7 +52,7 @@ async def get_usage_role(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> Usag
 @router.get('/player/{player_id}/gamelog', response_model=GameLogResponse)
 async def get_player_game_log(
     player_id: int,
-    window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
     mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> GameLogResponse:

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import math
 from collections import OrderedDict
@@ -557,13 +558,21 @@ class TrendService:
         self._db = DBService()
         self._anchor: Optional[date] = None
         self._regression_cache: dict[tuple[int, int, str], dict] = {}
+        self._regression_inflight: dict[tuple[int, int, str], asyncio.Future] = {}
         self._minutes_cache: dict[int, dict] = {}
+        self._minutes_inflight: dict[int, asyncio.Future] = {}
         self._usage_cache: dict[int, dict] = {}
+        self._usage_inflight: dict[int, asyncio.Future] = {}
         self._game_log_cache = _TTLLRUCache(maxsize=_GAME_LOG_CACHE_MAXSIZE, ttl=_TREND_CACHE_TTL)
+        self._game_log_inflight: dict[tuple, asyncio.Future] = {}
         self._league_cache: dict[str, dict] = {}
+        self._league_inflight: dict[str, asyncio.Future] = {}
         self._season_shooting_cache: dict[str, pd.DataFrame] = {}
+        self._season_shooting_inflight: dict[str, asyncio.Future] = {}
         self._season_usage_cache: dict[str, pd.DataFrame] = {}
+        self._season_usage_inflight: dict[str, asyncio.Future] = {}
         self._baseline_cache: dict[int, pd.DataFrame] = {}
+        self._baseline_inflight: dict[int, asyncio.Future] = {}
 
     @staticmethod
     def _cache_valid(cache: dict, key) -> bool:
@@ -574,6 +583,32 @@ class TrendService:
     def _cache_preset_response(cache: dict, window_days: int, cache_key, response) -> None:
         if window_days in VALID_RECENCY_WINDOWS_DAYS:
             cache[cache_key] = {'data': response, 'ts': datetime.now()}
+
+    @staticmethod
+    async def _coalesced(inflight: dict, key, compute):
+        """First caller on `key` runs `compute` and registers its Future so
+        concurrent callers on the same key await it instead of issuing a
+        duplicate DB round-trip. The finally block must run even when compute()
+        raises — otherwise a failed computation leaves its Future registered
+        forever and every later caller on that key awaits a permanently-failed
+        Future until process restart."""
+        existing = inflight.get(key)
+        if existing is not None:
+            return await existing
+
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        inflight[key] = future
+        try:
+            result = await compute()
+        except BaseException as exc:
+            future.set_exception(exc)
+            future.exception()
+            raise
+        else:
+            future.set_result(result)
+            return result
+        finally:
+            inflight.pop(key, None)
 
     def _sync_anchor(self, anchor: date) -> None:
         """anchor is deliberately not part of any cache key: it advances at
@@ -594,18 +629,28 @@ class TrendService:
         self._anchor = anchor
 
     async def _get_season_shooting(self, season: str, anchor: date) -> pd.DataFrame:
-        if season not in self._season_shooting_cache:
-            self._season_shooting_cache[season] = await self._db.aggregate_shooting_by_player(
+        if season in self._season_shooting_cache:
+            return self._season_shooting_cache[season]
+
+        async def _compute():
+            df = await self._db.aggregate_shooting_by_player(
                 [season], start=settings.season_start, end=anchor
             )
-        return self._season_shooting_cache[season]
+            self._season_shooting_cache[season] = df
+            return df
+
+        return await self._coalesced(self._season_shooting_inflight, season, _compute)
 
     async def _get_season_usage(self, season: str, anchor: date) -> pd.DataFrame:
-        if season not in self._season_usage_cache:
-            self._season_usage_cache[season] = await self._db.get_usage_components(
-                season, settings.season_start, anchor
-            )
-        return self._season_usage_cache[season]
+        if season in self._season_usage_cache:
+            return self._season_usage_cache[season]
+
+        async def _compute():
+            df = await self._db.get_usage_components(season, settings.season_start, anchor)
+            self._season_usage_cache[season] = df
+            return df
+
+        return await self._coalesced(self._season_usage_inflight, season, _compute)
 
     async def get_shooting_regression(
         self,
@@ -625,26 +670,29 @@ class TrendService:
         if self._cache_valid(self._regression_cache, cache_key):
             return self._regression_cache[cache_key]['data']
 
-        window_start = anchor_date - timedelta(days=window_days)
-        current_df = await self._get_season_shooting(current_season, anchor_date)
-        window_df = await self._db.aggregate_shooting_by_player(
-            [current_season], start=window_start, end=anchor_date
-        )
-        baseline_df = await self._prior_shooting(baseline_seasons)
-        games_last_15d = await self._db.get_games_since(window_start)
+        async def _compute():
+            window_start = anchor_date - timedelta(days=window_days)
+            current_df = await self._get_season_shooting(current_season, anchor_date)
+            window_df = await self._db.aggregate_shooting_by_player(
+                [current_season], start=window_start, end=anchor_date
+            )
+            baseline_df = await self._prior_shooting(baseline_seasons)
+            games_last_15d = await self._db.get_games_since(window_start)
 
-        groups = compute_regression_groups(
-            current_df, baseline_df, games_last_15d, players_df, baseline_seasons, window_df, mode
-        )
-        response = RegressionResponse(
-            items=groups,
-            window_days=window_days,
-            baseline_seasons=baseline_seasons,
-            mode=mode,
-            last_updated=datetime.now().isoformat(),
-        )
-        self._cache_preset_response(self._regression_cache, window_days, cache_key, response)
-        return response
+            groups = compute_regression_groups(
+                current_df, baseline_df, games_last_15d, players_df, baseline_seasons, window_df, mode
+            )
+            response = RegressionResponse(
+                items=groups,
+                window_days=window_days,
+                baseline_seasons=baseline_seasons,
+                mode=mode,
+                last_updated=datetime.now().isoformat(),
+            )
+            self._cache_preset_response(self._regression_cache, window_days, cache_key, response)
+            return response
+
+        return await self._coalesced(self._regression_inflight, cache_key, _compute)
 
     async def get_minutes_movers(self, players_df: pd.DataFrame, window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> MinutesResponse:
         window_days = _normalize_window_days(window_days)
@@ -656,17 +704,20 @@ class TrendService:
         if self._cache_valid(self._minutes_cache, window_days):
             return self._minutes_cache[window_days]['data']
 
-        window_start = anchor_date - timedelta(days=window_days)
-        season_df = await self._get_season_shooting(current_season, anchor_date)
-        window_df = await self._db.aggregate_shooting_by_player(
-            [current_season], start=window_start, end=anchor_date
-        )
-        games_last_15d = await self._db.get_games_since(window_start)
+        async def _compute():
+            window_start = anchor_date - timedelta(days=window_days)
+            season_df = await self._get_season_shooting(current_season, anchor_date)
+            window_df = await self._db.aggregate_shooting_by_player(
+                [current_season], start=window_start, end=anchor_date
+            )
+            games_last_15d = await self._db.get_games_since(window_start)
 
-        items = compute_minutes_movers(season_df, window_df, games_last_15d, players_df)
-        response = MinutesResponse(items=items, window_days=window_days, last_updated=datetime.now().isoformat())
-        self._cache_preset_response(self._minutes_cache, window_days, window_days, response)
-        return response
+            items = compute_minutes_movers(season_df, window_df, games_last_15d, players_df)
+            response = MinutesResponse(items=items, window_days=window_days, last_updated=datetime.now().isoformat())
+            self._cache_preset_response(self._minutes_cache, window_days, window_days, response)
+            return response
+
+        return await self._coalesced(self._minutes_inflight, window_days, _compute)
 
     async def get_usage_role(self, players_df: pd.DataFrame, window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> UsageResponse:
         window_days = _normalize_window_days(window_days)
@@ -678,22 +729,29 @@ class TrendService:
         if self._cache_valid(self._usage_cache, window_days):
             return self._usage_cache[window_days]['data']
 
-        window_start = anchor_date - timedelta(days=window_days)
-        games_df = await self._get_season_usage(current_season, anchor_date)
-        games_last_15d = await self._db.get_games_since(window_start)
+        async def _compute():
+            window_start = anchor_date - timedelta(days=window_days)
+            games_df = await self._get_season_usage(current_season, anchor_date)
+            games_last_15d = await self._db.get_games_since(window_start)
 
-        items = compute_usage_role(games_df, games_last_15d, players_df, window_start)
-        response = UsageResponse(items=items, window_days=window_days, last_updated=datetime.now().isoformat())
-        self._cache_preset_response(self._usage_cache, window_days, window_days, response)
-        return response
+            items = compute_usage_role(games_df, games_last_15d, players_df, window_start)
+            response = UsageResponse(items=items, window_days=window_days, last_updated=datetime.now().isoformat())
+            self._cache_preset_response(self._usage_cache, window_days, window_days, response)
+            return response
+
+        return await self._coalesced(self._usage_inflight, window_days, _compute)
 
     async def _prior_shooting(self, baseline_seasons: int) -> pd.DataFrame:
-        if baseline_seasons not in self._baseline_cache:
+        if baseline_seasons in self._baseline_cache:
+            return self._baseline_cache[baseline_seasons]
+
+        async def _compute():
             seasons = prior_season_strings(baseline_seasons)
-            self._baseline_cache[baseline_seasons] = (
-                await self._db.aggregate_shooting_by_player(seasons) if seasons else pd.DataFrame()
-            )
-        return self._baseline_cache[baseline_seasons]
+            df = await self._db.aggregate_shooting_by_player(seasons) if seasons else pd.DataFrame()
+            self._baseline_cache[baseline_seasons] = df
+            return df
+
+        return await self._coalesced(self._baseline_inflight, baseline_seasons, _compute)
 
     async def _get_league_refs(self, season: str, end) -> tuple[dict[str, float], Optional[float]]:
         """League-wide shooting pcts and USG%, cached together — one pull serves
@@ -708,17 +766,21 @@ class TrendService:
             entry = self._league_cache[season]
             return entry['pct'], entry['usg']
 
-        shooting_df = await self._get_season_shooting(season, end)
-        usage_df = await self._get_season_usage(season, end)
-        league_usg = None
-        if not usage_df.empty:
-            usg = usage_df.apply(_usg_per_game, axis=1)
-            total_min = usage_df['p_min'].sum()
-            if total_min:
-                league_usg = float((usg * usage_df['p_min']).sum() / total_min)
+        async def _compute():
+            shooting_df = await self._get_season_shooting(season, end)
+            usage_df = await self._get_season_usage(season, end)
+            league_usg = None
+            if not usage_df.empty:
+                usg = usage_df.apply(_usg_per_game, axis=1)
+                total_min = usage_df['p_min'].sum()
+                if total_min:
+                    league_usg = float((usg * usage_df['p_min']).sum() / total_min)
 
-        data = {'pct': _league_pct_map(shooting_df), 'usg': league_usg}
-        self._league_cache[season] = data
+            data = {'pct': _league_pct_map(shooting_df), 'usg': league_usg}
+            self._league_cache[season] = data
+            return data
+
+        data = await self._coalesced(self._league_inflight, season, _compute)
         return data['pct'], data['usg']
 
     async def get_player_game_log(
@@ -740,26 +802,29 @@ class TrendService:
         if cached is not None:
             return cached
 
-        window_start = anchor_date - timedelta(days=window_days)
+        async def _compute():
+            window_start = anchor_date - timedelta(days=window_days)
 
-        games_df = await self._db.get_player_game_log(
-            player_id, current_season, settings.season_start, anchor_date
-        )
-        if games_df.empty:
-            return None
+            games_df = await self._db.get_player_game_log(
+                player_id, current_season, settings.season_start, anchor_date
+            )
+            if games_df.empty:
+                return None
 
-        baseline_df = await self._prior_shooting(baseline_seasons)
-        baseline_pct = (
-            _form_baseline_pct(baseline_df, games_df, player_id, window_start)
-            if mode == 'form'
-            else _player_pct_map(baseline_df, player_id)
-        )
+            baseline_df = await self._prior_shooting(baseline_seasons)
+            baseline_pct = (
+                _form_baseline_pct(baseline_df, games_df, player_id, window_start)
+                if mode == 'form'
+                else _player_pct_map(baseline_df, player_id)
+            )
 
-        league_pct, league_usg = await self._get_league_refs(current_season, anchor_date)
+            league_pct, league_usg = await self._get_league_refs(current_season, anchor_date)
 
-        response = build_game_log(
-            games_df, player_id, current_season, window_days, window_start,
-            baseline_pct, baseline_seasons, league_pct, league_usg,
-        )
-        self._game_log_cache.set(cache_key, response)
-        return response
+            response = build_game_log(
+                games_df, player_id, current_season, window_days, window_start,
+                baseline_pct, baseline_seasons, league_pct, league_usg,
+            )
+            self._game_log_cache.set(cache_key, response)
+            return response
+
+        return await self._coalesced(self._game_log_inflight, cache_key, _compute)

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 DRIFT_THRESHOLD = 0.35  # makes/g-equivalent, provisional — see trends_page_plan.md
 DEFAULT_RECENCY_WINDOW_DAYS = 15
 VALID_RECENCY_WINDOWS_DAYS = (7, 15, 30)
+MIN_RECENCY_WINDOW_DAYS = 5
+MAX_RECENCY_WINDOW_DAYS = 60
 _TREND_CACHE_TTL = timedelta(hours=6)
 
 # current_min_att / baseline_min_att: sample-size gates below which a pct is
@@ -495,7 +497,7 @@ def build_game_log(
 
 
 def _normalize_window_days(window_days: int) -> int:
-    return window_days if window_days in VALID_RECENCY_WINDOWS_DAYS else DEFAULT_RECENCY_WINDOW_DAYS
+    return max(MIN_RECENCY_WINDOW_DAYS, min(MAX_RECENCY_WINDOW_DAYS, window_days))
 
 
 def _normalize_baseline_seasons(baseline_seasons: int, mode: RegressionMode = DEFAULT_REGRESSION_MODE) -> int:

--- a/backend/tests/routes/test_trends_route.py
+++ b/backend/tests/routes/test_trends_route.py
@@ -231,3 +231,27 @@ def test_get_game_log_404_when_no_rows(mock_services):
     resp = client.get('/api/trends/player/999/gamelog')
 
     assert resp.status_code == 404
+
+
+@pytest.mark.parametrize('endpoint', [
+    '/api/trends/regression',
+    '/api/trends/minutes',
+    '/api/trends/usage',
+    '/api/trends/player/1630245/gamelog',
+])
+@pytest.mark.parametrize('window_days', [0, 4, 61, 500])
+def test_out_of_range_window_days_returns_422(mock_services, endpoint, window_days):
+    client = TestClient(app)
+    resp = client.get(f'{endpoint}?window_days={window_days}')
+
+    assert resp.status_code == 422
+
+
+def test_in_range_off_preset_window_days_is_honoured(mock_services):
+    svc, _ = mock_services
+    client = TestClient(app)
+    resp = client.get('/api/trends/minutes?window_days=21')
+
+    assert resp.status_code == 200
+    svc.get_minutes_movers.assert_awaited_once()
+    assert svc.get_minutes_movers.call_args.args[1] == 21

--- a/backend/tests/services/test_trend_service.py
+++ b/backend/tests/services/test_trend_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from datetime import date, datetime, timedelta
 from unittest.mock import AsyncMock, patch
@@ -1072,3 +1073,51 @@ class TestAnchorInvalidation:
         pct_2, _ = await svc._get_league_refs('2025-26', date(2026, 1, 10))
 
         assert pct_1['FG%'] != pct_2['FG%']
+
+
+@pytest.mark.asyncio
+class TestInFlightCoalescing:
+    async def test_concurrent_callers_on_same_key_share_one_db_call(self):
+        svc = TrendService()
+        call_count = 0
+
+        async def fake_shooting(seasons, start=None, end=None):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return pd.DataFrame({'fgm': [1]})
+
+        with patch.object(svc._db, 'aggregate_shooting_by_player', fake_shooting):
+            results = await asyncio.gather(*[
+                svc._get_season_shooting('2025-26', date(2026, 1, 15)) for _ in range(10)
+            ])
+
+        assert call_count == 1
+        assert all(r['fgm'].iloc[0] == 1 for r in results)
+
+    async def test_raising_computation_propagates_to_waiters_and_clears_slot(self):
+        svc = TrendService()
+        call_count = 0
+
+        async def flaky_shooting(seasons, start=None, end=None):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.02)
+            if call_count == 1:
+                raise RuntimeError('db exploded')
+            return pd.DataFrame({'fgm': [1]})
+
+        with patch.object(svc._db, 'aggregate_shooting_by_player', flaky_shooting):
+            results = await asyncio.gather(
+                *[svc._get_season_shooting('2025-26', date(2026, 1, 15)) for _ in range(5)],
+                return_exceptions=True,
+            )
+
+            assert call_count == 1
+            assert all(isinstance(r, RuntimeError) for r in results)
+            assert svc._season_shooting_inflight == {}
+
+            second = await svc._get_season_shooting('2025-26', date(2026, 1, 15))
+
+        assert call_count == 2
+        assert second['fgm'].iloc[0] == 1

--- a/backend/tests/services/test_trend_service.py
+++ b/backend/tests/services/test_trend_service.py
@@ -8,8 +8,11 @@ import pytest
 from app.config import settings
 from app.services import trend_service
 from app.services.trend_service import (
+    MAX_RECENCY_WINDOW_DAYS,
+    MIN_RECENCY_WINDOW_DAYS,
     TrendService,
     _normalize_baseline_seasons,
+    _normalize_window_days,
     _TTLLRUCache,
     build_game_log,
     classify_role_badge,
@@ -958,6 +961,23 @@ class TestCachePresetResponse:
         svc._cache_preset_response(cache, 15, 15, 'response')
 
         assert cache[15]['data'] == 'response'
+
+
+class TestNormalizeWindowDays:
+    def test_below_min_clamps_up(self):
+        assert _normalize_window_days(1) == MIN_RECENCY_WINDOW_DAYS
+
+    def test_above_max_clamps_down(self):
+        assert _normalize_window_days(500) == MAX_RECENCY_WINDOW_DAYS
+
+    def test_off_preset_value_is_honoured(self):
+        assert _normalize_window_days(21) == 21
+
+    def test_min_boundary_passes_through(self):
+        assert _normalize_window_days(MIN_RECENCY_WINDOW_DAYS) == MIN_RECENCY_WINDOW_DAYS
+
+    def test_max_boundary_passes_through(self):
+        assert _normalize_window_days(MAX_RECENCY_WINDOW_DAYS) == MAX_RECENCY_WINDOW_DAYS
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/DateRangePicker.tsx
+++ b/frontend/src/components/DateRangePicker.tsx
@@ -7,6 +7,7 @@ interface DateRangePickerProps {
   today?: string
   initialStart?: string
   initialEnd?: string
+  fixedEnd?: string
   onApply: (range: CustomDateRange) => void
 }
 
@@ -15,35 +16,39 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
   today = todayIso(),
   initialStart = '',
   initialEnd = '',
+  fixedEnd,
   onApply,
 }) => {
   const [start, setStart] = useState(initialStart)
   const [end, setEnd] = useState(initialEnd)
 
-  const error = validateDateRange(start, end, seasonStart, today)
-  const applyDisabled = !start || !end || !!error
+  const effectiveEnd = fixedEnd ?? end
+  const error = fixedEnd
+    ? validateDateRange(start, fixedEnd, seasonStart, fixedEnd)
+    : validateDateRange(start, end, seasonStart, today)
+  const applyDisabled = !start || !effectiveEnd || !!error
 
   const handleApply = () => {
     if (applyDisabled) return
-    onApply({ start, end })
+    onApply({ start, end: effectiveEnd })
   }
 
   const handleClear = () => {
     setStart('')
-    setEnd('')
+    if (!fixedEnd) setEnd('')
   }
 
   return (
     <div className="mt-2 p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-sm w-full min-w-[260px] sm:w-auto sm:inline-block">
       <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
         <div className="flex flex-col gap-1 w-full sm:w-auto">
-          <label className="text-xs text-gray-600 dark:text-gray-300 font-medium">Start</label>
+          <label className="text-xs text-gray-600 dark:text-gray-300 font-medium">{fixedEnd ? 'Window starts' : 'Start'}</label>
           <input
             type="date"
             aria-label="Start date"
             value={start}
             min={seasonStart}
-            max={end || today}
+            max={fixedEnd ?? (end || today)}
             onChange={(e) => setStart(e.target.value)}
             className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 ${
               error ? 'border-red-400' : 'border-gray-300 dark:border-gray-600'
@@ -55,11 +60,12 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           <input
             type="date"
             aria-label="End date"
-            value={end}
+            value={effectiveEnd}
             min={start || seasonStart}
             max={today}
-            onChange={(e) => setEnd(e.target.value)}
-            className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 ${
+            disabled={!!fixedEnd}
+            onChange={(e) => !fixedEnd && setEnd(e.target.value)}
+            className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:opacity-60 disabled:cursor-not-allowed ${
               error ? 'border-red-400' : 'border-gray-300 dark:border-gray-600'
             }`}
           />
@@ -81,7 +87,9 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
         </div>
       </div>
       <p className="mt-2 text-[0.7rem] text-gray-500 dark:text-gray-400">
-        min = season start{seasonStart ? ` (${seasonStart})` : ''} · max = today · both required
+        {fixedEnd
+          ? `window ends ${fixedEnd} (latest game day)${seasonStart ? ` · min ${seasonStart}` : ''} · start required`
+          : `min = season start${seasonStart ? ` (${seasonStart})` : ''} · max = today · both required`}
       </p>
       {error && <p className="mt-1 text-xs text-red-600 dark:text-red-400">⚠ {error}</p>}
     </div>

--- a/frontend/src/components/__tests__/DateRangePicker.test.tsx
+++ b/frontend/src/components/__tests__/DateRangePicker.test.tsx
@@ -72,4 +72,54 @@ describe('DateRangePicker', () => {
     expect(screen.getByText(new RegExp(SEASON_START))).toBeInTheDocument()
     expect(screen.getByText(/both required/i)).toBeInTheDocument()
   })
+
+  describe('fixedEnd', () => {
+    const ANCHOR = '2026-07-10'
+
+    it('renders the end input disabled at the fixed value', () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      const endInput = screen.getByLabelText(/end date/i)
+      expect(endInput).toBeDisabled()
+      expect(endInput).toHaveValue(ANCHOR)
+    })
+
+    it('relabels the start field and disables Apply until a start is picked', async () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      expect(screen.getByText('Window starts')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeDisabled()
+    })
+
+    it('calls onApply with the fixed end once a start is picked, without an end-date error', async () => {
+      const onApply = vi.fn()
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={onApply} />)
+      const user = userEvent.setup()
+
+      await user.type(screen.getByLabelText(/start date/i), '2026-06-19')
+      expect(screen.queryByText(/before end date/i)).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeEnabled()
+
+      await user.click(screen.getByRole('button', { name: /apply/i }))
+      expect(onApply).toHaveBeenCalledWith({ start: '2026-06-19', end: ANCHOR })
+    })
+
+    it('still enforces seasonStart as a lower bound', async () => {
+      render(<DateRangePicker seasonStart={SEASON_START} fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      const user = userEvent.setup()
+
+      await user.type(screen.getByLabelText(/start date/i), '2025-10-01')
+      expect(screen.getByText(/cannot be before season start/i)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeDisabled()
+    })
+
+    it('Clear only resets the start field, not the fixed end', async () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} initialStart="2026-06-19" onApply={vi.fn()} />)
+      const user = userEvent.setup()
+
+      expect(screen.getByLabelText(/start date/i)).toHaveValue('2026-06-19')
+      await user.click(screen.getByRole('button', { name: /clear/i }))
+
+      expect(screen.getByLabelText(/start date/i)).toHaveValue('')
+      expect(screen.getByLabelText(/end date/i)).toHaveValue(ANCHOR)
+    })
+  })
 })

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -4,13 +4,30 @@ import {
   useGetTrendsMinutesQuery,
   useGetTrendsUsageQuery,
   useGetTrendsRegressionQuery,
+  useGetTrendGameLogQuery,
 } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import TrendGameLogChart from '../components/TrendGameLogChart'
 import InfoTip from '../components/InfoTip'
+import DateRangePicker from '../components/DateRangePicker'
 import { BASELINE_LABEL } from '../utils/trendBaseline'
-import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat, RegressionMode } from '../types/api'
+import { toLocalIso, daysBetween, formatShort } from '../utils/dateRange'
+import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat, RegressionMode, CustomDateRange } from '../types/api'
+
+const MIN_CUSTOM_WINDOW_DAYS = 5
+const MAX_CUSTOM_WINDOW_DAYS = 60
+
+function addDaysIso(iso: string, days: number): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  const dt = new Date(y, m - 1, d)
+  dt.setDate(dt.getDate() + days)
+  return toLocalIso(dt)
+}
+
+function subDaysIso(iso: string, days: number): string {
+  return addDaysIso(iso, -days)
+}
 
 type TabKey = 'minutes' | 'usage' | 'shooting-season' | 'shooting-form'
 type Ownership = 'all' | 'fa' | 'rostered'
@@ -572,6 +589,9 @@ export default function Trends() {
   // judging a season line, "this season" when judging current form
   const [seasonBaseline, setSeasonBaseline] = usePersistedState('trends.seasonBaseline', 2)
   const [formBaseline, setFormBaseline] = usePersistedState('trends.formBaseline', 0)
+  const [customStartIso, setCustomStartIso] = useState<string | null>(null)
+  const [customOpen, setCustomOpen] = useState(false)
+  const [customError, setCustomError] = useState<string | null>(null)
 
   const regressionMode = TAB_MODE[tab]
   const isShooting = regressionMode !== undefined
@@ -585,6 +605,50 @@ export default function Trends() {
     { windowDays, baselineSeasons, mode: regressionMode ?? 'season' },
     { skip: !isShooting },
   )
+
+  // The recency window always ends on the latest game day, not wall-clock
+  // today — none of the three tab payloads carry that date directly, but
+  // GameLogResponse does (window_start + window_days). Borrow it from
+  // whichever player is first in the currently active tab's results, only
+  // while the custom panel is open, so this doesn't add a request otherwise.
+  const anchorSourceId = tab === 'minutes'
+    ? minutesQuery.data?.items[0]?.player_id
+    : tab === 'usage'
+      ? usageQuery.data?.items[0]?.player_id
+      : regressionQuery.data?.items[0]?.player_id
+
+  const anchorQuery = useGetTrendGameLogQuery(
+    { playerId: anchorSourceId ?? 0, windowDays },
+    { skip: !customOpen || anchorSourceId === undefined },
+  )
+
+  const anchorIso = useMemo(() => {
+    const d = anchorQuery.data
+    if (!d) return null
+    return addDaysIso(d.window_start, d.window_days)
+  }, [anchorQuery.data])
+
+  const customMinStartIso = anchorIso ? subDaysIso(anchorIso, MAX_CUSTOM_WINDOW_DAYS) : undefined
+
+  const handleCustomApply = (range: CustomDateRange) => {
+    if (!anchorIso) return
+    const days = daysBetween(range.start, anchorIso)
+    if (days < MIN_CUSTOM_WINDOW_DAYS || days > MAX_CUSTOM_WINDOW_DAYS) {
+      setCustomError(`That's ${days} day${days === 1 ? '' : 's'} — pick a start between ${MIN_CUSTOM_WINDOW_DAYS} and ${MAX_CUSTOM_WINDOW_DAYS} days before ${formatShort(anchorIso)}.`)
+      return
+    }
+    setCustomError(null)
+    setCustomStartIso(range.start)
+    setWindowDays(days)
+    setCustomOpen(false)
+  }
+
+  const selectPreset = (d: number) => {
+    setWindowDays(d)
+    setCustomStartIso(null)
+    setCustomError(null)
+    setCustomOpen(false)
+  }
 
   const filters: Filters = { nameFilter, position, minG15: minGames, ownership, fantasyTeam }
 
@@ -634,17 +698,50 @@ export default function Trends() {
               {ALL_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
             </select>
             <span className="hidden sm:block flex-1" />
-            <div className="col-span-2 flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
-              {WINDOW_OPTIONS.map(d => (
+            <div className="col-span-2 flex flex-wrap items-center gap-2">
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
+                {WINDOW_OPTIONS.map(d => (
+                  <button
+                    key={d}
+                    onClick={() => selectPreset(d)}
+                    className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${!customStartIso && windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  >
+                    {d}d
+                  </button>
+                ))}
                 <button
-                  key={d}
-                  onClick={() => setWindowDays(d)}
-                  className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  onClick={() => setCustomOpen(o => !o)}
+                  title="Pick a custom start date — the window always ends on the latest game day"
+                  className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${customStartIso ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
-                  {d}d
+                  📆 Custom
                 </button>
-              ))}
+              </div>
+              {customStartIso && !customOpen && (
+                <span className="text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                  since {formatShort(customStartIso)} · {windowDays} days
+                </span>
+              )}
             </div>
+            {customOpen && (
+              <div className="col-span-2">
+                {!anchorIso ? (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 py-2">
+                    {anchorQuery.isFetching || anchorSourceId === undefined ? 'Loading latest game day…' : 'Could not determine the latest game day.'}
+                  </p>
+                ) : (
+                  <>
+                    <DateRangePicker
+                      seasonStart={customMinStartIso}
+                      fixedEnd={anchorIso}
+                      initialStart={customStartIso ?? ''}
+                      onApply={handleCustomApply}
+                    />
+                    {customError && <p className="mt-1 text-xs text-red-600 dark:text-red-400">⚠ {customError}</p>}
+                  </>
+                )}
+              </div>
+            )}
             <div className="col-span-2 flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Which players to show: everyone, free agents only, or rostered only">
               {OWNERSHIP_OPTIONS.map(([key, label]) => (
                 <button

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -654,6 +654,17 @@ export default function Trends() {
 
   const activeQuery = tab === 'minutes' ? minutesQuery : tab === 'usage' ? usageQuery : regressionQuery
 
+  // No endpoint returns a league-wide game-night count directly, so this
+  // approximates it from the loaded data: the most games any single player
+  // logged in the window is, in practice, the number of nights the league
+  // actually played (a full-minutes player hits every one of them).
+  const gameNights = useMemo(() => {
+    const items = minutesQuery.data?.items ?? usageQuery.data?.items ?? regressionQuery.data?.items ?? []
+    return items.reduce((max, r) => Math.max(max, r.games_last_15d), 0) || null
+  }, [minutesQuery.data, usageQuery.data, regressionQuery.data])
+
+  const isShootingSeasonTab = tab === 'shooting-season'
+
   const teamOptions = useMemo(() => {
     const items = minutesQuery.data?.items ?? usageQuery.data?.items ?? regressionQuery.data?.items ?? []
     return [...new Set(items.map(i => i.fantasy_status).filter(t => t !== 'FA'))].sort()
@@ -699,7 +710,15 @@ export default function Trends() {
             </select>
             <span className="hidden sm:block flex-1" />
             <div className="col-span-2 flex flex-wrap items-center gap-2">
-              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
+              {isShootingSeasonTab && (
+                <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">Activity window</span>
+              )}
+              <div
+                className={`flex rounded-lg border overflow-hidden text-xs sm:text-sm ${isShootingSeasonTab ? 'border-gray-200 dark:border-gray-700 opacity-70' : 'border-gray-300 dark:border-gray-600'}`}
+                title={isShootingSeasonTab
+                  ? 'Only filters by recent games played — the season-vs-prior-seasons comparison on this tab barely uses this window.'
+                  : 'Recency window for the G column and eligibility filter'}
+              >
                 {WINDOW_OPTIONS.map(d => (
                   <button
                     key={d}
@@ -722,7 +741,15 @@ export default function Trends() {
                   since {formatShort(customStartIso)} · {windowDays} days
                 </span>
               )}
+              {gameNights !== null && (
+                <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">{gameNights} game nights</span>
+              )}
             </div>
+            {!isShootingSeasonTab && windowDays < 10 && (
+              <p className="col-span-2 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg px-2.5 py-1.5">
+                ⚠ Short window ({windowDays}d) — most rows will be based on very few games and marked <span className="font-semibold">partial</span>.
+              </p>
+            )}
             {customOpen && (
               <div className="col-span-2">
                 {!anchorIso ? (

--- a/frontend/src/store/api/fantasyApi.ts
+++ b/frontend/src/store/api/fantasyApi.ts
@@ -125,15 +125,18 @@ export const fantasyApi = createApi({
     }),
     getTrendsMinutes: builder.query<MinutesResponse, { windowDays?: number }>({
       query: ({ windowDays = 15 } = {}) => ({ url: '/trends/minutes', params: { window_days: windowDays } }),
+      keepUnusedDataFor: 600,
     }),
     getTrendsUsage: builder.query<UsageResponse, { windowDays?: number }>({
       query: ({ windowDays = 15 } = {}) => ({ url: '/trends/usage', params: { window_days: windowDays } }),
+      keepUnusedDataFor: 600,
     }),
     getTrendsRegression: builder.query<RegressionResponse, { windowDays?: number; baselineSeasons?: number; mode?: RegressionMode }>({
       query: ({ windowDays = 15, baselineSeasons = 2, mode = 'season' } = {}) => ({
         url: '/trends/regression',
         params: { window_days: windowDays, baseline_seasons: baselineSeasons, mode },
       }),
+      keepUnusedDataFor: 600,
     }),
     getTrendGameLog: builder.query<GameLogResponse, { playerId: number; windowDays?: number; baselineSeasons?: number; mode?: RegressionMode }>({
       query: ({ playerId, windowDays = 15, baselineSeasons = 2, mode = 'season' }) => ({


### PR DESCRIPTION
More distinct windows (P3) and the player-profile game-log card
firing on every view both increase concurrent misses on the same
cache key. Adds a shared _coalesced helper: the first caller on a key
runs the computation and registers a Future; concurrent callers on
the same key await it instead of issuing a duplicate DB round-trip.

The finally block clears the in-flight slot unconditionally - if a
raising computation left its Future registered, every later caller on
that key would await a permanently-failed Future until process
restart.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>