### PR TITLE
feat: player-page next-game projection

### DIFF
--- a/backend/app/models/projection_models.py
+++ b/backend/app/models/projection_models.py
@@ -27,6 +27,19 @@ class Projection(BaseModel):
     stats: Optional[ProjectionStats] = None
 
 
+class PlayerNextGameProjection(BaseModel):
+    player_name: str
+    team: str
+    game_date: Optional[str] = None
+    opponent: Optional[str] = None
+    is_home: bool = True
+    scheduled: bool = True
+    default_minutes: float
+    status: ProjectionStatus
+    reason: str = ''
+    stats: Optional[ProjectionStats] = None
+
+
 class PredictProjectionRequest(BaseModel):
     player_name: str
     opponent: str  # ESPN abbreviation

--- a/backend/app/routes/projections.py
+++ b/backend/app/routes/projections.py
@@ -2,13 +2,27 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
-from app.models.projection_models import PredictProjectionRequest, PredictProjectionResponse
+from app.models.projection_models import (
+    PlayerNextGameProjection,
+    PredictProjectionRequest,
+    PredictProjectionResponse,
+)
 from app.services.live_projection_service import LiveProjectionService
+from app.services.player_next_game_service import PlayerNextGameService
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _projection_service = LiveProjectionService()
+_next_game_service = PlayerNextGameService()
+
+
+@router.get('/player/{player_id}', response_model=PlayerNextGameProjection)
+async def player_next_game_projection(player_id: str) -> PlayerNextGameProjection:
+    result = await _next_game_service.next_game_projection(player_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail='no upcoming projection for this player')
+    return result
 
 
 @router.post('/predict', response_model=PredictProjectionResponse)

--- a/backend/app/services/live_projection_service.py
+++ b/backend/app/services/live_projection_service.py
@@ -103,6 +103,30 @@ class LiveProjectionService:
             out[name] = _to_projection(inference.store, pid, default_min, today, res, err)
         return out
 
+    async def project_next_game(
+        self, player_name: str, opponent: str, is_home: bool, minutes: float | None = None
+    ) -> dict | None:
+        """Single player, full projection envelope (default_minutes + status +
+        stats) — the player-page card, which has no batch slate to read from."""
+        inference = await self._ensure_inference()
+        if inference is None:
+            return None
+        pid = self._name_index.get(normalize_player_name(player_name))
+        if pid is None:
+            logger.warning(f"No feature-store match for '{player_name}' — next-game projection skipped")
+            return None
+        opp_id = _opponent_team_id(opponent)
+        if opp_id is None:
+            return None
+        today = pd.Timestamp.now().normalize()
+        default_min = _default_minutes(inference.store, pid)
+        req = PredictionRequest(
+            player_id=pid, opponent_team_id=opp_id, is_home=is_home,
+            game_date=today, minutes=default_min if minutes is None else minutes,
+        )
+        results, errors = await asyncio.to_thread(inference.predict_many, [req])
+        return _to_projection(inference.store, pid, default_min, today, results[0], errors[0])
+
     async def project_one(
         self, player_name: str, opponent: str, is_home: bool, minutes: float
     ) -> dict | None:

