### PR TITLE
perf: cache players/dashboard backend reads, debounce players search

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.config import settings
 import logging
 from datetime import datetime
 from app.services.data_provider import DataProvider
+from app.services.nba_stats_service import NBAStatsService
 from app.services import injury_service
 from app.services import estimator_scheduler
 from app.services import model_nightly_scheduler
@@ -63,6 +64,7 @@ async def lifespan(app: FastAPI):
     try:
         data_provider = DataProvider()
         await data_provider.close()
+        await NBAStatsService().close()
         logger.info("Closed httpx client connections")
     except Exception as e:
         logger.error(f"Error during shutdown cleanup: {e}")

--- a/backend/app/services/league_service.py
+++ b/backend/app/services/league_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import pandas as pd
 from datetime import date
@@ -33,9 +34,10 @@ class LeagueService:
 
         try:
             nba_service = NBAStatsService()
-            nba_avg_pace = await nba_service.get_nba_average_pace(settings.season_id)
-            nba_game_days_left = await nba_service.get_nba_game_days_remaining()
-            await nba_service.close()
+            nba_avg_pace, nba_game_days_left = await asyncio.gather(
+                nba_service.get_nba_average_pace(settings.season_id),
+                nba_service.get_nba_game_days_remaining(),
+            )
         except Exception as e:
             self.logger.warning(f"Failed to fetch NBA stats: {e}")
 

--- a/backend/app/services/nba_stats_service.py
+++ b/backend/app/services/nba_stats_service.py
@@ -1,21 +1,42 @@
+import asyncio
 import httpx
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 
+_CACHE_TTL = timedelta(minutes=30)
+
+
 class NBAStatsService:
-    """Service for fetching NBA league-wide statistics from ESPN APIs"""
+    """Service for fetching NBA league-wide statistics from ESPN APIs.
+
+    Singleton (like DataProvider) so its pooled httpx client is reused across
+    requests instead of a fresh connection pool per Dashboard load."""
+
+    _instance = None
+    _initialized = False
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
 
     def __init__(self):
+        if NBAStatsService._initialized:
+            return
         self.logger = logging.getLogger(__name__)
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(30.0, connect=10.0),
             limits=httpx.Limits(max_keepalive_connections=10, max_connections=20)
         )
+        self._pace_cache: dict = {'season_id': None, 'value': None, 'ts': None}
+        self._days_left_cache: dict = {'value': None, 'ts': None}
+        NBAStatsService._initialized = True
 
     async def get_nba_average_pace(self, season_id: int) -> Optional[float]:
         """
-        Get average games played per NBA team from standings
+        Get average games played per NBA team from standings, cached 30 min
+        (moves at most once/day; polled on every Dashboard load otherwise).
 
         Args:
             season_id: NBA season year (e.g., 2026)
@@ -23,6 +44,19 @@ class NBAStatsService:
         Returns:
             Average games played across all 30 NBA teams, or None if fetch fails
         """
+        cache = self._pace_cache
+        if (
+            cache['season_id'] == season_id
+            and cache['ts'] is not None
+            and datetime.now() - cache['ts'] < _CACHE_TTL
+        ):
+            return cache['value']
+
+        value = await self._fetch_nba_average_pace(season_id)
+        self._pace_cache = {'season_id': season_id, 'value': value, 'ts': datetime.now()}
+        return value
+
+    async def _fetch_nba_average_pace(self, season_id: int) -> Optional[float]:
         try:
             url = f"https://site.api.espn.com/apis/v2/sports/basketball/nba/standings?season={season_id}"
             response = await self._client.get(url)
@@ -47,12 +81,12 @@ class NBAStatsService:
 
                 wins = stats_map.get('wins')
                 if wins is None:
-                    logger.warning("'wins' stat missing or null in ESPN standings response")
+                    self.logger.warning("'wins' stat missing or null in ESPN standings response")
                     wins = 0
-                
+
                 losses = stats_map.get('losses')
                 if losses is None:
-                    logger.warning("'losses' stat missing or null in ESPN standings response")
+                    self.logger.warning("'losses' stat missing or null in ESPN standings response")
                     losses = 0
                 games_played = wins + losses
                 games_played_list.append(games_played)
@@ -76,11 +110,20 @@ class NBAStatsService:
 
     async def get_nba_game_days_remaining(self) -> Optional[int]:
         """
-        Calculate remaining game days in NBA regular season
+        Calculate remaining game days in NBA regular season, cached 30 min.
 
         Returns:
             Number of days with NBA games remaining until end of regular season, or None if fetch fails
         """
