### PR TITLE
feat(frontend): player-profile trends card

### DIFF
--- a/frontend/src/components/PlayerTrendsCard.tsx
+++ b/frontend/src/components/PlayerTrendsCard.tsx
@@ -1,0 +1,166 @@
+import { useMemo, useState } from 'react'
+import { useGetTrendGameLogQuery } from '../store/api/fantasyApi'
+import TrendGameLogChart from './TrendGameLogChart'
+import type { RegressionStat } from '../types/api'
+import { FF_TRENDS } from '../config/featureFlags'
+import { LOW_SAMPLE_GP } from '../utils/trendBaseline'
+import { STAT_FIELDS, seasonAttempts, summarize, fmtValue, fmtDelta, type CardMode } from '../utils/playerTrendsSummary'
+
+const WINDOW_DAYS = 15
+
+const MODE_CHIPS: { key: CardMode; label: string }[] = [
+  { key: 'minutes', label: 'Minutes' },
+  { key: 'usage', label: 'Usage' },
+  { key: '3P%', label: '3P%' },
+  { key: 'FT%', label: 'FT%' },
+  { key: 'FG%', label: 'FG%' },
+]
+
+function shortDate(iso: string): string {
+  return iso.slice(5).replace('-', '/')
+}
+
+function Tile({ label, value, games, muted, badge }: {
+  label: string
+  value: string
+  games?: number
+  muted?: boolean
+  badge?: string
+}) {
+  return (
+    <div
+      className={`rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-3 py-2 min-w-0 ${
+        muted ? 'opacity-60' : ''
+      }`}
+    >
+      <div className="flex items-center gap-1.5">
+        <span className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">{label}</span>
+        {badge && (
+          <span className="text-[9px] font-semibold px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+            {badge}
+          </span>
+        )}
+      </div>
+      <div className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">{value}</div>
+      {games !== undefined && (
+        <div className="text-[11px] text-gray-500 dark:text-gray-400">{games} {games === 1 ? 'game' : 'games'}</div>
+      )}
+    </div>
+  )
+}
+
+function Skeleton() {
+  return (
+    <div className="h-[300px] sm:h-[320px] animate-pulse">
+      <div className="h-5 w-40 bg-gray-200 dark:bg-gray-700 rounded mb-4" />
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="h-16 bg-gray-200 dark:bg-gray-700 rounded-lg" />
+        ))}
+      </div>
+      <div className="h-[180px] bg-gray-200 dark:bg-gray-700 rounded-lg" />
+    </div>
+  )
+}
+
+interface Props {
+  playerId: number
+}
+
+export default function PlayerTrendsCard({ playerId }: Props) {
+  const [mode, setMode] = useState<CardMode>('minutes')
+
+  const { data: log, error, isLoading, refetch } = useGetTrendGameLogQuery(
+    { playerId, windowDays: WINDOW_DAYS, baselineSeasons: 0, mode: 'form' },
+    { skip: !playerId, refetchOnFocus: false },
+  )
+
+  const availableShootingStats = useMemo(() => {
+    if (!log) return []
+    return (Object.keys(STAT_FIELDS) as RegressionStat[]).filter((s) => seasonAttempts(log.games, s) > 0)
+  }, [log])
+
+  if (!FF_TRENDS) return null
+
+  const is404 = error && 'status' in error && error.status === 404
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-6 mt-6">
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">Trends</h2>
+
+      {isLoading && <Skeleton />}
+
+      {!isLoading && error && (
+        <div className="h-[300px] sm:h-[320px] flex items-center justify-center text-center px-4">
+          {is404 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">No game log this season.</p>
+          ) : (
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              Failed to load trends.{' '}
+              <button
+                type="button"
+                onClick={() => refetch()}
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isLoading && !error && log && (
+        <>
+          <div className="flex flex-wrap gap-2 mb-4">
+            {MODE_CHIPS.filter(
+              (c) => c.key === 'minutes' || c.key === 'usage' || availableShootingStats.includes(c.key as RegressionStat),
+            ).map((c) => (
+              <button
+                key={c.key}
+                type="button"
+                onClick={() => setMode(c.key)}
+                className={`px-3 py-1.5 text-sm rounded-lg border whitespace-nowrap transition-colors ${
+                  mode === c.key
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+                }`}
+              >
+                {c.label}
+              </button>
+            ))}
+          </div>
+
+          {(() => {
+            const summary = summarize(log, mode)
+            const partial = summary.windowGames < LOW_SAMPLE_GP
+            return (
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+                <Tile label="Season" value={fmtValue(summary.seasonValue, mode)} games={summary.seasonGames} />
+                <Tile label={`Last ${WINDOW_DAYS}d`} value={fmtValue(summary.windowValue, mode)} games={summary.windowGames} />
+                <Tile
+                  label="Δ vs season"
+                  value={fmtDelta(summary.delta, mode)}
+                  games={summary.windowGames}
+                  muted={partial}
+                  badge={partial ? 'partial' : undefined}
+                />
+                <Tile label="Window start" value={shortDate(summary.windowStart)} games={summary.windowGames} />
+              </div>
+            )
+          })()}
+
+          <TrendGameLogChart
+            playerId={playerId}
+            playerName={log.player_name}
+            mode={mode === 'minutes' || mode === 'usage' ? mode : 'shooting'}
+            regressionMode="form"
+            windowDays={WINDOW_DAYS}
+            baselineSeasons={0}
+            stat={mode === 'minutes' || mode === 'usage' ? undefined : mode}
+            qualifiedStats={availableShootingStats}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile.tsx
@@ -6,6 +6,7 @@ import TimePeriodSelector from '../components/TimePeriodSelector'
 import { CoverageNotice } from '../components/DateRangePicker'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import PlayerTrendsCard from '../components/PlayerTrendsCard'
 
 function backLabel(from: string | undefined): string {
   if (!from) return '← Back'
@@ -239,6 +240,8 @@ const PlayerProfile = () => {
           </div>
         )}
       </div>
+
+      <PlayerTrendsCard playerId={Number(playerId)} />
     </div>
   )
 }

--- a/frontend/src/utils/__tests__/playerTrendsSummary.test.ts
+++ b/frontend/src/utils/__tests__/playerTrendsSummary.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import type { GameLogEntry, GameLogResponse } from '../../types/api'
+import { fmtDelta, fmtValue, seasonAttempts, summarize } from '../playerTrendsSummary'
+
+function game(overrides: Partial<GameLogEntry>): GameLogEntry {
+  return {
+    game_date: '2026-01-01',
+    matchup: 'vs BOS',
+    min: 30,
+    usg: 20,
+    fgm: 5,
+    fga: 10,
+    ftm: 2,
+    fta: 2,
+    fg3m: 1,
+    fg3a: 3,
+    ...overrides,
+  }
+}
+
+function log(overrides: Partial<GameLogResponse>): GameLogResponse {
+  return {
+    player_id: 1,
+    player_name: 'Test Player',
+    season: '2025-26',
+    window_days: 15,
+    window_start: '2026-01-10',
+    season_gp: 10,
+    season_mpg: 28,
+    season_usg: 22,
+    season_pct: { '3P%': 35, 'FT%': 80, 'FG%': 45 },
+    baseline_pct: {},
+    league_pct: {},
+    league_usg: null,
+    baseline_seasons: 0,
+    games: [],
+    ...overrides,
+  }
+}
+
+describe('summarize', () => {
+  it('averages minutes over the window and computes delta vs season', () => {
+    const l = log({
+      games: [
+        game({ game_date: '2026-01-05', min: 20 }),
+        game({ game_date: '2026-01-11', min: 30 }),
+        game({ game_date: '2026-01-13', min: 34 }),
+      ],
+    })
+    const s = summarize(l, 'minutes')
+    expect(s.seasonValue).toBe(28)
+    expect(s.windowValue).toBe(32)
+    expect(s.delta).toBeCloseTo(4)
+    expect(s.windowGames).toBe(2)
+    expect(s.seasonGames).toBe(10)
+    expect(s.windowStart).toBe('2026-01-10')
+  })
+
+  it('pools makes over attempts for a shooting stat rather than averaging per-game percentages', () => {
+    const l = log({
+      games: [
+        game({ game_date: '2026-01-11', fg3m: 1, fg3a: 2 }), // 50%
+        game({ game_date: '2026-01-12', fg3m: 4, fg3a: 8 }), // 50%
+        game({ game_date: '2026-01-13', fg3m: 0, fg3a: 0 }), // no attempts, excluded from pooling but counted as a game
+      ],
+    })
+    const s = summarize(l, '3P%')
+    expect(s.windowValue).toBeCloseTo(50)
+    expect(s.windowGames).toBe(3)
+    expect(s.seasonValue).toBe(35)
+    expect(s.delta).toBeCloseTo(15)
+  })
+
+  it('returns null window value when no games fall in the window', () => {
+    const l = log({ games: [game({ game_date: '2025-12-01' })] })
+    const s = summarize(l, 'minutes')
+    expect(s.windowValue).toBeNull()
+    expect(s.delta).toBeNull()
+    expect(s.windowGames).toBe(0)
+  })
+
+  it('returns null window value for a shooting stat with zero attempts in the window', () => {
+    const l = log({
+      games: [game({ game_date: '2026-01-11', fg3m: 0, fg3a: 0 })],
+    })
+    const s = summarize(l, '3P%')
+    expect(s.windowValue).toBeNull()
+    expect(s.delta).toBeNull()
+  })
+})
+
+describe('seasonAttempts', () => {
+  it('sums attempts for the given stat across all games', () => {
+    const games = [game({ fg3a: 3 }), game({ fg3a: 5 })]
+    expect(seasonAttempts(games, '3P%')).toBe(8)
+  })
+
+  it('returns 0 when no games have attempts', () => {
+    const games = [game({ fta: 0 })]
+    expect(seasonAttempts(games, 'FT%')).toBe(0)
+  })
+})
+
+describe('fmtValue / fmtDelta', () => {
+  it('formats minutes without a percent sign', () => {
+    expect(fmtValue(28.456, 'minutes')).toBe('28.5')
+  })
+
+  it('formats usage and shooting stats with a percent sign', () => {
+    expect(fmtValue(22.1, 'usage')).toBe('22.1%')
+    expect(fmtValue(35, '3P%')).toBe('35.0%')
+  })
+
+  it('formats null as an em dash', () => {
+    expect(fmtValue(null, 'minutes')).toBe('—')
+    expect(fmtDelta(null, '3P%')).toBe('—')
+  })
+
+  it('signs deltas explicitly', () => {
+    expect(fmtDelta(4, 'minutes')).toBe('+4.0')
+    expect(fmtDelta(-2.3, 'usage')).toBe('-2.3%')
+  })
+})

--- a/frontend/src/utils/playerTrendsSummary.ts
+++ b/frontend/src/utils/playerTrendsSummary.ts
@@ -1,0 +1,68 @@
+import type { GameLogEntry, GameLogResponse, RegressionStat } from '../types/api'
+
+export type CardMode = 'minutes' | 'usage' | RegressionStat
+
+export const STAT_FIELDS: Record<RegressionStat, { made: keyof GameLogEntry; att: keyof GameLogEntry }> = {
+  '3P%': { made: 'fg3m', att: 'fg3a' },
+  'FT%': { made: 'ftm', att: 'fta' },
+  'FG%': { made: 'fgm', att: 'fga' },
+}
+
+export function seasonAttempts(games: GameLogEntry[], stat: RegressionStat): number {
+  const { att } = STAT_FIELDS[stat]
+  return games.reduce((sum, g) => sum + (g[att] as number), 0)
+}
+
+export interface TrendSummary {
+  seasonValue: number | null
+  windowValue: number | null
+  delta: number | null
+  windowStart: string
+  seasonGames: number
+  windowGames: number
+}
+
+export function summarize(log: GameLogResponse, mode: CardMode): TrendSummary {
+  const windowGames = log.games.filter((g) => g.game_date >= log.window_start)
+
+  if (mode === 'minutes' || mode === 'usage') {
+    const field: keyof GameLogEntry = mode === 'minutes' ? 'min' : 'usg'
+    const seasonValue = mode === 'minutes' ? log.season_mpg : log.season_usg
+    const windowValue = windowGames.length
+      ? windowGames.reduce((sum, g) => sum + (g[field] as number), 0) / windowGames.length
+      : null
+    return {
+      seasonValue,
+      windowValue,
+      delta: windowValue === null ? null : windowValue - seasonValue,
+      windowStart: log.window_start,
+      seasonGames: log.season_gp,
+      windowGames: windowGames.length,
+    }
+  }
+
+  const { made, att } = STAT_FIELDS[mode]
+  const seasonValue = log.season_pct[mode] ?? null
+  const attSum = windowGames.reduce((sum, g) => sum + (g[att] as number), 0)
+  const madeSum = windowGames.reduce((sum, g) => sum + (g[made] as number), 0)
+  const windowValue = attSum > 0 ? (madeSum / attSum) * 100 : null
+  return {
+    seasonValue,
+    windowValue,
+    delta: windowValue === null || seasonValue === null ? null : windowValue - seasonValue,
+    windowStart: log.window_start,
+    seasonGames: log.season_gp,
+    windowGames: windowGames.length,
+  }
+}
+
+export function fmtValue(value: number | null, mode: CardMode): string {
+  if (value === null) return '—'
+  return mode === 'minutes' ? value.toFixed(1) : `${value.toFixed(1)}%`
+}
+
+export function fmtDelta(value: number | null, mode: CardMode): string {
+  if (value === null) return '—'
+  const sign = value >= 0 ? '+' : ''
+  return mode === 'minutes' ? `${sign}${value.toFixed(1)}` : `${sign}${value.toFixed(1)}%`
+}

--- a/frontend/src/utils/trendBaseline.ts
+++ b/frontend/src/utils/trendBaseline.ts
@@ -1,1 +1,5 @@
 export const BASELINE_LABEL: Record<number, string> = { 0: 'this season only', 1: 'last season', 2: 'prior 2 seasons' }
+
+// Mirrors LOW_SAMPLE_GP in backend/app/services/trend_service.py — below this
+// many games in the window, a delta is more noise than signal.
+export const LOW_SAMPLE_GP = 3


### PR DESCRIPTION
## Summary
- New `PlayerTrendsCard` mounted below the Stats card on `/player/:playerId` — independent `useGetTrendGameLogQuery` (windowDays=15, baselineSeasons=0, mode='form', `refetchOnFocus: false`), so it loads/errors separately from the page's bio fetch. Fixed-height skeleton avoids layout shift.
- Mode chips (Minutes/Usage/3P%/FT%/FG%) reuse `TrendGameLogChart` unmodified — a shooting chip hides when the player has zero season attempts for that stat.
- Four summary tiles (season/window/Δ/window-start), each with its game count. Under `LOW_SAMPLE_GP` (3) games in the window, the Δ tile greys out with a "partial" badge — moved the constant into `trendBaseline.ts` so it mirrors the backend value by name instead of a second hardcoded `3`.
- No role badge, no z-score — intentional scope decision (Option A), avoids duplicating Python thresholds in TypeScript. No new backend endpoint.
- `PlayerTrendsCard` returns `null` when `FF_TRENDS` is off, matching the standalone Trends page's gating.
- Phases S1+S2+S3 of `trends_implementation_plan.html`. Independent of the backend track (P0-P3) — doesn't need any of it merged first. S4 (adopting the custom date window from P4) is a separate follow-up.

## Test plan
- [x] `npm run build` clean (tsc + vite)
- [x] vitest: 19 files, 174 passed / 3 skipped
- [x] Live-tested against 2 real players: normal case (Caleb Love, 49 GP — chip switching, tiles, chart all correct) and low-sample case (Peyton Watson, 2 games in 15d window — confirmed "partial" badge and greyed Δ tile)
- [x] Screenshots at desktop and 390×844 mobile — chips wrap, tiles go 2×2, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)