--- a/backend/app/services/player_next_game_service.py
+++ b/backend/app/services/player_next_game_service.py
@@ -1,0 +1,94 @@
+"""Player-page projection: resolve an NBA player's next scheduled game from the
+ESPN schedule, then project that game off the live feature store.
+
+Distinct from the Projections page, which starts from a slate and projects every
+player in it — here the player is fixed and the slate has to be found.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.models.projection_models import PlayerNextGameProjection, ProjectionStats
+from app.services.db_service import DBService
+from app.services.live_projection_service import LiveProjectionService
+from app.services.nba_matchup_service import NbaMatchupService
+from app.services.nba_player_catalog import get_player_bio
+from app.utils.team_abbr_map import canonical_abbr
+
+logger = logging.getLogger(__name__)
+
+_LOOKAHEAD_DATES = 5
+_LOOKBACK_DATES = 10
+
+
+class PlayerNextGameService:
+    def __init__(self) -> None:
+        self._matchups = NbaMatchupService()
+        self._projections = LiveProjectionService()
+
+    async def next_game_projection(
+        self, player_id: str | int, minutes: float | None = None
+    ) -> PlayerNextGameProjection | None:
+        """The player's next scheduled game, projected. Between seasons there is
+        no next game, so it falls back to the team's most recent played game —
+        the same what-if view the Projections page's past slates give."""
+        bio = get_player_bio(player_id)
+        if bio is None:
+            return None
+        team = canonical_abbr(bio.team_abbr)
+
+        found = await self._find_next_game(team)
+        scheduled = found is not None
+        if found is None:
+            found = await self._find_recent_game(team)
+        if found is None:
+            return None
+        game_date, opponent, is_home = found
+
+        proj = await self._projections.project_next_game(
+            bio.display_name, opponent, is_home, minutes
+        )
+        if proj is None:
+            return None
+        return PlayerNextGameProjection(
+            player_name=bio.display_name,
+            team=team,
+            game_date=game_date,
+            opponent=opponent,
+            is_home=is_home,
+            scheduled=scheduled,
+            default_minutes=proj['default_minutes'],
+            status=proj['status'],
+            reason=proj['reason'],
+            stats=ProjectionStats(**proj['stats']) if proj['stats'] else None,
+        )
+
+    async def _find_next_game(self, team: str) -> tuple[str, str, bool] | None:
+        """(iso date, opponent abbr, is_home) for the team's next game, or None."""
+        games = await self._matchups.get_games_today()
+        resolved = self._matchups.get_schedule_date()
+        info = games.get(team)
+        if info is not None and resolved:
+            return resolved, canonical_abbr(info.opponent), info.is_home
+
+        for iso in await self._matchups.get_upcoming_game_dates(count=_LOOKAHEAD_DATES):
+            if iso == resolved:
+                continue
+            day_games = await self._matchups.get_games_today(iso.replace('-', ''))
+            info = day_games.get(team)
+            if info is not None:
+                return iso, canonical_abbr(info.opponent), info.is_home
+        return None
+
+    async def _find_recent_game(self, team: str) -> tuple[str, str, bool] | None:
+        """Offseason fallback: the team's latest played game, from the dates the
+        feature store already knows about."""
+        dates = await DBService().get_recent_game_dates()
+        for day in dates[:_LOOKBACK_DATES]:
+            iso = day.isoformat()
+            day_games = await self._matchups.get_games_today(iso.replace('-', ''))
+            info = day_games.get(team)
+            if info is not None:
+                return iso, canonical_abbr(info.opponent), info.is_home
+        return None