+        cache = self._days_left_cache
+        if cache['ts'] is not None and datetime.now() - cache['ts'] < _CACHE_TTL:
+            return cache['value']
+
+        value = await self._fetch_nba_game_days_remaining()
+        self._days_left_cache = {'value': value, 'ts': datetime.now()}
+        return value
+
+    async def _fetch_nba_game_days_remaining(self) -> Optional[int]:
         try:
             url = "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?calendartype=whitelist"
             response = await self._client.get(url)

--- a/backend/app/services/player_service.py
+++ b/backend/app/services/player_service.py
@@ -46,6 +46,15 @@ _SEASON_ANCHOR_TTL = timedelta(hours=1)
 _season_anchor_cache: dict = {'season': None, 'date': None, 'ts': None}
 
 
+# The windowed DataFrame for a preset period (season/last_7/last_15/last_30)
+# only moves on nightly ingest, but build_windowed_players_df reruns a full
+# fs_player_games aggregation + pandas merge on every /players request.
+# Cached briefly per preset. Custom ranges are never cached here — the key
+# space is unbounded (any start/end pair), so caching them would grow forever.
+_WINDOWED_PLAYERS_TTL = timedelta(minutes=5)
+_windowed_players_cache: dict = {}
+
+
 async def get_season_anchor_date(season: str, db_service: DBService) -> date:
     cached = _season_anchor_cache
     now = datetime.now()
