### PR TITLE
feat(frontend): custom start-date window on Trends

### DIFF
--- a/frontend/src/components/DateRangePicker.tsx
+++ b/frontend/src/components/DateRangePicker.tsx
@@ -7,6 +7,7 @@ interface DateRangePickerProps {
   today?: string
   initialStart?: string
   initialEnd?: string
+  fixedEnd?: string
   onApply: (range: CustomDateRange) => void
 }
 
@@ -15,35 +16,39 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
   today = todayIso(),
   initialStart = '',
   initialEnd = '',
+  fixedEnd,
   onApply,
 }) => {
   const [start, setStart] = useState(initialStart)
   const [end, setEnd] = useState(initialEnd)
 
-  const error = validateDateRange(start, end, seasonStart, today)
-  const applyDisabled = !start || !end || !!error
+  const effectiveEnd = fixedEnd ?? end
+  const error = fixedEnd
+    ? validateDateRange(start, fixedEnd, seasonStart, fixedEnd)
+    : validateDateRange(start, end, seasonStart, today)
+  const applyDisabled = !start || !effectiveEnd || !!error
 
   const handleApply = () => {
     if (applyDisabled) return
-    onApply({ start, end })
+    onApply({ start, end: effectiveEnd })
   }
 
   const handleClear = () => {
     setStart('')
-    setEnd('')
+    if (!fixedEnd) setEnd('')
   }
 
   return (
     <div className="mt-2 p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-sm w-full min-w-[260px] sm:w-auto sm:inline-block">
       <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
         <div className="flex flex-col gap-1 w-full sm:w-auto">
-          <label className="text-xs text-gray-600 dark:text-gray-300 font-medium">Start</label>
+          <label className="text-xs text-gray-600 dark:text-gray-300 font-medium">{fixedEnd ? 'Window starts' : 'Start'}</label>
           <input
             type="date"
             aria-label="Start date"
             value={start}
             min={seasonStart}
-            max={end || today}
+            max={fixedEnd ?? (end || today)}
             onChange={(e) => setStart(e.target.value)}
             className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 ${
               error ? 'border-red-400' : 'border-gray-300 dark:border-gray-600'
@@ -55,11 +60,12 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           <input
             type="date"
             aria-label="End date"
-            value={end}
+            value={effectiveEnd}
             min={start || seasonStart}
             max={today}
-            onChange={(e) => setEnd(e.target.value)}
-            className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 ${
+            disabled={!!fixedEnd}
+            onChange={(e) => !fixedEnd && setEnd(e.target.value)}
+            className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:opacity-60 disabled:cursor-not-allowed ${
               error ? 'border-red-400' : 'border-gray-300 dark:border-gray-600'
             }`}
           />
@@ -81,7 +87,9 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
         </div>
       </div>
       <p className="mt-2 text-[0.7rem] text-gray-500 dark:text-gray-400">
-        min = season start{seasonStart ? ` (${seasonStart})` : ''} · max = today · both required
+        {fixedEnd
+          ? `window ends ${fixedEnd} (latest game day)${seasonStart ? ` · min ${seasonStart}` : ''} · start required`
+          : `min = season start${seasonStart ? ` (${seasonStart})` : ''} · max = today · both required`}
       </p>
       {error && <p className="mt-1 text-xs text-red-600 dark:text-red-400">⚠ {error}</p>}
     </div>

--- a/frontend/src/components/__tests__/DateRangePicker.test.tsx
+++ b/frontend/src/components/__tests__/DateRangePicker.test.tsx
@@ -72,4 +72,54 @@ describe('DateRangePicker', () => {
     expect(screen.getByText(new RegExp(SEASON_START))).toBeInTheDocument()
     expect(screen.getByText(/both required/i)).toBeInTheDocument()
   })
+
+  describe('fixedEnd', () => {
+    const ANCHOR = '2026-07-10'
+
+    it('renders the end input disabled at the fixed value', () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      const endInput = screen.getByLabelText(/end date/i)
+      expect(endInput).toBeDisabled()
+      expect(endInput).toHaveValue(ANCHOR)
+    })
+
+    it('relabels the start field and disables Apply until a start is picked', async () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      expect(screen.getByText('Window starts')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeDisabled()
+    })
+
+    it('calls onApply with the fixed end once a start is picked, without an end-date error', async () => {
+      const onApply = vi.fn()
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={onApply} />)
+      const user = userEvent.setup()
+
+      await user.type(screen.getByLabelText(/start date/i), '2026-06-19')
+      expect(screen.queryByText(/before end date/i)).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeEnabled()
+
+      await user.click(screen.getByRole('button', { name: /apply/i }))
+      expect(onApply).toHaveBeenCalledWith({ start: '2026-06-19', end: ANCHOR })
+    })
+
+    it('still enforces seasonStart as a lower bound', async () => {
+      render(<DateRangePicker seasonStart={SEASON_START} fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      const user = userEvent.setup()
+
+      await user.type(screen.getByLabelText(/start date/i), '2025-10-01')
+      expect(screen.getByText(/cannot be before season start/i)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeDisabled()
+    })
+
+    it('Clear only resets the start field, not the fixed end', async () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} initialStart="2026-06-19" onApply={vi.fn()} />)
+      const user = userEvent.setup()
+
+      expect(screen.getByLabelText(/start date/i)).toHaveValue('2026-06-19')
+      await user.click(screen.getByRole('button', { name: /clear/i }))
+
+      expect(screen.getByLabelText(/start date/i)).toHaveValue('')
+      expect(screen.getByLabelText(/end date/i)).toHaveValue(ANCHOR)
+    })
+  })
 })

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -4,13 +4,30 @@ import {
   useGetTrendsMinutesQuery,
   useGetTrendsUsageQuery,
   useGetTrendsRegressionQuery,
+  useGetTrendGameLogQuery,
 } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import TrendGameLogChart from '../components/TrendGameLogChart'
 import InfoTip from '../components/InfoTip'
+import DateRangePicker from '../components/DateRangePicker'
 import { BASELINE_LABEL } from '../utils/trendBaseline'
-import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat, RegressionMode } from '../types/api'
+import { toLocalIso, daysBetween, formatShort } from '../utils/dateRange'
+import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat, RegressionMode, CustomDateRange } from '../types/api'
+
+const MIN_CUSTOM_WINDOW_DAYS = 5
+const MAX_CUSTOM_WINDOW_DAYS = 60
+
+function addDaysIso(iso: string, days: number): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  const dt = new Date(y, m - 1, d)
+  dt.setDate(dt.getDate() + days)
+  return toLocalIso(dt)
+}
+
+function subDaysIso(iso: string, days: number): string {
+  return addDaysIso(iso, -days)
+}
 
 type TabKey = 'minutes' | 'usage' | 'shooting-season' | 'shooting-form'
 type Ownership = 'all' | 'fa' | 'rostered'
@@ -572,6 +589,9 @@ export default function Trends() {
   // judging a season line, "this season" when judging current form
   const [seasonBaseline, setSeasonBaseline] = usePersistedState('trends.seasonBaseline', 2)
   const [formBaseline, setFormBaseline] = usePersistedState('trends.formBaseline', 0)
+  const [customStartIso, setCustomStartIso] = useState<string | null>(null)
+  const [customOpen, setCustomOpen] = useState(false)
+  const [customError, setCustomError] = useState<string | null>(null)
 
   const regressionMode = TAB_MODE[tab]
   const isShooting = regressionMode !== undefined
@@ -585,6 +605,50 @@ export default function Trends() {
     { windowDays, baselineSeasons, mode: regressionMode ?? 'season' },
     { skip: !isShooting },
   )
+
+  // The recency window always ends on the latest game day, not wall-clock
+  // today — none of the three tab payloads carry that date directly, but
+  // GameLogResponse does (window_start + window_days). Borrow it from
+  // whichever player is first in the currently active tab's results, only
+  // while the custom panel is open, so this doesn't add a request otherwise.
+  const anchorSourceId = tab === 'minutes'
+    ? minutesQuery.data?.items[0]?.player_id
+    : tab === 'usage'
+      ? usageQuery.data?.items[0]?.player_id
+      : regressionQuery.data?.items[0]?.player_id
+
+  const anchorQuery = useGetTrendGameLogQuery(
+    { playerId: anchorSourceId ?? 0, windowDays },
+    { skip: !customOpen || anchorSourceId === undefined },
+  )
+
+  const anchorIso = useMemo(() => {
+    const d = anchorQuery.data
+    if (!d) return null
+    return addDaysIso(d.window_start, d.window_days)
+  }, [anchorQuery.data])
+
+  const customMinStartIso = anchorIso ? subDaysIso(anchorIso, MAX_CUSTOM_WINDOW_DAYS) : undefined
+
+  const handleCustomApply = (range: CustomDateRange) => {
+    if (!anchorIso) return
+    const days = daysBetween(range.start, anchorIso)
+    if (days < MIN_CUSTOM_WINDOW_DAYS || days > MAX_CUSTOM_WINDOW_DAYS) {
+      setCustomError(`That's ${days} day${days === 1 ? '' : 's'} — pick a start between ${MIN_CUSTOM_WINDOW_DAYS} and ${MAX_CUSTOM_WINDOW_DAYS} days before ${formatShort(anchorIso)}.`)
+      return
+    }
+    setCustomError(null)
+    setCustomStartIso(range.start)
+    setWindowDays(days)
+    setCustomOpen(false)
+  }
+
+  const selectPreset = (d: number) => {
+    setWindowDays(d)
+    setCustomStartIso(null)
+    setCustomError(null)
+    setCustomOpen(false)
+  }
 
   const filters: Filters = { nameFilter, position, minG15: minGames, ownership, fantasyTeam }
 
@@ -634,17 +698,50 @@ export default function Trends() {
               {ALL_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
             </select>
             <span className="hidden sm:block flex-1" />
-            <div className="col-span-2 flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
-              {WINDOW_OPTIONS.map(d => (
+            <div className="col-span-2 flex flex-wrap items-center gap-2">
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
+                {WINDOW_OPTIONS.map(d => (
+                  <button
+                    key={d}
+                    onClick={() => selectPreset(d)}
+                    className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${!customStartIso && windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  >
+                    {d}d
+                  </button>
+                ))}
                 <button
-                  key={d}
-                  onClick={() => setWindowDays(d)}
-                  className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  onClick={() => setCustomOpen(o => !o)}
+                  title="Pick a custom start date — the window always ends on the latest game day"
+                  className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${customStartIso ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
-                  {d}d
+                  📆 Custom
                 </button>
-              ))}
+              </div>
+              {customStartIso && !customOpen && (
+                <span className="text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                  since {formatShort(customStartIso)} · {windowDays} days
+                </span>
+              )}
             </div>
+            {customOpen && (
+              <div className="col-span-2">
+                {!anchorIso ? (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 py-2">
+                    {anchorQuery.isFetching || anchorSourceId === undefined ? 'Loading latest game day…' : 'Could not determine the latest game day.'}
+                  </p>
+                ) : (
+                  <>
+                    <DateRangePicker
+                      seasonStart={customMinStartIso}
+                      fixedEnd={anchorIso}
+                      initialStart={customStartIso ?? ''}
+                      onApply={handleCustomApply}
+                    />
+                    {customError && <p className="mt-1 text-xs text-red-600 dark:text-red-400">⚠ {customError}</p>}
+                  </>
+                )}
+              </div>
+            )}
             <div className="col-span-2 flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Which players to show: everyone, free agents only, or rostered only">
               {OWNERSHIP_OPTIONS.map(([key, label]) => (
                 <button

--- a/frontend/src/store/api/fantasyApi.ts
+++ b/frontend/src/store/api/fantasyApi.ts
@@ -125,15 +125,18 @@ export const fantasyApi = createApi({
     }),
     getTrendsMinutes: builder.query<MinutesResponse, { windowDays?: number }>({
       query: ({ windowDays = 15 } = {}) => ({ url: '/trends/minutes', params: { window_days: windowDays } }),
+      keepUnusedDataFor: 600,
     }),
     getTrendsUsage: builder.query<UsageResponse, { windowDays?: number }>({
       query: ({ windowDays = 15 } = {}) => ({ url: '/trends/usage', params: { window_days: windowDays } }),
+      keepUnusedDataFor: 600,
     }),
     getTrendsRegression: builder.query<RegressionResponse, { windowDays?: number; baselineSeasons?: number; mode?: RegressionMode }>({
       query: ({ windowDays = 15, baselineSeasons = 2, mode = 'season' } = {}) => ({
         url: '/trends/regression',
         params: { window_days: windowDays, baseline_seasons: baselineSeasons, mode },
       }),
+      keepUnusedDataFor: 600,
     }),
     getTrendGameLog: builder.query<GameLogResponse, { playerId: number; windowDays?: number; baselineSeasons?: number; mode?: RegressionMode }>({
       query: ({ playerId, windowDays = 15, baselineSeasons = 2, mode = 'season' }) => ({


### PR DESCRIPTION
## Summary
- Stacked on #168 (P3) — merge #167→#168 first.
- `DateRangePicker` gets an optional `fixedEnd` prop: when set, the end input locks to that value (relabeled "Window starts"), end validation is skipped, and clicking Clear only resets start. Absent, behavior is byte-identical to today.
- Raises `keepUnusedDataFor` to 600s on `getTrendsMinutes`/`Usage`/`Regression` to match `getTrendGameLog` — custom windows deliberately skip the server response cache (P3), so the client cache is what makes revisiting one instant.
- `Trends.tsx`: 📆 Custom button beside the presets. Apply converts start → `window_days` via `daysBetween` (P0). Chip shows "since Mar 22 · 21 days". `<5` or `>60` day picks are caught client-side before firing a request.
- **Deviation from the original plan worth a look**: the plan assumed `window_start` exists on every trends payload for deriving the anchor. It only exists on `GameLogResponse` — Minutes/Usage/Regression only carry `window_days`. Rather than add a backend field (out of scope for this branch), the anchor is derived from an existing `getTrendGameLog` query already in flight while the Custom panel is open. Reuses an existing endpoint/cache instead of adding one, at the cost of a round-trip on panel open (cheap, 600s cache, often already warm).

## Test plan
- [x] `npm run build` clean (tsc + vite)
- [x] vitest: 174 passed, 3 skipped — `DateRangePicker.test.tsx` 11/11 (6 original unchanged confirming byte-identical `fixedEnd`-absent path, 5 new for `fixedEnd`)
- [x] Live-tested: Custom panel opens with correct anchor/hint text, Apply produces correct `window_days` request (confirmed via network log), >60-day pick blocked with inline error before any request, <5-day pick blocked with inline error and confirmed no request sent, presets still work and clear the custom chip
- [x] Desktop (1440px) and mobile (390px) screenshots — no overflow, fields stack correctly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)