--- a/frontend/src/components/PlayerNextGameCard.tsx
+++ b/frontend/src/components/PlayerNextGameCard.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useRef, useState } from 'react'
+import { useGetPlayerNextGameProjectionQuery, usePredictProjectionMutation } from '../store/api/fantasyApi'
+import { usePersistedState } from '../hooks/usePersistedState'
+import { FF_PAST_SLATES, FF_PROJECTIONS } from '../config/featureFlags'
+import type { ProjectionStats, ProjectionStatus } from '../types/api'
+import { coherentInts } from '../utils/coherentRound'
+
+// Same colors/sizing as the Projections page's confidence dot, so a player's
+// status reads the same whether it's seen there or on their own profile.
+function StatusDot({ status, reason }: { status: ProjectionStatus; reason?: string }) {
+  const color = status === 'green' ? 'bg-green-500' : status === 'amber' ? 'bg-amber-500' : 'bg-red-500'
+  return <span className={`inline-block w-2.5 h-2.5 rounded-full ${color}`} title={reason || undefined} />
+}
+
+function fmtStat(n: number, integer: boolean): string {
+  return integer ? String(Math.round(n)) : n.toFixed(1)
+}
+
+function pctCell(pctVal: number, made: number, att: number, integer: boolean): { pct: string; frac: string } {
+  if (!(att > 0)) return { pct: '—', frac: '' }
+  if (integer) {
+    const m = Math.round(made), a = Math.round(att)
+    return { pct: a > 0 ? `${Math.round((m / a) * 100)}%` : '—', frac: `${m}/${a}` }
+  }
+  return { pct: `${(pctVal * 100).toFixed(1)}%`, frac: `${made.toFixed(1)}/${att.toFixed(1)}` }
+}
+
+function formatGameDate(iso: string): string {
+  const d = new Date(`${iso}T12:00:00`)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
+}
+
+function relativeDay(iso: string): string | null {
+  const d = new Date(`${iso}T12:00:00`)
+  if (Number.isNaN(d.getTime())) return null
+  const today = new Date()
+  today.setHours(12, 0, 0, 0)
+  const days = Math.round((d.getTime() - today.getTime()) / 86400000)
+  if (days < 0) return null
+  if (days === 0) return 'today'
+  if (days === 1) return 'tomorrow'
+  return `in ${days} days`
+}
+
+function Skeleton() {
+  return (
+    <div className="mt-4 bg-white dark:bg-gray-900 rounded-lg shadow border border-gray-200 dark:border-gray-700 px-3 py-2.5 animate-pulse">
+      <div className="flex items-center gap-2 mb-2">
+        <div className="h-4 w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3 w-40 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3 w-24 bg-gray-200 dark:bg-gray-700 rounded ml-2" />
+      </div>
+      <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded" />
+    </div>
+  )
+}
+
+const PlayerNextGameCard = ({ playerId }: { playerId: string }) => {
+  const { data, isLoading, isError } = useGetPlayerNextGameProjectionQuery(playerId, { skip: !playerId || !FF_PROJECTIONS })
+  const [predict] = usePredictProjectionMutation()
+  const [integerMode, setIntegerMode] = usePersistedState('playerProjection.integerMode', true)
+  const [minutes, setMinutes] = useState(0)
+  const [stats, setStats] = useState<ProjectionStats | null>(null)
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  // Keyed on stable primitives, not the response object — a background
+  // revalidation must not wipe an adjusted slider.
+  const defaultMinutes = data?.default_minutes ?? 0
+  const opponent = data?.opponent ?? null
+  useEffect(() => {
+    clearTimeout(timer.current)
+    setMinutes(defaultMinutes)
+    setStats(data?.stats ?? null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opponent, defaultMinutes])
+
+  if (!FF_PROJECTIONS) return null
+
+  // No line to show = no block at all. Covers every "can't project" case the
+  // backend can return: unknown player, insufficient history (<10 games,
+  // status 'red'), and no game found at all (brand-new team with no past
+  // games either). The unscheduled-fallback line (offseason: shows the
+  // team's last played game instead of a real "next" one) is a debug view,
+  // gated behind the same flag as the Projections page's past-slates picker.
+  if (isLoading) return <Skeleton />
+  const hasLine = !!data?.opponent && data.status !== 'red' && !!data.stats
+  if (isError || !data || !hasLine) return null
+  if (!data.scheduled && !FF_PAST_SLATES) return null
+
+  const onSlider = (v: number) => {
+    setMinutes(v)
+    clearTimeout(timer.current)
+    timer.current = setTimeout(async () => {
+      try {
+        const res = await predict({
+          player_name: data.player_name, opponent: data.opponent as string,
+          is_home: data.is_home, minutes: v,
+        }).unwrap()
+        setStats(res.stats)
+      } catch { /* ignore transient predict errors */ }
+    }, 350)
+  }
+
+  const resetToDefault = () => {
+    clearTimeout(timer.current)
+    setMinutes(data.default_minutes)
+    setStats(data.stats)
+  }
+
+  const isAdjusted = Math.round(minutes) !== Math.round(data.default_minutes)
+  const shown = stats ?? data.stats!
+  const coherent = integerMode ? coherentInts(shown) : null
+  const fg = pctCell(shown.fg_pct, coherent ? coherent.fgm : shown.fgm, coherent ? coherent.fga : shown.fga, integerMode)
+  const ft = pctCell(shown.ft_pct, coherent ? coherent.ftm : shown.ftm, coherent ? coherent.fta : shown.fta, integerMode)
+  const val = (key: keyof ProjectionStats) =>
+    coherent && (key === 'pts' || key === 'three_pm')
+      ? String(coherent[key])
+      : fmtStat(shown[key] as number, integerMode)
+  const fgm = coherent ? String(coherent.fgm) : shown.fgm.toFixed(1)
+  const fga = coherent ? String(coherent.fga) : shown.fga.toFixed(1)
+  const ftm = coherent ? String(coherent.ftm) : shown.ftm.toFixed(1)
+  const fta = coherent ? String(coherent.fta) : shown.fta.toFixed(1)
+
+  const rel = data.game_date ? relativeDay(data.game_date) : null
+  const dateLabel = data.game_date ? ` · ${formatGameDate(data.game_date)}${rel ? ` (${rel})` : ''}` : ''
+  const when = data.scheduled
+    ? `Next game: ${data.is_home ? 'vs' : '@'} ${data.opponent}${dateLabel}`
+    : `Next game unavailable — showing ${data.is_home ? 'vs' : '@'} ${data.opponent}${dateLabel} (last played, debug)`
+
+  return (
+    <div className="mt-4 bg-white dark:bg-gray-900 rounded-lg shadow border border-gray-200 dark:border-gray-700 px-4 py-3.5">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-2 mb-3">
+        <span className="inline-flex items-center text-[9px] font-bold uppercase tracking-wide text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40 border border-blue-300 dark:border-blue-800 rounded px-1.5 py-0.5">
+          Projected
+        </span>
+        <StatusDot status={data.status} reason={data.reason} />
+        <span className="text-xs text-gray-600 dark:text-gray-300" title={data.status === 'amber' ? data.reason : undefined}>
+          {when}
+        </span>
+
+        <span className="flex items-center gap-1.5 ml-2">
+          <span className="text-[11px] text-gray-500 dark:text-gray-400">MIN</span>
+          <input
+            type="range" min={0} max={48} step={1} value={Math.round(minutes)}
+            onChange={(e) => onSlider(Number(e.target.value))}
+            className="w-24 sm:w-36 h-1 accent-blue-600"
+            aria-label="Projected minutes"
+          />
+          <span className="tabular-nums w-6 text-right text-xs font-semibold text-gray-900 dark:text-gray-100">{Math.round(minutes)}</span>
+          <button
+            type="button"
+            onClick={resetToDefault}
+            title={`Reset to default (${Math.round(data.default_minutes)} min)`}
+            className={`text-[11px] leading-none px-1.5 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 ${isAdjusted ? '' : 'invisible'}`}
+          >
+            ↺
+          </button>
+        </span>
+
+        <label className="ml-auto flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300 cursor-pointer select-none">
+          <input type="checkbox" checked={integerMode} onChange={(e) => setIntegerMode(e.target.checked)} className="accent-blue-600" />
+          Integer projections
+        </label>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-gray-500 dark:text-gray-400">
+              <th className="hidden sm:table-cell text-left font-medium pr-2 pb-1.5"></th>
+              <th className="px-1 pb-1.5 font-medium">MIN</th>
+              <th className="px-1 pb-1.5 font-medium">PTS</th>
+              <th className="px-1 pb-1.5 font-medium">REB</th>
+              <th className="px-1 pb-1.5 font-medium">AST</th>
+              <th className="px-1 pb-1.5 font-medium">STL</th>
+              <th className="px-1 pb-1.5 font-medium">BLK</th>
+              <th className="px-1 pb-1.5 font-medium">3PM</th>
+              <th className="hidden sm:table-cell px-1 pb-1.5 font-medium">FGM</th>
+              <th className="hidden sm:table-cell px-1 pb-1.5 font-medium">FGA</th>
+              <th className="px-1 pb-1.5 font-medium">FG%</th>
+              <th className="hidden sm:table-cell px-1 pb-1.5 font-medium">FTM</th>
+              <th className="hidden sm:table-cell px-1 pb-1.5 font-medium">FTA</th>
+              <th className="px-1 pb-1.5 font-medium">FT%</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="bg-blue-50/70 dark:bg-blue-900/20 rounded">
+              <td className="hidden sm:table-cell text-left font-semibold text-gray-700 dark:text-gray-200 pr-2 py-2 whitespace-nowrap">
+                Projected {data.is_home ? 'vs' : '@'} {data.opponent}
+              </td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">{Math.round(minutes)}</td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">{val('pts')}</td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">{val('reb')}</td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">{val('ast')}</td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">{val('stl')}</td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">{val('blk')}</td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">{val('three_pm')}</td>
+              <td className="hidden sm:table-cell px-1 py-2 text-center tabular-nums font-semibold">{fgm}</td>
+              <td className="hidden sm:table-cell px-1 py-2 text-center tabular-nums font-semibold">{fga}</td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">
+                {fg.pct}
+                {fg.frac && <span className="sm:hidden block text-[9px] font-normal text-gray-400">{fg.frac}</span>}
+              </td>
+              <td className="hidden sm:table-cell px-1 py-2 text-center tabular-nums font-semibold">{ftm}</td>
+              <td className="hidden sm:table-cell px-1 py-2 text-center tabular-nums font-semibold">{fta}</td>
+              <td className="px-1 py-2 text-center tabular-nums font-semibold">
+                {ft.pct}
+                {ft.frac && <span className="sm:hidden block text-[9px] font-normal text-gray-400">{ft.frac}</span>}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export default PlayerNextGameCard

--- a/frontend/src/components/PlayerTrendsCard.tsx
+++ b/frontend/src/components/PlayerTrendsCard.tsx
@@ -130,8 +130,8 @@ export default function PlayerTrendsCard({ playerId }: Props) {
   const is404 = error && 'status' in error && error.status === 404
 
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-6 mt-6">
-      <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">Trends</h2>
+    <div className="bg-white dark:bg-gray-900 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-5 sm:p-6 mt-6">
+      <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-3">Trends</h2>
 
       {isLoading && <Skeleton />}
 
@@ -156,32 +156,53 @@ export default function PlayerTrendsCard({ playerId }: Props) {
 
       {!isLoading && !error && log && (
         <>
-          <div className="flex flex-wrap items-center gap-2 mb-3">
-            <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs">
-              {PRESET_WINDOWS.map((d) => (
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-3">
+            <div className="flex flex-wrap gap-2 order-2 sm:order-1">
+              {MODE_CHIPS.filter(
+                (c) => c.key === 'minutes' || c.key === 'usage' || availableShootingStats.includes(c.key as RegressionStat),
+              ).map((c) => (
                 <button
-                  key={d}
+                  key={c.key}
                   type="button"
-                  onClick={() => selectPreset(d)}
-                  className={`px-2.5 py-1.5 whitespace-nowrap ${!customStartIso && windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  onClick={() => setMode(c.key)}
+                  className={`px-3 py-1.5 text-sm rounded-lg border whitespace-nowrap transition-colors ${
+                    mode === c.key
+                      ? 'bg-blue-600 text-white border-blue-600'
+                      : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}
                 >
-                  {d}d
+                  {c.label}
                 </button>
               ))}
-              <button
-                type="button"
-                onClick={() => setCustomOpen((o) => !o)}
-                title="Pick a custom start date — the window always ends on the latest game day"
-                className={`px-2.5 py-1.5 whitespace-nowrap ${customStartIso ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
-              >
-                📆
-              </button>
             </div>
-            {customStartIso && !customOpen && (
-              <span className="text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
-                since {formatShort(customStartIso)} · {windowDays}d
-              </span>
-            )}
+
+            <div className="flex flex-wrap items-center gap-2 order-1 sm:order-2">
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-xs">
+                {PRESET_WINDOWS.map((d) => (
+                  <button
+                    key={d}
+                    type="button"
+                    onClick={() => selectPreset(d)}
+                    className={`px-2.5 py-1.5 whitespace-nowrap ${!customStartIso && windowDays === d ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                  >
+                    {d}d
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => setCustomOpen((o) => !o)}
+                  title="Pick a custom start date — the window always ends on the latest game day"
+                  className={`px-2.5 py-1.5 whitespace-nowrap ${customStartIso ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200'}`}
+                >
+                  📆
+                </button>
+              </div>
+              {customStartIso && !customOpen && (
+                <span className="text-xs text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                  since {formatShort(customStartIso)} · {windowDays}d
+                </span>
+              )}
+            </div>
           </div>
 
           {customOpen && anchorIso && (
@@ -195,25 +216,6 @@ export default function PlayerTrendsCard({ playerId }: Props) {
               {customError && <p className="mt-1 text-xs text-red-600 dark:text-red-400">⚠ {customError}</p>}
             </div>
           )}
-
-          <div className="flex flex-wrap gap-2 mb-4">
-            {MODE_CHIPS.filter(
-              (c) => c.key === 'minutes' || c.key === 'usage' || availableShootingStats.includes(c.key as RegressionStat),
-            ).map((c) => (
-              <button
-                key={c.key}
-                type="button"
-                onClick={() => setMode(c.key)}
-                className={`px-3 py-1.5 text-sm rounded-lg border whitespace-nowrap transition-colors ${
-                  mode === c.key
-                    ? 'bg-blue-600 text-white border-blue-600'
-                    : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
-                }`}
-              >
-                {c.label}
-              </button>
-            ))}
-          </div>
 
           {(() => {
             const summary = summarize(log, mode)

--- a/frontend/src/pages/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router'
-import { useGetNbaPlayerQuery, useGetNbaPlayerStatsQuery } from '../store/api/fantasyApi'
+import { Link, useLocation, useNavigate, useParams } from 'react-router'
+import { useGetAllPlayersQuery, useGetNbaPlayerQuery, useGetNbaPlayerStatsQuery } from '../store/api/fantasyApi'
 import type { CustomDateRange, PlayerStats, TimePeriod } from '../types/api'
 import TimePeriodSelector from '../components/TimePeriodSelector'
 import { CoverageNotice } from '../components/DateRangePicker'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import PlayerTrendsCard from '../components/PlayerTrendsCard'
+import PlayerNextGameCard from '../components/PlayerNextGameCard'
 
 function backLabel(from: string | undefined): string {
   if (!from) return '← Back'
@@ -82,6 +83,12 @@ const PlayerProfile = () => {
     { skip: !playerId || (timePeriod === 'custom' && !customRange) },
   )
 
+  // Fantasy roster status (owner / free agent) — reuses the same paginated
+  // players list the Players/Projections pages already query, so it's often
+  // already warm in the RTK Query cache rather than a fresh fetch.
+  const { data: allPlayers } = useGetAllPlayersQuery({ page: 1, limit: 1200 })
+  const fantasyEntry = allPlayers?.players.find((p) => p.player_id === Number(playerId))
+
   if (!playerId) return <ErrorMessage message="Missing player id" />
   if (bioLoading) return <LoadingSpinner />
   if (bioError || !bio) return <ErrorMessage message="Failed to load player" />
@@ -125,9 +132,25 @@ const PlayerProfile = () => {
               </span>
             ) : null}
           </h1>
-          <p className="text-gray-700 dark:text-gray-300 text-lg mb-3">
+          <p className="text-gray-700 dark:text-gray-300 text-lg mb-2">
             {bio.team} ({bio.team_abbr}) · {bio.position}
           </p>
+          {fantasyEntry && (
+            <p className="mb-3">
+              {fantasyEntry.status === 'ONTEAM' && fantasyEntry.fantasy_team_name ? (
+                <Link
+                  to={`/team/${fantasyEntry.team_id}`}
+                  className="inline-flex items-center text-xs font-medium px-2 py-0.5 rounded bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-800 hover:bg-blue-200 dark:hover:bg-blue-900/60"
+                >
+                  Rostered by {fantasyEntry.fantasy_team_name}
+                </Link>
+              ) : (
+                <span className="inline-flex items-center text-xs font-medium px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border border-gray-300 dark:border-gray-600">
+                  {fantasyEntry.status === 'WAIVERS' ? 'Waivers' : 'Free Agent'}
+                </span>
+              )}
+            </p>
+          )}
           <dl className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-2 text-sm">
             <div>
               <dt className="text-gray-500 dark:text-gray-400">Conference</dt>
@@ -242,6 +265,8 @@ const PlayerProfile = () => {
       </div>
 
       <PlayerTrendsCard playerId={Number(playerId)} />
+
+      <PlayerNextGameCard playerId={playerId} />
     </div>
   )
 }

--- a/frontend/src/store/api/fantasyApi.ts
+++ b/frontend/src/store/api/fantasyApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import type { LeagueRankings, TeamDetail, LeagueSummary, HeatmapData, LeagueShotsData, TeamPlayers, Team, TradeSuggestionsResponse, PaginatedPlayers, TimePeriod, RankingsOverTimeResponse, OverTimeSource, NbaTeamInfo, TeamDepthChart, NbaPlayerBio, NbaPlayerStatsResponse, PlayerMatchup, ProjectionStats, PlayersListResponse, PlayerStoreState, TeamsListResponse, TeamStoreState, DraftReport, MinutesResponse, UsageResponse, RegressionResponse, RegressionMode, GameLogResponse } from '../../types/api';
+import type { LeagueRankings, TeamDetail, LeagueSummary, HeatmapData, LeagueShotsData, TeamPlayers, Team, TradeSuggestionsResponse, PaginatedPlayers, TimePeriod, RankingsOverTimeResponse, OverTimeSource, NbaTeamInfo, TeamDepthChart, NbaPlayerBio, NbaPlayerStatsResponse, PlayerMatchup, ProjectionStats, PlayerNextGameProjection, PlayersListResponse, PlayerStoreState, TeamsListResponse, TeamStoreState, DraftReport, MinutesResponse, UsageResponse, RegressionResponse, RegressionMode, GameLogResponse } from '../../types/api';
 import type { GameSlug, LeaderboardRow, MinigamePlayerBundle } from '../../minigames/types';
 import type { EstimatorResults } from '../../types/estimator';
 
@@ -104,6 +104,9 @@ export const fantasyApi = createApi({
     getCurrentSlateDate: builder.query<string | null, void>({
       query: () => '/matchups/current-slate-date',
     }),
+    getPlayerNextGameProjection: builder.query<PlayerNextGameProjection, string>({
+      query: (playerId) => `/projections/player/${playerId}`,
+    }),
     predictProjection: builder.mutation<{ stats: ProjectionStats }, { player_name: string; opponent: string; is_home: boolean; minutes: number }>({
       query: (body) => ({ url: '/projections/predict', method: 'POST', body }),
     }),
@@ -198,6 +201,7 @@ export const {
   useGetMatchupDatesQuery,
   useGetUpcomingDatesQuery,
   useGetCurrentSlateDateQuery,
+  useGetPlayerNextGameProjectionQuery,
   usePredictProjectionMutation,
   useGetFeatureStorePlayersQuery,
   useGetFeatureStorePlayerStateQuery,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -347,6 +347,19 @@ export interface Projection {
   stats: ProjectionStats | null;
 }
 
+export interface PlayerNextGameProjection {
+  player_name: string;
+  team: string;
+  game_date: string | null;
+  opponent: string | null;
+  is_home: boolean;
+  scheduled: boolean;
+  default_minutes: number;
+  status: ProjectionStatus;
+  reason: string;
+  stats: ProjectionStats | null;
+}
+
 export interface PlayerMatchup {
   player_name: string;
   pro_team: string;


### PR DESCRIPTION
## Summary
- Adds a per-player next-game projection to the player profile page, reusing the existing live-inference model and `/projections/predict` endpoint (`PlayerNextGameService` resolves the player's next scheduled game from the ESPN schedule; falls back to their last played game, debug-only via `FF_PAST_SLATES`, when nothing is scheduled — e.g. offseason)
- Minutes slider with live re-prediction; whole/decimal toggle matches the existing "Integer projections" convention from the Projections page
- Renders as a highlighted row in a Stats-table-style layout: full FGM/FGA/FTM/FTA volume columns on desktop, collapsing to fraction-under-percentage (`45% · 5/11`) on mobile with no horizontal scroll
- Status dot (green/amber/red) matches the Projections page's confidence indicator
- Fully gated behind `FF_PROJECTIONS`; hidden entirely (no card, no fetch) when the model can't produce a line — insufficient history (<10 games), unknown player, or no game found at all

## Test plan
- [x] `tsc --noEmit` clean (frontend)
- [x] Verified live in browser: default + adjusted minutes re-predict correctly, whole/decimal toggle, status dot color/tooltip
- [x] Verified at 390px — zero horizontal overflow, no clipped cells
- [x] Verified `FF_PROJECTIONS=false` and `FF_PAST_SLATES=false` independently hide the card
- [ ] Manual QA once real in-season games are on the schedule (built/tested during the 2026 offseason, so live "next game" resolution is currently exercised only via the offseason fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)