@@ -169,15 +178,25 @@ class PlayerService:
             start: Start date, required when time_period is custom
             end: End date, required when time_period is custom
         """
-        stat_split_id = StatTimePeriod.to_stat_split_id(time_period)
-        players_df = await self.data_provider.get_players_df(stat_split_id)
+        is_preset = time_period != StatTimePeriod.CUSTOM
+        cached = _windowed_players_cache.get(time_period) if is_preset else None
+        if cached is not None and datetime.now() - cached['ts'] < _WINDOWED_PLAYERS_TTL:
+            players_df, actual_start, actual_end = cached['df'], cached['start'], cached['end']
+        else:
+            stat_split_id = StatTimePeriod.to_stat_split_id(time_period)
+            espn_players_df = await self.data_provider.get_players_df(stat_split_id)
 
-        if players_df is None or players_df.empty:
-            raise ResourceNotFoundError("No players found")
+            if espn_players_df is None or espn_players_df.empty:
+                raise ResourceNotFoundError("No players found")
 
-        players_df, actual_start, actual_end = await build_windowed_players_df(
-            time_period, players_df, self.data_provider.db_service, start, end
-        )
+            players_df, actual_start, actual_end = await build_windowed_players_df(
+                time_period, espn_players_df, self.data_provider.db_service, start, end
+            )
+            if is_preset:
+                _windowed_players_cache[time_period] = {
+                    'df': players_df, 'start': actual_start, 'end': actual_end,
+                    'ts': datetime.now(),
+                }
 
         total_count = len(players_df)
         start_idx = (page - 1) * limit

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -178,6 +178,27 @@ def reset_season_anchor_cache():
     yield
     _season_anchor_cache.update({'season': None, 'date': None, 'ts': None})
 
+@pytest.fixture(autouse=True)
+def reset_windowed_players_cache():
+    """Same as reset_season_anchor_cache, for the windowed-players preset cache."""
+    from app.services.player_service import _windowed_players_cache
+    _windowed_players_cache.clear()
+    yield
+    _windowed_players_cache.clear()
+
+@pytest.fixture(autouse=True)
+def reset_nba_stats_service_singleton():
+    """NBAStatsService is a singleton (pooled httpx client + TTL caches
+    persisting across requests in production) — reset it every test so
+    cached values/mocked clients from one test can't leak into another,
+    across any test file."""
+    from app.services.nba_stats_service import NBAStatsService
+    NBAStatsService._instance = None
+    NBAStatsService._initialized = False
+    yield
+    NBAStatsService._instance = None
+    NBAStatsService._initialized = False
+
 @pytest.fixture
 def test_client():
     """Create a test client for the FastAPI application."""

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { usePersistedState } from '../hooks/usePersistedState';
+import { useDebounce } from '../hooks/useDebounce';
 import { useGetAllPlayersQuery, useGetTeamsListQuery } from '../store/api/fantasyApi';
 import { useGetMatchupsTodayQuery, useGetMatchupDatesQuery, useGetUpcomingDatesQuery, useGetCurrentSlateDateQuery } from '../store/api/fantasyApi';
 import type { PlayerFilters, Player, StatFilter, TimePeriod, ComparisonOperator, PlayerStats, CustomDateRange } from '../types/api';
@@ -58,12 +59,14 @@ const Players = () => {
     return new Map(teams.map(team => [team.team_id, team.team_name]));
   }, [teams]);
 
+  const debouncedSearch = useDebounce(filters.search, 250);
+
   const filteredPlayers = useMemo(() => {
     if (!data?.players) return [];
 
     return data.players.filter(player => {
-      if (filters.search) {
-        const search = filters.search.toLowerCase();
+      if (debouncedSearch) {
+        const search = debouncedSearch.toLowerCase();
         const matchesName = player.player_name.toLowerCase().includes(search);
         const matchesTeam = player.pro_team.toLowerCase().includes(search);
         const matchesPosition = player.positions.some(p =>
@@ -111,7 +114,7 @@ const Players = () => {
 
       return true;
     });
-  }, [data, filters, showAverages]);
+  }, [data, filters, showAverages, debouncedSearch]);
 
   if (isLoading) return <div className="loading">Loading players...</div>;
   if (error) return <div className="error">Error loading players</div>;

--- a/frontend/src/pages/__tests__/Players.test.tsx
+++ b/frontend/src/pages/__tests__/Players.test.tsx
@@ -93,7 +93,7 @@ describe('Players page', () => {
     renderWithProviders(<Players />);
     await waitFor(() => expect(screen.getByText('Bench Guy')).toBeInTheDocument());
     await user.type(screen.getByPlaceholderText(/search players/i), 'Alpha');
-    expect(screen.getAllByText(/showing 1 players/i).length).toBeGreaterThan(0);
+    await waitFor(() => expect(screen.getAllByText(/showing 1 players/i).length).toBeGreaterThan(0));
     expect(screen.queryByText('Bench Guy')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/store/api/fantasyApi.ts
+++ b/frontend/src/store/api/fantasyApi.ts
@@ -16,6 +16,7 @@ export const fantasyApi = createApi({
         params: { sort_by: sortBy, order, ...(startDate ? { start_date: startDate } : {}), ...(endDate ? { end_date: endDate } : {}) },
       }),
       providesTags: ['Rankings'],
+      keepUnusedDataFor: 300,
     }),
     getTeamDetail: builder.query<TeamDetail, { teamId: number; time_period?: TimePeriod; start?: string; end?: string }>({
       query: ({ teamId, time_period = 'season', start, end }) => ({
@@ -27,6 +28,7 @@ export const fantasyApi = createApi({
     getLeagueSummary: builder.query<LeagueSummary, void>({
       query: () => '/league/summary',
       providesTags: ['League'],
+      keepUnusedDataFor: 300,
     }),
     getHeatmapData: builder.query<HeatmapData, { startDate?: string; endDate?: string }>({
       query: ({ startDate, endDate } = {}) => ({


### PR DESCRIPTION
## Summary
- Backend: cache windowed players aggregation for preset time periods (season/7/15/30d), 5-min TTL. Custom ranges excluded (unbounded key space).
- Backend: `NBAStatsService` is now a singleton (pooled httpx client, no fresh connection pool per request), results cached 30 min, ESPN pace/days-remaining calls parallelized via `asyncio.gather`. Also fixed a pre-existing `NameError` bug (bare `logger` instead of `self.logger`).
- Frontend: debounce Players search input (250ms) so typing doesn't re-filter up to 1200 rows per keystroke.
- Frontend: `keepUnusedDataFor: 300` added to `getRankings`/`getLeagueSummary` to match the pattern already used on other endpoints, avoiding refetch on quick re-navigation.

Investigated but explicitly out of scope (confirmed non-issues): DB indexes on `fs_player_games` already correct, `/matchups/today` already internally cached, most "raw fetch" audit hits were already RTK Query. Full-table virtualization for the Players page was attempted and reverted — caused blank-flash on fast scroll with no clear perceived win.

## Test plan
- [x] Backend: full `uv run pytest -q` — 492 passed
- [x] Frontend: `npm run build`, `tsc -b --noEmit`, `npm run lint` (pre-existing lint issues only, in unrelated minigame files)
- [x] Manual/browser verification: players search debounce, cache-hit behavior on Dashboard/Rankings re-navigation (no refetch within TTL), Dashboard NBA stats still populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)