### PR TITLE
feat(frontend): player trends card adopts the custom window picker

### DIFF
--- a/backend/app/routes/trends.py
+++ b/backend/app/routes/trends.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
 from app.models.trend_models import (
     GameLogResponse,
@@ -12,6 +12,8 @@ from app.services.trend_service import (
     DEFAULT_BASELINE_SEASONS,
     DEFAULT_RECENCY_WINDOW_DAYS,
     DEFAULT_REGRESSION_MODE,
+    MAX_RECENCY_WINDOW_DAYS,
+    MIN_RECENCY_WINDOW_DAYS,
     TrendService,
 )
 
@@ -23,7 +25,7 @@ _data_provider = DataProvider()
 
 @router.get('/regression', response_model=RegressionResponse)
 async def get_shooting_regression(
-    window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
     mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> RegressionResponse:
@@ -32,13 +34,17 @@ async def get_shooting_regression(
 
 
 @router.get('/minutes', response_model=MinutesResponse)
-async def get_minutes_movers(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> MinutesResponse:
+async def get_minutes_movers(
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
+) -> MinutesResponse:
     players_df = await _data_provider.get_players_df()
     return await _trend_service.get_minutes_movers(players_df, window_days)
 
 
 @router.get('/usage', response_model=UsageResponse)
-async def get_usage_role(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> UsageResponse:
+async def get_usage_role(
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
+) -> UsageResponse:
     players_df = await _data_provider.get_players_df()
     return await _trend_service.get_usage_role(players_df, window_days)
 
@@ -46,7 +52,7 @@ async def get_usage_role(window_days: int = DEFAULT_RECENCY_WINDOW_DAYS) -> Usag
 @router.get('/player/{player_id}/gamelog', response_model=GameLogResponse)
 async def get_player_game_log(
     player_id: int,
-    window_days: int = DEFAULT_RECENCY_WINDOW_DAYS,
+    window_days: int = Query(DEFAULT_RECENCY_WINDOW_DAYS, ge=MIN_RECENCY_WINDOW_DAYS, le=MAX_RECENCY_WINDOW_DAYS),
     baseline_seasons: int = DEFAULT_BASELINE_SEASONS,
     mode: RegressionMode = DEFAULT_REGRESSION_MODE,
 ) -> GameLogResponse:

--- a/backend/app/services/trend_service.py
+++ b/backend/app/services/trend_service.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 DRIFT_THRESHOLD = 0.35  # makes/g-equivalent, provisional — see trends_page_plan.md
 DEFAULT_RECENCY_WINDOW_DAYS = 15
 VALID_RECENCY_WINDOWS_DAYS = (7, 15, 30)
+MIN_RECENCY_WINDOW_DAYS = 5
+MAX_RECENCY_WINDOW_DAYS = 60
 _TREND_CACHE_TTL = timedelta(hours=6)
 
 # current_min_att / baseline_min_att: sample-size gates below which a pct is
@@ -495,7 +497,7 @@ def build_game_log(
 
 
 def _normalize_window_days(window_days: int) -> int:
-    return window_days if window_days in VALID_RECENCY_WINDOWS_DAYS else DEFAULT_RECENCY_WINDOW_DAYS
+    return max(MIN_RECENCY_WINDOW_DAYS, min(MAX_RECENCY_WINDOW_DAYS, window_days))
 
 
 def _normalize_baseline_seasons(baseline_seasons: int, mode: RegressionMode = DEFAULT_REGRESSION_MODE) -> int:

--- a/backend/tests/routes/test_trends_route.py
+++ b/backend/tests/routes/test_trends_route.py
@@ -231,3 +231,27 @@ def test_get_game_log_404_when_no_rows(mock_services):
     resp = client.get('/api/trends/player/999/gamelog')
 
     assert resp.status_code == 404
+
+
+@pytest.mark.parametrize('endpoint', [
+    '/api/trends/regression',
+    '/api/trends/minutes',
+    '/api/trends/usage',
+    '/api/trends/player/1630245/gamelog',
+])
+@pytest.mark.parametrize('window_days', [0, 4, 61, 500])
+def test_out_of_range_window_days_returns_422(mock_services, endpoint, window_days):
+    client = TestClient(app)
+    resp = client.get(f'{endpoint}?window_days={window_days}')
+
+    assert resp.status_code == 422
+
+
+def test_in_range_off_preset_window_days_is_honoured(mock_services):
+    svc, _ = mock_services
+    client = TestClient(app)
+    resp = client.get('/api/trends/minutes?window_days=21')
+
+    assert resp.status_code == 200
+    svc.get_minutes_movers.assert_awaited_once()
+    assert svc.get_minutes_movers.call_args.args[1] == 21

--- a/backend/tests/services/test_trend_service.py
+++ b/backend/tests/services/test_trend_service.py
@@ -8,8 +8,11 @@ import pytest
 from app.config import settings
 from app.services import trend_service
 from app.services.trend_service import (
+    MAX_RECENCY_WINDOW_DAYS,
+    MIN_RECENCY_WINDOW_DAYS,
     TrendService,
     _normalize_baseline_seasons,
+    _normalize_window_days,
     _TTLLRUCache,
     build_game_log,
     classify_role_badge,
@@ -958,6 +961,23 @@ class TestCachePresetResponse:
         svc._cache_preset_response(cache, 15, 15, 'response')
 
         assert cache[15]['data'] == 'response'
+
+
+class TestNormalizeWindowDays:
+    def test_below_min_clamps_up(self):
+        assert _normalize_window_days(1) == MIN_RECENCY_WINDOW_DAYS
+
+    def test_above_max_clamps_down(self):
+        assert _normalize_window_days(500) == MAX_RECENCY_WINDOW_DAYS
+
+    def test_off_preset_value_is_honoured(self):
+        assert _normalize_window_days(21) == 21
+
+    def test_min_boundary_passes_through(self):
+        assert _normalize_window_days(MIN_RECENCY_WINDOW_DAYS) == MIN_RECENCY_WINDOW_DAYS
+
+    def test_max_boundary_passes_through(self):
+        assert _normalize_window_days(MAX_RECENCY_WINDOW_DAYS) == MAX_RECENCY_WINDOW_DAYS
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/DateRangePicker.tsx
+++ b/frontend/src/components/DateRangePicker.tsx
@@ -7,6 +7,7 @@ interface DateRangePickerProps {
   today?: string
   initialStart?: string
   initialEnd?: string
+  fixedEnd?: string
   onApply: (range: CustomDateRange) => void
 }
 
@@ -15,35 +16,39 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
   today = todayIso(),
   initialStart = '',
   initialEnd = '',
+  fixedEnd,
   onApply,
 }) => {
   const [start, setStart] = useState(initialStart)
   const [end, setEnd] = useState(initialEnd)
 
-  const error = validateDateRange(start, end, seasonStart, today)
-  const applyDisabled = !start || !end || !!error
+  const effectiveEnd = fixedEnd ?? end
+  const error = fixedEnd
+    ? validateDateRange(start, fixedEnd, seasonStart, fixedEnd)
+    : validateDateRange(start, end, seasonStart, today)
+  const applyDisabled = !start || !effectiveEnd || !!error
 
   const handleApply = () => {
     if (applyDisabled) return
-    onApply({ start, end })
+    onApply({ start, end: effectiveEnd })
   }
 
   const handleClear = () => {
     setStart('')
-    setEnd('')
+    if (!fixedEnd) setEnd('')
   }
 
   return (
     <div className="mt-2 p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-sm w-full min-w-[260px] sm:w-auto sm:inline-block">
       <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
         <div className="flex flex-col gap-1 w-full sm:w-auto">
-          <label className="text-xs text-gray-600 dark:text-gray-300 font-medium">Start</label>
+          <label className="text-xs text-gray-600 dark:text-gray-300 font-medium">{fixedEnd ? 'Window starts' : 'Start'}</label>
           <input
             type="date"
             aria-label="Start date"
             value={start}
             min={seasonStart}
-            max={end || today}
+            max={fixedEnd ?? (end || today)}
             onChange={(e) => setStart(e.target.value)}
             className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 ${
               error ? 'border-red-400' : 'border-gray-300 dark:border-gray-600'
@@ -55,11 +60,12 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           <input
             type="date"
             aria-label="End date"
-            value={end}
+            value={effectiveEnd}
             min={start || seasonStart}
             max={today}
-            onChange={(e) => setEnd(e.target.value)}
-            className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 ${
+            disabled={!!fixedEnd}
+            onChange={(e) => !fixedEnd && setEnd(e.target.value)}
+            className={`w-full sm:w-auto px-3 py-1.5 rounded-md text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:opacity-60 disabled:cursor-not-allowed ${
               error ? 'border-red-400' : 'border-gray-300 dark:border-gray-600'
             }`}
           />
@@ -81,7 +87,9 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
         </div>
       </div>
       <p className="mt-2 text-[0.7rem] text-gray-500 dark:text-gray-400">
-        min = season start{seasonStart ? ` (${seasonStart})` : ''} · max = today · both required
+        {fixedEnd
+          ? `window ends ${fixedEnd} (latest game day)${seasonStart ? ` · min ${seasonStart}` : ''} · start required`
+          : `min = season start${seasonStart ? ` (${seasonStart})` : ''} · max = today · both required`}
       </p>
       {error && <p className="mt-1 text-xs text-red-600 dark:text-red-400">⚠ {error}</p>}
     </div>

--- a/frontend/src/components/PlayerTrendsCard.tsx
+++ b/frontend/src/components/PlayerTrendsCard.tsx
@@ -1,0 +1,166 @@
+import { useMemo, useState } from 'react'
+import { useGetTrendGameLogQuery } from '../store/api/fantasyApi'
+import TrendGameLogChart from './TrendGameLogChart'
+import type { RegressionStat } from '../types/api'
+import { FF_TRENDS } from '../config/featureFlags'
+import { LOW_SAMPLE_GP } from '../utils/trendBaseline'
+import { STAT_FIELDS, seasonAttempts, summarize, fmtValue, fmtDelta, type CardMode } from '../utils/playerTrendsSummary'
+
+const WINDOW_DAYS = 15
+
+const MODE_CHIPS: { key: CardMode; label: string }[] = [
+  { key: 'minutes', label: 'Minutes' },
+  { key: 'usage', label: 'Usage' },
+  { key: '3P%', label: '3P%' },
+  { key: 'FT%', label: 'FT%' },
+  { key: 'FG%', label: 'FG%' },
+]
+
+function shortDate(iso: string): string {
+  return iso.slice(5).replace('-', '/')
+}
+
+function Tile({ label, value, games, muted, badge }: {
+  label: string
+  value: string
+  games?: number
+  muted?: boolean
+  badge?: string
+}) {
+  return (
+    <div
+      className={`rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-3 py-2 min-w-0 ${
+        muted ? 'opacity-60' : ''
+      }`}
+    >
+      <div className="flex items-center gap-1.5">
+        <span className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">{label}</span>
+        {badge && (
+          <span className="text-[9px] font-semibold px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+            {badge}
+          </span>
+        )}
+      </div>
+      <div className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">{value}</div>
+      {games !== undefined && (
+        <div className="text-[11px] text-gray-500 dark:text-gray-400">{games} {games === 1 ? 'game' : 'games'}</div>
+      )}
+    </div>
+  )
+}
+
+function Skeleton() {
+  return (
+    <div className="h-[300px] sm:h-[320px] animate-pulse">
+      <div className="h-5 w-40 bg-gray-200 dark:bg-gray-700 rounded mb-4" />
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="h-16 bg-gray-200 dark:bg-gray-700 rounded-lg" />
+        ))}
+      </div>
+      <div className="h-[180px] bg-gray-200 dark:bg-gray-700 rounded-lg" />
+    </div>
+  )
+}
+
+interface Props {
+  playerId: number
+}
+
+export default function PlayerTrendsCard({ playerId }: Props) {
+  const [mode, setMode] = useState<CardMode>('minutes')
+
+  const { data: log, error, isLoading, refetch } = useGetTrendGameLogQuery(
+    { playerId, windowDays: WINDOW_DAYS, baselineSeasons: 0, mode: 'form' },
+    { skip: !playerId, refetchOnFocus: false },
+  )
+
+  const availableShootingStats = useMemo(() => {
+    if (!log) return []
+    return (Object.keys(STAT_FIELDS) as RegressionStat[]).filter((s) => seasonAttempts(log.games, s) > 0)
+  }, [log])
+
+  if (!FF_TRENDS) return null
+
+  const is404 = error && 'status' in error && error.status === 404
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-6 mt-6">
+      <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">Trends</h2>
+
+      {isLoading && <Skeleton />}
+
+      {!isLoading && error && (
+        <div className="h-[300px] sm:h-[320px] flex items-center justify-center text-center px-4">
+          {is404 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">No game log this season.</p>
+          ) : (
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              Failed to load trends.{' '}
+              <button
+                type="button"
+                onClick={() => refetch()}
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isLoading && !error && log && (
+        <>
+          <div className="flex flex-wrap gap-2 mb-4">
+            {MODE_CHIPS.filter(
+              (c) => c.key === 'minutes' || c.key === 'usage' || availableShootingStats.includes(c.key as RegressionStat),
+            ).map((c) => (
+              <button
+                key={c.key}
+                type="button"
+                onClick={() => setMode(c.key)}
+                className={`px-3 py-1.5 text-sm rounded-lg border whitespace-nowrap transition-colors ${
+                  mode === c.key
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+                }`}
+              >
+                {c.label}
+              </button>
+            ))}
+          </div>
+
+          {(() => {
+            const summary = summarize(log, mode)
+            const partial = summary.windowGames < LOW_SAMPLE_GP
+            return (
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+                <Tile label="Season" value={fmtValue(summary.seasonValue, mode)} games={summary.seasonGames} />
+                <Tile label={`Last ${WINDOW_DAYS}d`} value={fmtValue(summary.windowValue, mode)} games={summary.windowGames} />
+                <Tile
+                  label="Δ vs season"
+                  value={fmtDelta(summary.delta, mode)}
+                  games={summary.windowGames}
+                  muted={partial}
+                  badge={partial ? 'partial' : undefined}
+                />
+                <Tile label="Window start" value={shortDate(summary.windowStart)} games={summary.windowGames} />
+              </div>
+            )
+          })()}
+
+          <TrendGameLogChart
+            playerId={playerId}
+            playerName={log.player_name}
+            mode={mode === 'minutes' || mode === 'usage' ? mode : 'shooting'}
+            regressionMode="form"
+            windowDays={WINDOW_DAYS}
+            baselineSeasons={0}
+            stat={mode === 'minutes' || mode === 'usage' ? undefined : mode}
+            qualifiedStats={availableShootingStats}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/PlayerTrendsCard.tsx
+++ b/frontend/src/components/PlayerTrendsCard.tsx
@@ -1,12 +1,17 @@
 import { useMemo, useState } from 'react'
 import { useGetTrendGameLogQuery } from '../store/api/fantasyApi'
 import TrendGameLogChart from './TrendGameLogChart'
-import type { RegressionStat } from '../types/api'
+import DateRangePicker from './DateRangePicker'
+import type { RegressionStat, CustomDateRange } from '../types/api'
 import { FF_TRENDS } from '../config/featureFlags'
 import { LOW_SAMPLE_GP } from '../utils/trendBaseline'
+import { toLocalIso, daysBetween, formatShort } from '../utils/dateRange'
 import { STAT_FIELDS, seasonAttempts, summarize, fmtValue, fmtDelta, type CardMode } from '../utils/playerTrendsSummary'
 
-const WINDOW_DAYS = 15
+const DEFAULT_WINDOW_DAYS = 15
+const PRESET_WINDOWS = [7, 15, 30] as const
+const MIN_CUSTOM_WINDOW_DAYS = 5
+const MAX_CUSTOM_WINDOW_DAYS = 60
 
 const MODE_CHIPS: { key: CardMode; label: string }[] = [
   { key: 'minutes', label: 'Minutes' },
@@ -18,6 +23,17 @@ const MODE_CHIPS: { key: CardMode; label: string }[] = [
 
 function shortDate(iso: string): string {
   return iso.slice(5).replace('-', '/')
+}
+
+function addDaysIso(iso: string, days: number): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  const dt = new Date(y, m - 1, d)
+  dt.setDate(dt.getDate() + days)
+  return toLocalIso(dt)
+}
+
+function subDaysIso(iso: string, days: number): string {
+  return addDaysIso(iso, -days)
 }
 
 function Tile({ label, value, games, muted, badge }: {
@@ -69,9 +85,13 @@ interface Props {
 
 export default function PlayerTrendsCard({ playerId }: Props) {
   const [mode, setMode] = useState<CardMode>('minutes')
+  const [windowDays, setWindowDays] = useState(DEFAULT_WINDOW_DAYS)
+  const [customStartIso, setCustomStartIso] = useState<string | null>(null)
+  const [customOpen, setCustomOpen] = useState(false)
+  const [customError, setCustomError] = useState<string | null>(null)
 
   const { data: log, error, isLoading, refetch } = useGetTrendGameLogQuery(
-    { playerId, windowDays: WINDOW_DAYS, baselineSeasons: 0, mode: 'form' },
+    { playerId, windowDays, baselineSeasons: 0, mode: 'form' },
     { skip: !playerId, refetchOnFocus: false },
   )
 
@@ -79,6 +99,31 @@ export default function PlayerTrendsCard({ playerId }: Props) {
     if (!log) return []
     return (Object.keys(STAT_FIELDS) as RegressionStat[]).filter((s) => seasonAttempts(log.games, s) > 0)
   }, [log])
+
+  // anchor (latest game day) is invariant across windows, so any loaded
+  // response - whichever window it was fetched for - can derive it
+  const anchorIso = log ? addDaysIso(log.window_start, log.window_days) : null
+  const customMinStartIso = anchorIso ? subDaysIso(anchorIso, MAX_CUSTOM_WINDOW_DAYS) : undefined
+
+  const selectPreset = (d: number) => {
+    setWindowDays(d)
+    setCustomStartIso(null)
+    setCustomError(null)
+    setCustomOpen(false)
+  }
+
+  const handleCustomApply = (range: CustomDateRange) => {
+    if (!anchorIso) return
+    const days = daysBetween(range.start, anchorIso)
+    if (days < MIN_CUSTOM_WINDOW_DAYS || days > MAX_CUSTOM_WINDOW_DAYS) {
+      setCustomError(`That's ${days} day${days === 1 ? '' : 's'} — pick a start between ${MIN_CUSTOM_WINDOW_DAYS} and ${MAX_CUSTOM_WINDOW_DAYS} days before ${formatShort(anchorIso)}.`)
+      return
+    }
+    setCustomError(null)
+    setCustomStartIso(range.start)
+    setWindowDays(days)
+    setCustomOpen(false)
+  }
 
   if (!FF_TRENDS) return null
 
@@ -111,6 +156,46 @@ export default function PlayerTrendsCard({ playerId }: Props) {
 
       {!isLoading && !error && log && (
         <>
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs">
+              {PRESET_WINDOWS.map((d) => (
+                <button
+                  key={d}
+                  type="button"
+                  onClick={() => selectPreset(d)}
+                  className={`px-2.5 py-1.5 whitespace-nowrap ${!customStartIso && windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                >
+                  {d}d
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => setCustomOpen((o) => !o)}
+                title="Pick a custom start date — the window always ends on the latest game day"
+                className={`px-2.5 py-1.5 whitespace-nowrap ${customStartIso ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+              >
+                📆
+              </button>
+            </div>
+            {customStartIso && !customOpen && (
+              <span className="text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                since {formatShort(customStartIso)} · {windowDays}d
+              </span>
+            )}
+          </div>
+
+          {customOpen && anchorIso && (
+            <div className="mb-3">
+              <DateRangePicker
+                seasonStart={customMinStartIso}
+                fixedEnd={anchorIso}
+                initialStart={customStartIso ?? ''}
+                onApply={handleCustomApply}
+              />
+              {customError && <p className="mt-1 text-xs text-red-600 dark:text-red-400">⚠ {customError}</p>}
+            </div>
+          )}
+
           <div className="flex flex-wrap gap-2 mb-4">
             {MODE_CHIPS.filter(
               (c) => c.key === 'minutes' || c.key === 'usage' || availableShootingStats.includes(c.key as RegressionStat),
@@ -136,7 +221,7 @@ export default function PlayerTrendsCard({ playerId }: Props) {
             return (
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
                 <Tile label="Season" value={fmtValue(summary.seasonValue, mode)} games={summary.seasonGames} />
-                <Tile label={`Last ${WINDOW_DAYS}d`} value={fmtValue(summary.windowValue, mode)} games={summary.windowGames} />
+                <Tile label={`Last ${windowDays}d`} value={fmtValue(summary.windowValue, mode)} games={summary.windowGames} />
                 <Tile
                   label="Δ vs season"
                   value={fmtDelta(summary.delta, mode)}
@@ -154,7 +239,7 @@ export default function PlayerTrendsCard({ playerId }: Props) {
             playerName={log.player_name}
             mode={mode === 'minutes' || mode === 'usage' ? mode : 'shooting'}
             regressionMode="form"
-            windowDays={WINDOW_DAYS}
+            windowDays={windowDays}
             baselineSeasons={0}
             stat={mode === 'minutes' || mode === 'usage' ? undefined : mode}
             qualifiedStats={availableShootingStats}

--- a/frontend/src/components/__tests__/DateRangePicker.test.tsx
+++ b/frontend/src/components/__tests__/DateRangePicker.test.tsx
@@ -72,4 +72,54 @@ describe('DateRangePicker', () => {
     expect(screen.getByText(new RegExp(SEASON_START))).toBeInTheDocument()
     expect(screen.getByText(/both required/i)).toBeInTheDocument()
   })
+
+  describe('fixedEnd', () => {
+    const ANCHOR = '2026-07-10'
+
+    it('renders the end input disabled at the fixed value', () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      const endInput = screen.getByLabelText(/end date/i)
+      expect(endInput).toBeDisabled()
+      expect(endInput).toHaveValue(ANCHOR)
+    })
+
+    it('relabels the start field and disables Apply until a start is picked', async () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      expect(screen.getByText('Window starts')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeDisabled()
+    })
+
+    it('calls onApply with the fixed end once a start is picked, without an end-date error', async () => {
+      const onApply = vi.fn()
+      render(<DateRangePicker fixedEnd={ANCHOR} onApply={onApply} />)
+      const user = userEvent.setup()
+
+      await user.type(screen.getByLabelText(/start date/i), '2026-06-19')
+      expect(screen.queryByText(/before end date/i)).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeEnabled()
+
+      await user.click(screen.getByRole('button', { name: /apply/i }))
+      expect(onApply).toHaveBeenCalledWith({ start: '2026-06-19', end: ANCHOR })
+    })
+
+    it('still enforces seasonStart as a lower bound', async () => {
+      render(<DateRangePicker seasonStart={SEASON_START} fixedEnd={ANCHOR} onApply={vi.fn()} />)
+      const user = userEvent.setup()
+
+      await user.type(screen.getByLabelText(/start date/i), '2025-10-01')
+      expect(screen.getByText(/cannot be before season start/i)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply/i })).toBeDisabled()
+    })
+
+    it('Clear only resets the start field, not the fixed end', async () => {
+      render(<DateRangePicker fixedEnd={ANCHOR} initialStart="2026-06-19" onApply={vi.fn()} />)
+      const user = userEvent.setup()
+
+      expect(screen.getByLabelText(/start date/i)).toHaveValue('2026-06-19')
+      await user.click(screen.getByRole('button', { name: /clear/i }))
+
+      expect(screen.getByLabelText(/start date/i)).toHaveValue('')
+      expect(screen.getByLabelText(/end date/i)).toHaveValue(ANCHOR)
+    })
+  })
 })

--- a/frontend/src/pages/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile.tsx
@@ -6,6 +6,7 @@ import TimePeriodSelector from '../components/TimePeriodSelector'
 import { CoverageNotice } from '../components/DateRangePicker'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import PlayerTrendsCard from '../components/PlayerTrendsCard'
 
 function backLabel(from: string | undefined): string {
   if (!from) return '← Back'
@@ -239,6 +240,8 @@ const PlayerProfile = () => {
           </div>
         )}
       </div>
+
+      <PlayerTrendsCard playerId={Number(playerId)} />
     </div>
   )
 }

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -4,13 +4,30 @@ import {
   useGetTrendsMinutesQuery,
   useGetTrendsUsageQuery,
   useGetTrendsRegressionQuery,
+  useGetTrendGameLogQuery,
 } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import TrendGameLogChart from '../components/TrendGameLogChart'
 import InfoTip from '../components/InfoTip'
+import DateRangePicker from '../components/DateRangePicker'
 import { BASELINE_LABEL } from '../utils/trendBaseline'
-import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat, RegressionMode } from '../types/api'
+import { toLocalIso, daysBetween, formatShort } from '../utils/dateRange'
+import type { MinutesMoverItem, UsageRoleItem, RegressionPlayerGroup, RegressionStatItem, RegressionStat, RegressionMode, CustomDateRange } from '../types/api'
+
+const MIN_CUSTOM_WINDOW_DAYS = 5
+const MAX_CUSTOM_WINDOW_DAYS = 60
+
+function addDaysIso(iso: string, days: number): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  const dt = new Date(y, m - 1, d)
+  dt.setDate(dt.getDate() + days)
+  return toLocalIso(dt)
+}
+
+function subDaysIso(iso: string, days: number): string {
+  return addDaysIso(iso, -days)
+}
 
 type TabKey = 'minutes' | 'usage' | 'shooting-season' | 'shooting-form'
 type Ownership = 'all' | 'fa' | 'rostered'
@@ -572,6 +589,9 @@ export default function Trends() {
   // judging a season line, "this season" when judging current form
   const [seasonBaseline, setSeasonBaseline] = usePersistedState('trends.seasonBaseline', 2)
   const [formBaseline, setFormBaseline] = usePersistedState('trends.formBaseline', 0)
+  const [customStartIso, setCustomStartIso] = useState<string | null>(null)
+  const [customOpen, setCustomOpen] = useState(false)
+  const [customError, setCustomError] = useState<string | null>(null)
 
   const regressionMode = TAB_MODE[tab]
   const isShooting = regressionMode !== undefined
@@ -585,6 +605,50 @@ export default function Trends() {
     { windowDays, baselineSeasons, mode: regressionMode ?? 'season' },
     { skip: !isShooting },
   )
+
+  // The recency window always ends on the latest game day, not wall-clock
+  // today — none of the three tab payloads carry that date directly, but
+  // GameLogResponse does (window_start + window_days). Borrow it from
+  // whichever player is first in the currently active tab's results, only
+  // while the custom panel is open, so this doesn't add a request otherwise.
+  const anchorSourceId = tab === 'minutes'
+    ? minutesQuery.data?.items[0]?.player_id
+    : tab === 'usage'
+      ? usageQuery.data?.items[0]?.player_id
+      : regressionQuery.data?.items[0]?.player_id
+
+  const anchorQuery = useGetTrendGameLogQuery(
+    { playerId: anchorSourceId ?? 0, windowDays },
+    { skip: !customOpen || anchorSourceId === undefined },
+  )
+
+  const anchorIso = useMemo(() => {
+    const d = anchorQuery.data
+    if (!d) return null
+    return addDaysIso(d.window_start, d.window_days)
+  }, [anchorQuery.data])
+
+  const customMinStartIso = anchorIso ? subDaysIso(anchorIso, MAX_CUSTOM_WINDOW_DAYS) : undefined
+
+  const handleCustomApply = (range: CustomDateRange) => {
+    if (!anchorIso) return
+    const days = daysBetween(range.start, anchorIso)
+    if (days < MIN_CUSTOM_WINDOW_DAYS || days > MAX_CUSTOM_WINDOW_DAYS) {
+      setCustomError(`That's ${days} day${days === 1 ? '' : 's'} — pick a start between ${MIN_CUSTOM_WINDOW_DAYS} and ${MAX_CUSTOM_WINDOW_DAYS} days before ${formatShort(anchorIso)}.`)
+      return
+    }
+    setCustomError(null)
+    setCustomStartIso(range.start)
+    setWindowDays(days)
+    setCustomOpen(false)
+  }
+
+  const selectPreset = (d: number) => {
+    setWindowDays(d)
+    setCustomStartIso(null)
+    setCustomError(null)
+    setCustomOpen(false)
+  }
 
   const filters: Filters = { nameFilter, position, minG15: minGames, ownership, fantasyTeam }
 
@@ -634,17 +698,50 @@ export default function Trends() {
               {ALL_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
             </select>
             <span className="hidden sm:block flex-1" />
-            <div className="col-span-2 flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
-              {WINDOW_OPTIONS.map(d => (
+            <div className="col-span-2 flex flex-wrap items-center gap-2">
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Recency window for the G column and eligibility filter">
+                {WINDOW_OPTIONS.map(d => (
+                  <button
+                    key={d}
+                    onClick={() => selectPreset(d)}
+                    className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${!customStartIso && windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  >
+                    {d}d
+                  </button>
+                ))}
                 <button
-                  key={d}
-                  onClick={() => setWindowDays(d)}
-                  className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  onClick={() => setCustomOpen(o => !o)}
+                  title="Pick a custom start date — the window always ends on the latest game day"
+                  className={`flex-1 sm:flex-none px-2.5 py-2 sm:py-1.5 whitespace-nowrap ${customStartIso ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
                 >
-                  {d}d
+                  📆 Custom
                 </button>
-              ))}
+              </div>
+              {customStartIso && !customOpen && (
+                <span className="text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                  since {formatShort(customStartIso)} · {windowDays} days
+                </span>
+              )}
             </div>
+            {customOpen && (
+              <div className="col-span-2">
+                {!anchorIso ? (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 py-2">
+                    {anchorQuery.isFetching || anchorSourceId === undefined ? 'Loading latest game day…' : 'Could not determine the latest game day.'}
+                  </p>
+                ) : (
+                  <>
+                    <DateRangePicker
+                      seasonStart={customMinStartIso}
+                      fixedEnd={anchorIso}
+                      initialStart={customStartIso ?? ''}
+                      onApply={handleCustomApply}
+                    />
+                    {customError && <p className="mt-1 text-xs text-red-600 dark:text-red-400">⚠ {customError}</p>}
+                  </>
+                )}
+              </div>
+            )}
             <div className="col-span-2 flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs sm:text-sm" title="Which players to show: everyone, free agents only, or rostered only">
               {OWNERSHIP_OPTIONS.map(([key, label]) => (
                 <button

--- a/frontend/src/store/api/fantasyApi.ts
+++ b/frontend/src/store/api/fantasyApi.ts
@@ -125,15 +125,18 @@ export const fantasyApi = createApi({
     }),
     getTrendsMinutes: builder.query<MinutesResponse, { windowDays?: number }>({
       query: ({ windowDays = 15 } = {}) => ({ url: '/trends/minutes', params: { window_days: windowDays } }),
+      keepUnusedDataFor: 600,
     }),
     getTrendsUsage: builder.query<UsageResponse, { windowDays?: number }>({
       query: ({ windowDays = 15 } = {}) => ({ url: '/trends/usage', params: { window_days: windowDays } }),
+      keepUnusedDataFor: 600,
     }),
     getTrendsRegression: builder.query<RegressionResponse, { windowDays?: number; baselineSeasons?: number; mode?: RegressionMode }>({
       query: ({ windowDays = 15, baselineSeasons = 2, mode = 'season' } = {}) => ({
         url: '/trends/regression',
         params: { window_days: windowDays, baseline_seasons: baselineSeasons, mode },
       }),
+      keepUnusedDataFor: 600,
     }),
     getTrendGameLog: builder.query<GameLogResponse, { playerId: number; windowDays?: number; baselineSeasons?: number; mode?: RegressionMode }>({
       query: ({ playerId, windowDays = 15, baselineSeasons = 2, mode = 'season' }) => ({

--- a/frontend/src/utils/__tests__/playerTrendsSummary.test.ts
+++ b/frontend/src/utils/__tests__/playerTrendsSummary.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import type { GameLogEntry, GameLogResponse } from '../../types/api'
+import { fmtDelta, fmtValue, seasonAttempts, summarize } from '../playerTrendsSummary'
+
+function game(overrides: Partial<GameLogEntry>): GameLogEntry {
+  return {
+    game_date: '2026-01-01',
+    matchup: 'vs BOS',
+    min: 30,
+    usg: 20,
+    fgm: 5,
+    fga: 10,
+    ftm: 2,
+    fta: 2,
+    fg3m: 1,
+    fg3a: 3,
+    ...overrides,
+  }
+}
+
+function log(overrides: Partial<GameLogResponse>): GameLogResponse {
+  return {
+    player_id: 1,
+    player_name: 'Test Player',
+    season: '2025-26',
+    window_days: 15,
+    window_start: '2026-01-10',
+    season_gp: 10,
+    season_mpg: 28,
+    season_usg: 22,
+    season_pct: { '3P%': 35, 'FT%': 80, 'FG%': 45 },
+    baseline_pct: {},
+    league_pct: {},
+    league_usg: null,
+    baseline_seasons: 0,
+    games: [],
+    ...overrides,
+  }
+}
+
+describe('summarize', () => {
+  it('averages minutes over the window and computes delta vs season', () => {
+    const l = log({
+      games: [
+        game({ game_date: '2026-01-05', min: 20 }),
+        game({ game_date: '2026-01-11', min: 30 }),
+        game({ game_date: '2026-01-13', min: 34 }),
+      ],
+    })
+    const s = summarize(l, 'minutes')
+    expect(s.seasonValue).toBe(28)
+    expect(s.windowValue).toBe(32)
+    expect(s.delta).toBeCloseTo(4)
+    expect(s.windowGames).toBe(2)
+    expect(s.seasonGames).toBe(10)
+    expect(s.windowStart).toBe('2026-01-10')
+  })
+
+  it('pools makes over attempts for a shooting stat rather than averaging per-game percentages', () => {
+    const l = log({
+      games: [
+        game({ game_date: '2026-01-11', fg3m: 1, fg3a: 2 }), // 50%
+        game({ game_date: '2026-01-12', fg3m: 4, fg3a: 8 }), // 50%
+        game({ game_date: '2026-01-13', fg3m: 0, fg3a: 0 }), // no attempts, excluded from pooling but counted as a game
+      ],
+    })
+    const s = summarize(l, '3P%')
+    expect(s.windowValue).toBeCloseTo(50)
+    expect(s.windowGames).toBe(3)
+    expect(s.seasonValue).toBe(35)
+    expect(s.delta).toBeCloseTo(15)
+  })
+
+  it('returns null window value when no games fall in the window', () => {
+    const l = log({ games: [game({ game_date: '2025-12-01' })] })
+    const s = summarize(l, 'minutes')
+    expect(s.windowValue).toBeNull()
+    expect(s.delta).toBeNull()
+    expect(s.windowGames).toBe(0)
+  })
+
+  it('returns null window value for a shooting stat with zero attempts in the window', () => {
+    const l = log({
+      games: [game({ game_date: '2026-01-11', fg3m: 0, fg3a: 0 })],
+    })
+    const s = summarize(l, '3P%')
+    expect(s.windowValue).toBeNull()
+    expect(s.delta).toBeNull()
+  })
+})
+
+describe('seasonAttempts', () => {
+  it('sums attempts for the given stat across all games', () => {
+    const games = [game({ fg3a: 3 }), game({ fg3a: 5 })]
+    expect(seasonAttempts(games, '3P%')).toBe(8)
+  })
+
+  it('returns 0 when no games have attempts', () => {
+    const games = [game({ fta: 0 })]
+    expect(seasonAttempts(games, 'FT%')).toBe(0)
+  })
+})
+
+describe('fmtValue / fmtDelta', () => {
+  it('formats minutes without a percent sign', () => {
+    expect(fmtValue(28.456, 'minutes')).toBe('28.5')
+  })
+
+  it('formats usage and shooting stats with a percent sign', () => {
+    expect(fmtValue(22.1, 'usage')).toBe('22.1%')
+    expect(fmtValue(35, '3P%')).toBe('35.0%')
+  })
+
+  it('formats null as an em dash', () => {
+    expect(fmtValue(null, 'minutes')).toBe('—')
+    expect(fmtDelta(null, '3P%')).toBe('—')
+  })
+
+  it('signs deltas explicitly', () => {
+    expect(fmtDelta(4, 'minutes')).toBe('+4.0')
+    expect(fmtDelta(-2.3, 'usage')).toBe('-2.3%')
+  })
+})

--- a/frontend/src/utils/playerTrendsSummary.ts
+++ b/frontend/src/utils/playerTrendsSummary.ts
@@ -1,0 +1,68 @@
+import type { GameLogEntry, GameLogResponse, RegressionStat } from '../types/api'
+
+export type CardMode = 'minutes' | 'usage' | RegressionStat
+
+export const STAT_FIELDS: Record<RegressionStat, { made: keyof GameLogEntry; att: keyof GameLogEntry }> = {
+  '3P%': { made: 'fg3m', att: 'fg3a' },
+  'FT%': { made: 'ftm', att: 'fta' },
+  'FG%': { made: 'fgm', att: 'fga' },
+}
+
+export function seasonAttempts(games: GameLogEntry[], stat: RegressionStat): number {
+  const { att } = STAT_FIELDS[stat]
+  return games.reduce((sum, g) => sum + (g[att] as number), 0)
+}
+
+export interface TrendSummary {
+  seasonValue: number | null
+  windowValue: number | null
+  delta: number | null
+  windowStart: string
+  seasonGames: number
+  windowGames: number
+}
+
+export function summarize(log: GameLogResponse, mode: CardMode): TrendSummary {
+  const windowGames = log.games.filter((g) => g.game_date >= log.window_start)
+
+  if (mode === 'minutes' || mode === 'usage') {
+    const field: keyof GameLogEntry = mode === 'minutes' ? 'min' : 'usg'
+    const seasonValue = mode === 'minutes' ? log.season_mpg : log.season_usg
+    const windowValue = windowGames.length
+      ? windowGames.reduce((sum, g) => sum + (g[field] as number), 0) / windowGames.length
+      : null
+    return {
+      seasonValue,
+      windowValue,
+      delta: windowValue === null ? null : windowValue - seasonValue,
+      windowStart: log.window_start,
+      seasonGames: log.season_gp,
+      windowGames: windowGames.length,
+    }
+  }
+
+  const { made, att } = STAT_FIELDS[mode]
+  const seasonValue = log.season_pct[mode] ?? null
+  const attSum = windowGames.reduce((sum, g) => sum + (g[att] as number), 0)
+  const madeSum = windowGames.reduce((sum, g) => sum + (g[made] as number), 0)
+  const windowValue = attSum > 0 ? (madeSum / attSum) * 100 : null
+  return {
+    seasonValue,
+    windowValue,
+    delta: windowValue === null || seasonValue === null ? null : windowValue - seasonValue,
+    windowStart: log.window_start,
+    seasonGames: log.season_gp,
+    windowGames: windowGames.length,
+  }
+}
+
+export function fmtValue(value: number | null, mode: CardMode): string {
+  if (value === null) return '—'
+  return mode === 'minutes' ? value.toFixed(1) : `${value.toFixed(1)}%`
+}
+
+export function fmtDelta(value: number | null, mode: CardMode): string {
+  if (value === null) return '—'
+  const sign = value >= 0 ? '+' : ''
+  return mode === 'minutes' ? `${sign}${value.toFixed(1)}` : `${sign}${value.toFixed(1)}%`
+}

--- a/frontend/src/utils/trendBaseline.ts
+++ b/frontend/src/utils/trendBaseline.ts
@@ -1,1 +1,5 @@
 export const BASELINE_LABEL: Record<number, string> = { 0: 'this season only', 1: 'last season', 2: 'prior 2 seasons' }
+
+// Mirrors LOW_SAMPLE_GP in backend/app/services/trend_service.py — below this
+// many games in the window, a delta is more noise than signal.
+export const LOW_SAMPLE_GP = 3


### PR DESCRIPTION
## Summary
- Stacked on #172 (P4) — also merges in #171 (S1-S3)'s card component, since this branch needs both. Merge #171 and the #167→#168→#172 stack before this one.
- Swaps `PlayerTrendsCard`'s fixed 15-day window for the same presets (7/15/30) + 📆 custom start-date control from P4 — end still pinned to the anchor, never a free range.
- Anchor is derived from whichever game-log response is currently loaded (`window_start + window_days` is invariant regardless of which window was requested), so opening the custom panel doesn't need an extra request — reuses the card's own already-in-flight query.
- Phase S4 of `trends_implementation_plan.html` — the convergence point between the P-track (picker) and S-track (card).

## Test plan
- [x] `tsc -b` clean, pre-push hook passed
- Not independently re-tested in browser this pass — small, additive change reusing already-verified `DateRangePicker`/`daysBetween` (P4) and `PlayerTrendsCard` (S1-S3) pieces; CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)