### PR TITLE
Scope backend data by league/season, fix preseason data gaps

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.services.nba_stats_service import NBAStatsService
 from app.services import injury_service
 from app.services import estimator_scheduler
 from app.services import model_nightly_scheduler
+from app.exceptions import ResourceNotFoundError, DataSourceError
 
 # Configure logging
 logging.basicConfig(
@@ -49,6 +50,15 @@ async def lifespan(app: FastAPI):
     """Manage application lifespan for proper resource cleanup"""
     # Startup
     logger.info("Starting Fantasy League Dashboard API")
+    try:
+        derived_start = await NBAStatsService().get_regular_season_start_date(settings.season_id)
+        if derived_start is not None:
+            logger.info(f"Derived regular-season start from NBA schedule: {derived_start} (was {settings.season_start})")
+            settings.season_start = derived_start
+        else:
+            logger.warning(f"Could not derive regular-season start; keeping configured SEASON_START={settings.season_start}")
+    except Exception as e:
+        logger.warning(f"Failed to derive regular-season start, keeping configured SEASON_START={settings.season_start}: {e}")
     await injury_service.initialize()
     if settings.injury_scheduler_enabled:
         asyncio.create_task(injury_service.start_scheduler())
@@ -77,6 +87,15 @@ app = FastAPI(
 
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+@app.exception_handler(ResourceNotFoundError)
+async def resource_not_found_handler(request: Request, exc: ResourceNotFoundError):
+    return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+@app.exception_handler(DataSourceError)
+async def data_source_error_handler(request: Request, exc: DataSourceError):
+    logger.warning(f"Data source unavailable for {request.url}: {exc}")
+    return JSONResponse(status_code=503, content={"detail": str(exc)})
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):

--- a/backend/app/routes/analytics.py
+++ b/backend/app/routes/analytics.py
@@ -4,7 +4,7 @@ from app.models import HeatmapData, RankingsOverTimeResponse, TeamTimeSeriesPoin
 from app.services.league_service import LeagueService
 from app.services.db_service import DBService
 from typing import Annotated, Optional
-from app.exceptions import ResourceNotFoundError
+from app.exceptions import ResourceNotFoundError, DataSourceError
 from datetime import date, date as date_type
 from app.config import settings
 
@@ -43,6 +43,8 @@ async def get_heatmap(
     except ResourceNotFoundError as e:
         logger.warning(f"Invalid request for heatmap: {e}")
         raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting heatmap data: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve heatmap data")
@@ -63,12 +65,12 @@ async def get_over_time(
                 raise HTTPException(status_code=400, detail="Invalid team_ids format")
 
         if source == "snapshot":
-            rows = await db_service.get_snapshot_over_time(parsed_team_ids)
+            rows = await db_service.get_snapshot_over_time(parsed_team_ids, settings.league_id, settings.season_id)
         elif source == "averages":
-            rows = await db_service.get_averages_over_time(parsed_team_ids)
+            rows = await db_service.get_averages_over_time(parsed_team_ids, settings.league_id, settings.season_id)
         else:
             table = _SOURCE_TO_TABLE[source]
-            rows = await db_service.get_rankings_over_time(table, parsed_team_ids)
+            rows = await db_service.get_rankings_over_time(table, parsed_team_ids, settings.league_id, settings.season_id)
 
         points = [TeamTimeSeriesPoint(**{k: (v.isoformat() if isinstance(v, date_type) else v) for k, v in row.items()}) for row in rows]
         return RankingsOverTimeResponse(data=points)

--- a/backend/app/routes/league.py
+++ b/backend/app/routes/league.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from app.models import LeagueSummary, LeagueShotsData, DraftReport
 from app.services.league_service import LeagueService
 from app.services.draft_report_service import DraftReportService
-from app.exceptions import ResourceNotFoundError
+from app.exceptions import ResourceNotFoundError, DataSourceError
 from typing import Annotated
 import logging
 
@@ -22,6 +22,10 @@ async def get_league_summary(
         return await league_service.get_league_summary()
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting league summary: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve league summary") from e
@@ -36,6 +40,10 @@ async def get_league_shots(
         return await league_service.get_league_shots_data()
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting league shots data: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve league shots data") from e
@@ -50,6 +58,8 @@ async def get_draft_report(
         return await draft_report_service.get_draft_report()
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting draft report: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve draft report") from e

--- a/backend/app/routes/matchups.py
+++ b/backend/app/routes/matchups.py
@@ -141,12 +141,17 @@ async def get_matchups_today(
     for _, row in players_df.iterrows():
         pro_team: str = str(row.get('Pro Team', ''))
         game = games_today.get(pro_team)
-        if game is None or game.opponent not in def_ranks:
+        if game is None:
             continue
         opponent = game.opponent
 
+        # def_ranks/def_values are season-to-date opponent defense — genuinely
+        # empty before this season's first game is ingested. That's not a
+        # reason to hide the player/projection too: fall back to neutral
+        # values (rank 15 = league-average, matching the existing per-category
+        # fallback below) rather than dropping the row entirely.
         team_pace = pace_map.get(opponent, league_avg_pace)
-        opp_ranks = def_ranks[opponent]
+        opp_ranks = def_ranks.get(opponent, {})
         opp_vals = def_values.get(opponent, {})
         positions_raw: str = str(row.get('Positions', 'Unknown'))
         positions = [p.strip() for p in positions_raw.split(',') if p.strip() and p.strip() != 'Unknown']

--- a/backend/app/routes/players.py
+++ b/backend/app/routes/players.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, Depends, Query
 from app.models import PaginatedPlayers, StatTimePeriod
-from app.exceptions import ResourceNotFoundError
+from app.exceptions import ResourceNotFoundError, DataSourceError
 from app.services.player_service import PlayerService
 from typing import Annotated, Optional
 from datetime import date
@@ -42,6 +42,8 @@ async def get_all_players(
         raise
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting all players: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve players")

--- a/backend/app/routes/rankings.py
+++ b/backend/app/routes/rankings.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Query, HTTPException, Depends
 from typing import Optional, Annotated
 from datetime import date
 from app.models import LeagueRankings
-from app.exceptions import InvalidParameterError, ResourceNotFoundError
+from app.exceptions import InvalidParameterError, ResourceNotFoundError, DataSourceError
 from app.models.requests import SortOrder
 from app.services.ranking_service import RankingService
 from app.config import settings
@@ -45,6 +45,8 @@ async def get_rankings(
         raise HTTPException(status_code=422, detail=str(e))
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting rankings: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to retrieve rankings: {e}")

--- a/backend/app/routes/teams.py
+++ b/backend/app/routes/teams.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, Depends, Query
 from app.models import TeamDetail, TeamPlayers, Team, StatTimePeriod
-from app.exceptions import InvalidParameterError, ResourceNotFoundError
+from app.exceptions import InvalidParameterError, ResourceNotFoundError, DataSourceError
 from app.services.team_service import TeamService
 from typing import Annotated, List, Optional
 from datetime import date
@@ -24,6 +24,8 @@ async def get_teams_list(
         raise HTTPException(status_code=422, detail=str(e))
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting teams list: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve teams list")
@@ -62,6 +64,8 @@ async def get_team_detail(
         raise HTTPException(status_code=422, detail=str(e))
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting team stats for {team_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve team statistics")
@@ -82,6 +86,8 @@ async def get_team_players(
         raise HTTPException(status_code=422, detail=str(e))
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except DataSourceError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error(f"Error getting players for team ID {team_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve team players")

--- a/backend/app/services/data_provider.py
+++ b/backend/app/services/data_provider.py
@@ -61,13 +61,16 @@ class DataProvider:
 
                 response.raise_for_status()
                 api_data = response.json()
+                # Cache raw payload before the stats transform, which can fail on its
+                # own (e.g. preseason: teams exist but carry no valuesByStat yet) —
+                # get_team_names_df() still needs team identity from this same fetch.
+                self.cache_manager.totals_cache['raw'] = api_data
 
                 totals_df = self.data_transformer.raw_standings_to_totals_df(api_data)
 
                 scoring_period_id = api_data.get('scoringPeriodId', 0)
                 self.cache_manager.totals_cache['etag'] = response.headers.get('ETag')
                 self.cache_manager.totals_cache['data'] = totals_df
-                self.cache_manager.totals_cache['raw'] = api_data
                 self.cache_manager.totals_cache['scoring_period_id'] = scoring_period_id
                 self.cache_manager.totals_cache['data_date'] = None
 
@@ -101,7 +104,9 @@ class DataProvider:
                 return False
 
         completed_period = scoring_period_id - 1
-        max_snap = await self.db_service.get_db_max_scoring_period('team_daily_snapshot')
+        max_snap = await self.db_service.get_db_max_scoring_period(
+            'team_daily_snapshot', settings.league_id, settings.season_id
+        )
         if max_snap >= completed_period:
             self.logger.info(f"sync_db_now: snapshot already current (period {completed_period}), skipping")
             return False
@@ -111,9 +116,9 @@ class DataProvider:
 
     async def _fallback_from_db(self) -> pd.DataFrame:
         """Build a totals DataFrame from the latest DB snapshot. Stores data_date in cache."""
-        snap_date, rows = await self.db_service.get_latest_snapshot()
+        snap_date, rows = await self.db_service.get_latest_snapshot(settings.league_id, settings.season_id)
         if not rows:
-            raise Exception("ESPN unavailable and no DB fallback data found")
+            raise DataSourceError("ESPN unavailable and no DB fallback data found for this league/season")
         df = pd.DataFrame(rows)
         df = df.rename(columns={
             'fg_pct': 'FG%', 'ft_pct': 'FT%', 'three_pm': '3PM',
@@ -122,11 +127,31 @@ class DataProvider:
             'ftm': 'FTM', 'fta': 'FTA',
         })
         df = df.drop(columns=['date'], errors='ignore')
+        # asyncpg returns Decimal for NUMERIC columns; cast to float here so every
+        # totals DataFrame (ESPN or DB fallback) is uniformly float downstream.
+        numeric_cols = [c for c in RANKING_CATEGORIES + ['GP'] if c in df.columns]
+        df[numeric_cols] = df[numeric_cols].astype(float)
         self.cache_manager.totals_cache['data'] = df
         self.cache_manager.totals_cache['data_date'] = snap_date
         self.cache_manager.totals_cache['etag'] = None
         self.logger.warning(f"Serving DB fallback data from {snap_date}")
         return df
+
+    async def get_team_names(self) -> list:
+        """team_id/team_name pairs, independent of whether stat totals exist yet.
+        Reuses the raw standings payload already cached by get_totals_df when
+        possible; falls back to a fresh fetch only if nothing is cached."""
+        raw = self.cache_manager.totals_cache.get('raw')
+        if raw is None:
+            try:
+                response = await self._client.get(self.espn_standings_url)
+                response.raise_for_status()
+                raw = response.json()
+                self.cache_manager.totals_cache['raw'] = raw
+            except httpx.RequestError as e:
+                self.logger.error(f"Error fetching team names from ESPN API: {e}")
+                raise DataSourceError("Error fetching team names from ESPN API")
+        return self.data_transformer.raw_standings_to_team_names(raw)
 
     async def get_players_df(self, stat_split_type_id: int = 0) -> pd.DataFrame:
         """Get ALL players (roster + FA + waivers) DataFrame with caching
@@ -176,7 +201,13 @@ class DataProvider:
                 api_data = response.json()
 
                 if self.cache_manager.totals_cache.get('data') is None:
-                    await self.get_totals_df()
+                    # Best-effort only: fantasy_team_name is optional enrichment
+                    # (handled below via `if totals_data is not None`) — a totals
+                    # failure must not block the players list itself.
+                    try:
+                        await self.get_totals_df()
+                    except Exception as e:
+                        self.logger.warning(f"Could not fetch totals for fantasy_team_map: {e}")
 
                 fantasy_team_map = {}
                 totals_data = self.cache_manager.totals_cache.get('data')
@@ -305,19 +336,20 @@ class DataProvider:
                 totals_for_ranking = totals_for_ranking[[c for c in cols_to_keep if c in totals_for_ranking.columns]]
                 rankings_totals_df = self.data_transformer.averages_to_rankings_df(totals_for_ranking)
 
+                league_id, season_id = settings.league_id, settings.season_id
                 max_avg, max_tot, max_snap = await asyncio.gather(
-                    self.db_service.get_db_max_scoring_period('team_rankings_averages'),
-                    self.db_service.get_db_max_scoring_period('team_rankings_totals'),
-                    self.db_service.get_db_max_scoring_period('team_daily_snapshot'),
+                    self.db_service.get_db_max_scoring_period('team_rankings_averages', league_id, season_id),
+                    self.db_service.get_db_max_scoring_period('team_rankings_totals', league_id, season_id),
+                    self.db_service.get_db_max_scoring_period('team_daily_snapshot', league_id, season_id),
                 )
 
                 tasks = []
                 if max_avg < completed_period:
-                    tasks.append(self.db_service.upsert_rankings_averages(completed_period, rankings_avg_df))
+                    tasks.append(self.db_service.upsert_rankings_averages(completed_period, rankings_avg_df, league_id, season_id))
                 if max_tot < completed_period:
-                    tasks.append(self.db_service.upsert_rankings_totals(completed_period, rankings_totals_df))
+                    tasks.append(self.db_service.upsert_rankings_totals(completed_period, rankings_totals_df, league_id, season_id))
                 if max_snap < completed_period:
-                    tasks.append(self.db_service.upsert_daily_snapshot(completed_period, totals_df))
+                    tasks.append(self.db_service.upsert_daily_snapshot(completed_period, totals_df, league_id, season_id))
 
                 if tasks:
                     await asyncio.gather(*tasks)

--- a/backend/app/services/data_transformer.py
+++ b/backend/app/services/data_transformer.py
@@ -85,11 +85,16 @@ class DataTransformer:
                 for stat in stats:
                     if stat.get('scoringPeriodId') == 0 and stat.get('statSplitTypeId') == stat_split_type_id and stat.get('seasonId') == settings.season_id:
                         player_stats = stat.get('stats', {})
-                        mapped_stats = {
-                            ESPN_COLUMN_MAP.get(key, key): value
+                        # ESPN tags this split with the current season before any games
+                        # have been played, but leaves 'stats' empty — treat that as a
+                        # real zero row (0 GP) rather than dropping the player, so the
+                        # DataFrame always has every ESPN_COLUMN_MAP column.
+                        mapped_stats: Dict[str, object] = {col: 0 for col in ESPN_COLUMN_MAP.values()}
+                        mapped_stats.update({
+                            ESPN_COLUMN_MAP[key]: value
                             for key, value in player_stats.items()
                             if key in ESPN_COLUMN_MAP
-                        }
+                        })
 
                         mapped_stats.update({
                             'Name': player_name,
@@ -155,6 +160,20 @@ class DataTransformer:
             self.logger.error(f"Error transforming ESPN players data to DataFrame: {e}")
             raise Exception("Error transforming ESPN players data to DataFrame")
 
+    def raw_standings_to_team_names(self, espn_standings_data: Dict) -> list:
+        """
+        Extract just team_id/team_name from the same standings payload, independent
+        of valuesByStat — team identity exists on ESPN's side even before any
+        games are played, unlike per-team stat totals.
+        """
+        if not espn_standings_data or 'teams' not in espn_standings_data:
+            return []
+        return [
+            {"team_id": team['id'], "team_name": team['name'].strip()}
+            for team in espn_standings_data['teams']
+            if 'id' in team and team.get('name')
+        ]
+
     def raw_standings_to_totals_df(self, espn_standings_data: Dict) -> pd.DataFrame:
         """
         Convert raw ESPN API standings data to totals DataFrame
@@ -167,17 +186,21 @@ class DataTransformer:
             if not espn_standings_data or 'teams' not in espn_standings_data:
                 raise ValueError("Invalid ESPN standings data structure")
             
-            # Extract team data from ESPN response
+            # Extract team data from ESPN response. ESPN omits valuesByStat
+            # entirely before any games are played (preseason) — that's a real
+            # zero-stat team, not a missing one, so synthesize zeros rather than
+            # drop the team (same treatment as the players zero-row case).
             teams_data = []
             for team in espn_standings_data['teams']:
-                if 'id' in team and 'name' in team and 'valuesByStat' in team:
+                if 'id' in team and 'name' in team:
+                    values_by_stat = team.get('valuesByStat') or {key: 0 for key in ESPN_COLUMN_MAP}
                     team_data = {
-                        "team_id": team['id'], 
-                        "team_name": team['name'].strip(), 
-                        **team['valuesByStat']
+                        "team_id": team['id'],
+                        "team_name": team['name'].strip(),
+                        **values_by_stat
                     }
                     teams_data.append(team_data)
-            
+
             if not teams_data:
                 raise ValueError("No valid team data found")
                 

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -9,8 +9,6 @@ from model_stats_inference.research import config as rconfig
 
 logger = logging.getLogger(__name__)
 
-_SEASON_START = settings.season_start
-
 _RANKINGS_COL_MAP = {
     'FG%': 'rk_fg_pct',
     'FT%': 'rk_ft_pct',
@@ -63,33 +61,39 @@ class DBService:
                 return None
         return self._pool
 
-    async def get_db_max_scoring_period(self, table: str) -> int:
+    async def get_db_max_scoring_period(self, table: str, league_id: int, season_id: int) -> int:
         pool = await self._get_pool()
         if pool is None:
             return 0
         try:
             async with pool.acquire() as conn:
-                row = await conn.fetchrow(f"SELECT COALESCE(MAX(scoring_period_id), 0) AS max_period FROM {table}")
+                row = await conn.fetchrow(
+                    f"SELECT COALESCE(MAX(scoring_period_id), 0) AS max_period FROM {table} "
+                    "WHERE league_id = $1 AND season_id = $2",
+                    league_id, season_id,
+                )
                 return row['max_period']
         except Exception as e:
             logger.error(f"Failed to query max scoring_period_id from {table}: {e}")
             return 0
 
-    async def upsert_rankings_averages(self, scoring_period_id: int, rankings_df: pd.DataFrame) -> None:
+    async def upsert_rankings_averages(
+        self, scoring_period_id: int, rankings_df: pd.DataFrame, league_id: int, season_id: int
+    ) -> None:
         pool = await self._get_pool()
         if pool is None:
             return
-        snap_date = _SEASON_START + timedelta(days=scoring_period_id - 1)
+        snap_date = settings.season_start + timedelta(days=scoring_period_id - 1)
         try:
             async with pool.acquire() as conn:
                 await conn.executemany(
                     """
                     INSERT INTO team_rankings_averages
-                        (scoring_period_id, date, team_id, team_name,
+                        (league_id, season_id, scoring_period_id, date, team_id, team_name,
                          rk_fg_pct, rk_ft_pct, rk_three_pm, rk_reb,
                          rk_ast, rk_stl, rk_blk, rk_pts, rk_total)
-                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
-                    ON CONFLICT (scoring_period_id, team_id) DO UPDATE SET
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                    ON CONFLICT (league_id, season_id, scoring_period_id, team_id) DO UPDATE SET
                         team_name   = EXCLUDED.team_name,
                         rk_fg_pct   = EXCLUDED.rk_fg_pct,
                         rk_ft_pct   = EXCLUDED.rk_ft_pct,
@@ -103,7 +107,7 @@ class DBService:
                     """,
                     [
                         (
-                            scoring_period_id, snap_date,
+                            league_id, season_id, scoring_period_id, snap_date,
                             int(row['team_id']), str(row['team_name']),
                             float(row['FG%']), float(row['FT%']), float(row['3PM']),
                             float(row['REB']), float(row['AST']), float(row['STL']),
@@ -112,25 +116,30 @@ class DBService:
                         for _, row in rankings_df.iterrows()
                     ],
                 )
-            logger.info(f"Upserted team_rankings_averages for scoring_period_id={scoring_period_id}")
+            logger.info(
+                f"Upserted team_rankings_averages for league_id={league_id} season_id={season_id} "
+                f"scoring_period_id={scoring_period_id}"
+            )
         except Exception as e:
             logger.error(f"Failed to upsert team_rankings_averages: {e}")
 
-    async def upsert_rankings_totals(self, scoring_period_id: int, rankings_totals_df: pd.DataFrame) -> None:
+    async def upsert_rankings_totals(
+        self, scoring_period_id: int, rankings_totals_df: pd.DataFrame, league_id: int, season_id: int
+    ) -> None:
         pool = await self._get_pool()
         if pool is None:
             return
-        snap_date = _SEASON_START + timedelta(days=scoring_period_id - 1)
+        snap_date = settings.season_start + timedelta(days=scoring_period_id - 1)
         try:
             async with pool.acquire() as conn:
                 await conn.executemany(
                     """
                     INSERT INTO team_rankings_totals
-                        (scoring_period_id, date, team_id, team_name,
+                        (league_id, season_id, scoring_period_id, date, team_id, team_name,
                          rk_fg_pct, rk_ft_pct, rk_three_pm, rk_reb,
                          rk_ast, rk_stl, rk_blk, rk_pts, rk_total)
-                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
-                    ON CONFLICT (scoring_period_id, team_id) DO UPDATE SET
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                    ON CONFLICT (league_id, season_id, scoring_period_id, team_id) DO UPDATE SET
                         team_name   = EXCLUDED.team_name,
                         rk_fg_pct   = EXCLUDED.rk_fg_pct,
                         rk_ft_pct   = EXCLUDED.rk_ft_pct,
@@ -144,7 +153,7 @@ class DBService:
                     """,
                     [
                         (
-                            scoring_period_id, snap_date,
+                            league_id, season_id, scoring_period_id, snap_date,
                             int(row['team_id']), str(row['team_name']),
                             float(row['FG%']), float(row['FT%']), float(row['3PM']),
                             float(row['REB']), float(row['AST']), float(row['STL']),
@@ -153,15 +162,20 @@ class DBService:
                         for _, row in rankings_totals_df.iterrows()
                     ],
                 )
-            logger.info(f"Upserted team_rankings_totals for scoring_period_id={scoring_period_id}")
+            logger.info(
+                f"Upserted team_rankings_totals for league_id={league_id} season_id={season_id} "
+                f"scoring_period_id={scoring_period_id}"
+            )
         except Exception as e:
             logger.error(f"Failed to upsert team_rankings_totals: {e}")
 
-    async def upsert_daily_snapshot(self, scoring_period_id: int, totals_df: pd.DataFrame) -> None:
+    async def upsert_daily_snapshot(
+        self, scoring_period_id: int, totals_df: pd.DataFrame, league_id: int, season_id: int
+    ) -> None:
         pool = await self._get_pool()
         if pool is None:
             return
-        snap_date = _SEASON_START + timedelta(days=scoring_period_id - 1)
+        snap_date = settings.season_start + timedelta(days=scoring_period_id - 1)
         try:
             async with pool.acquire() as conn:
                 rows = []
@@ -171,7 +185,7 @@ class DBService:
                     ftm = int(row['FTM'])
                     fta = int(row['FTA'])
                     rows.append((
-                        scoring_period_id, snap_date,
+                        league_id, season_id, scoring_period_id, snap_date,
                         int(row['team_id']), str(row['team_name']),
                         int(row['GP']),
                         fgm, fga, round(fgm / fga, 4) if fga > 0 else 0.0,
@@ -182,11 +196,11 @@ class DBService:
                 await conn.executemany(
                     """
                     INSERT INTO team_daily_snapshot
-                        (scoring_period_id, date, team_id, team_name,
+                        (league_id, season_id, scoring_period_id, date, team_id, team_name,
                          gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
                          three_pm, reb, ast, stl, blk, pts)
-                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
-                    ON CONFLICT (scoring_period_id, team_id) DO UPDATE SET
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
+                    ON CONFLICT (league_id, season_id, scoring_period_id, team_id) DO UPDATE SET
                         team_name = EXCLUDED.team_name,
                         gp        = EXCLUDED.gp,
                         fgm       = EXCLUDED.fgm,
@@ -204,11 +218,14 @@ class DBService:
                     """,
                     rows,
                 )
-            logger.info(f"Upserted team_daily_snapshot for scoring_period_id={scoring_period_id}")
+            logger.info(
+                f"Upserted team_daily_snapshot for league_id={league_id} season_id={season_id} "
+                f"scoring_period_id={scoring_period_id}"
+            )
         except Exception as e:
             logger.error(f"Failed to upsert team_daily_snapshot: {e}")
 
-    async def get_latest_snapshot(self):
+    async def get_latest_snapshot(self, league_id: int, season_id: int):
         """
         Returns (date, rows) where rows is a list of dicts with team totals.
         Returns (None, []) if DB unavailable or empty.
@@ -219,7 +236,9 @@ class DBService:
         try:
             async with pool.acquire() as conn:
                 max_row = await conn.fetchrow(
-                    "SELECT COALESCE(MAX(scoring_period_id), 0) AS max_period FROM team_daily_snapshot"
+                    "SELECT COALESCE(MAX(scoring_period_id), 0) AS max_period FROM team_daily_snapshot "
+                    "WHERE league_id = $1 AND season_id = $2",
+                    league_id, season_id,
                 )
                 max_period = max_row['max_period']
                 if max_period == 0:
@@ -229,9 +248,9 @@ class DBService:
                     SELECT team_id, team_name, gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
                            three_pm, reb, ast, stl, blk, pts, date
                     FROM team_daily_snapshot
-                    WHERE scoring_period_id = $1
+                    WHERE league_id = $1 AND season_id = $2 AND scoring_period_id = $3
                     """,
-                    max_period
+                    league_id, season_id, max_period
                 )
                 if not rows:
                     return None, []
@@ -241,7 +260,9 @@ class DBService:
             logger.error(f"Failed to fetch latest snapshot: {e}")
             return None, []
 
-    async def get_rankings_over_time(self, table: str, team_ids: list[int] | None) -> list[dict]:
+    async def get_rankings_over_time(
+        self, table: str, team_ids: list[int] | None, league_id: int, season_id: int
+    ) -> list[dict]:
         pool = await self._get_pool()
         if pool is None:
             return []
@@ -257,10 +278,11 @@ class DBService:
                         FROM {table} r
                         LEFT JOIN team_daily_snapshot s
                             ON s.date = r.date AND s.team_id = r.team_id
-                        WHERE r.team_id = ANY($1)
+                            AND s.league_id = r.league_id AND s.season_id = r.season_id
+                        WHERE r.league_id = $1 AND r.season_id = $2 AND r.team_id = ANY($3)
                         ORDER BY r.date, r.team_id
                         """,
-                        team_ids,
+                        league_id, season_id, team_ids,
                     )
                 else:
                     rows = await conn.fetch(
@@ -272,19 +294,24 @@ class DBService:
                         FROM {table} r
                         LEFT JOIN team_daily_snapshot s
                             ON s.date = r.date AND s.team_id = r.team_id
+                            AND s.league_id = r.league_id AND s.season_id = r.season_id
+                        WHERE r.league_id = $1 AND r.season_id = $2
                         ORDER BY r.date, r.team_id
-                        """
+                        """,
+                        league_id, season_id,
                     )
                 return [dict(r) for r in rows]
         except Exception as e:
             logger.error(f"Failed to fetch rankings over time from {table}: {e}")
             return []
 
-    async def get_snapshot_over_time(self, team_ids: list[int] | None) -> list[dict]:
+    async def get_snapshot_over_time(
+        self, team_ids: list[int] | None, league_id: int, season_id: int
+    ) -> list[dict]:
         pool = await self._get_pool()
         if pool is None:
             return []
-        cutoff = _SEASON_START + timedelta(days=10)
+        cutoff = settings.season_start + timedelta(days=10)
         try:
             async with pool.acquire() as conn:
                 if team_ids:
@@ -293,10 +320,11 @@ class DBService:
                         SELECT date, team_id, team_name,
                                fg_pct, ft_pct, three_pm, reb, ast, stl, blk, pts
                         FROM team_daily_snapshot
-                        WHERE date >= $1 AND team_id = ANY($2)
+                        WHERE league_id = $1 AND season_id = $2
+                          AND date >= $3 AND team_id = ANY($4)
                         ORDER BY date, team_id
                         """,
-                        cutoff, team_ids,
+                        league_id, season_id, cutoff, team_ids,
                     )
                 else:
                     rows = await conn.fetch(
@@ -304,17 +332,19 @@ class DBService:
                         SELECT date, team_id, team_name,
                                fg_pct, ft_pct, three_pm, reb, ast, stl, blk, pts
                         FROM team_daily_snapshot
-                        WHERE date >= $1
+                        WHERE league_id = $1 AND season_id = $2 AND date >= $3
                         ORDER BY date, team_id
                         """,
-                        cutoff,
+                        league_id, season_id, cutoff,
                     )
                 return [dict(r) for r in rows]
         except Exception as e:
             logger.error(f"Failed to fetch snapshot over time: {e}")
             return []
 
-    async def get_averages_over_time(self, team_ids: list[int] | None) -> list[dict]:
+    async def get_averages_over_time(
+        self, team_ids: list[int] | None, league_id: int, season_id: int
+    ) -> list[dict]:
         pool = await self._get_pool()
         if pool is None:
             return []
@@ -329,21 +359,28 @@ class DBService:
                    ROUND((blk::numeric    / NULLIF(gp, 0)), 4) AS blk,
                    ROUND((pts::numeric    / NULLIF(gp, 0)), 4) AS pts
             FROM team_daily_snapshot
-            WHERE date >= $1
+            WHERE league_id = $1 AND season_id = $2 AND date >= $3
         """
         try:
             async with pool.acquire() as conn:
-                cutoff = _SEASON_START + timedelta(days=10)
+                cutoff = settings.season_start + timedelta(days=10)
                 if team_ids:
-                    rows = await conn.fetch(_base + " AND team_id = ANY($2) ORDER BY date, team_id", cutoff, team_ids)
+                    rows = await conn.fetch(
+                        _base + " AND team_id = ANY($4) ORDER BY date, team_id",
+                        league_id, season_id, cutoff, team_ids,
+                    )
                 else:
-                    rows = await conn.fetch(_base + " ORDER BY date, team_id", cutoff)
+                    rows = await conn.fetch(
+                        _base + " ORDER BY date, team_id", league_id, season_id, cutoff
+                    )
                 return [dict(r) for r in rows]
         except Exception as e:
             logger.error(f"Failed to fetch averages over time: {e}")
             return []
 
-    async def get_snapshots_for_date_range(self, start_date: date, end_date: date):
+    async def get_snapshots_for_date_range(
+        self, start_date: date, end_date: date, league_id: int, season_id: int
+    ):
         """
         Returns (actual_end_date, actual_start_date, rows_end, rows_start) for delta calculation.
         - actual_end_date: closest date <= end_date in DB
@@ -357,14 +394,18 @@ class DBService:
         try:
             async with pool.acquire() as conn:
                 end_row = await conn.fetchrow(
-                    "SELECT MAX(date) AS d FROM team_daily_snapshot WHERE date <= $1", end_date
+                    "SELECT MAX(date) AS d FROM team_daily_snapshot "
+                    "WHERE league_id = $1 AND season_id = $2 AND date <= $3",
+                    league_id, season_id, end_date,
                 )
                 actual_end_date = end_row['d'] if end_row else None
                 if actual_end_date is None:
                     return None, None, [], []
 
                 start_row = await conn.fetchrow(
-                    "SELECT MIN(date) AS d FROM team_daily_snapshot WHERE date >= $1", start_date
+                    "SELECT MIN(date) AS d FROM team_daily_snapshot "
+                    "WHERE league_id = $1 AND season_id = $2 AND date >= $3",
+                    league_id, season_id, start_date,
                 )
                 actual_start_date = start_row['d'] if start_row else None
 
@@ -372,9 +413,10 @@ class DBService:
                     """
                     SELECT team_id, team_name, gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
                            three_pm, reb, ast, stl, blk, pts
-                    FROM team_daily_snapshot WHERE date = $1
+                    FROM team_daily_snapshot
+                    WHERE league_id = $1 AND season_id = $2 AND date = $3
                     """,
-                    actual_end_date
+                    league_id, season_id, actual_end_date
                 )
 
                 rows_start = []
@@ -383,9 +425,10 @@ class DBService:
                         """
                         SELECT team_id, team_name, gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
                                three_pm, reb, ast, stl, blk, pts
-                        FROM team_daily_snapshot WHERE date = $1
+                        FROM team_daily_snapshot
+                        WHERE league_id = $1 AND season_id = $2 AND date = $3
                         """,
-                        actual_start_date
+                        league_id, season_id, actual_start_date
                     )
 
                 return actual_end_date, actual_start_date, [dict(r) for r in rows_end], [dict(r) for r in rows_start]
@@ -393,27 +436,30 @@ class DBService:
             logger.error(f"Failed to fetch snapshots for date range: {e}")
             return None, None, [], []
 
-    async def upsert_estimator_prediction(self, df: pd.DataFrame) -> None:
+    async def upsert_estimator_prediction(self, df: pd.DataFrame, league_id: int, season_id: int) -> None:
         pool = await self._get_pool()
         if pool is None:
             return
         try:
             async with pool.acquire() as conn:
                 async with conn.transaction():
-                    await conn.execute("DELETE FROM estimator_prediction")
+                    await conn.execute(
+                        "DELETE FROM estimator_prediction WHERE league_id = $1 AND season_id = $2",
+                        league_id, season_id,
+                    )
                     for _, row in df.iterrows():
                         await conn.execute(
                             """
                             INSERT INTO estimator_prediction (
-                                team_id, team_name, as_of_date, projected_total_gp,
+                                league_id, season_id, team_id, team_name, as_of_date, projected_total_gp,
                                 estimated_final_fg_pct, estimated_final_ft_pct, estimated_final_three_pm,
                                 estimated_final_reb, estimated_final_ast, estimated_final_stl,
                                 estimated_final_blk, estimated_final_pts,
                                 variance_fg_pct, variance_ft_pct, variance_three_pm,
                                 variance_reb, variance_ast, variance_stl, variance_blk, variance_pts,
                                 nba_avg_pace
-                            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
-                            ON CONFLICT (team_id) DO UPDATE SET
+                            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)
+                            ON CONFLICT (league_id, season_id, team_id) DO UPDATE SET
                                 team_name = EXCLUDED.team_name,
                                 as_of_date = EXCLUDED.as_of_date,
                                 projected_total_gp = EXCLUDED.projected_total_gp,
@@ -435,6 +481,8 @@ class DBService:
                                 variance_pts = EXCLUDED.variance_pts,
                                 nba_avg_pace = EXCLUDED.nba_avg_pace
                             """,
+                            league_id,
+                            season_id,
                             int(row['team_id']),
                             str(row['team_name']),
                             row['as_of_date'],
@@ -457,28 +505,31 @@ class DBService:
                             float(row['variance_pts']),
                             float(row['nba_avg_pace']),
                         )
-            logger.info("Upserted estimator_prediction")
+            logger.info(f"Upserted estimator_prediction for league_id={league_id} season_id={season_id}")
         except Exception as e:
             logger.error(f"Failed to upsert estimator_prediction: {e}")
 
-    async def upsert_estimator_ranking(self, df: pd.DataFrame) -> None:
+    async def upsert_estimator_ranking(self, df: pd.DataFrame, league_id: int, season_id: int) -> None:
         pool = await self._get_pool()
         if pool is None:
             return
         try:
             async with pool.acquire() as conn:
                 async with conn.transaction():
-                    await conn.execute("DELETE FROM estimator_ranking")
+                    await conn.execute(
+                        "DELETE FROM estimator_ranking WHERE league_id = $1 AND season_id = $2",
+                        league_id, season_id,
+                    )
                     for _, row in df.iterrows():
                         await conn.execute(
                             """
                             INSERT INTO estimator_ranking (
-                                team_id, team_name, rank, total_expected_pts,
+                                league_id, season_id, team_id, team_name, rank, total_expected_pts,
                                 expected_pts_fg_pct, expected_pts_ft_pct, expected_pts_three_pm,
                                 expected_pts_reb, expected_pts_ast, expected_pts_stl,
                                 expected_pts_blk, expected_pts_pts, projected_total_gp
-                            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
-                            ON CONFLICT (team_id) DO UPDATE SET
+                            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                            ON CONFLICT (league_id, season_id, team_id) DO UPDATE SET
                                 team_name = EXCLUDED.team_name,
                                 rank = EXCLUDED.rank,
                                 total_expected_pts = EXCLUDED.total_expected_pts,
@@ -492,6 +543,8 @@ class DBService:
                                 expected_pts_pts = EXCLUDED.expected_pts_pts,
                                 projected_total_gp = EXCLUDED.projected_total_gp
                             """,
+                            league_id,
+                            season_id,
                             int(row['team_id']),
                             str(row['team_name']),
                             int(row['rank']),
@@ -506,46 +559,53 @@ class DBService:
                             float(row['expected_pts_pts']),
                             float(row['projected_total_gp']),
                         )
-            logger.info("Upserted estimator_ranking")
+            logger.info(f"Upserted estimator_ranking for league_id={league_id} season_id={season_id}")
         except Exception as e:
             logger.error(f"Failed to upsert estimator_ranking: {e}")
 
-    async def upsert_estimator_rank_probability(self, df: pd.DataFrame) -> None:
+    async def upsert_estimator_rank_probability(self, df: pd.DataFrame, league_id: int, season_id: int) -> None:
         pool = await self._get_pool()
         if pool is None:
             return
         try:
             async with pool.acquire() as conn:
                 async with conn.transaction():
-                    await conn.execute("DELETE FROM estimator_rank_probability")
+                    await conn.execute(
+                        "DELETE FROM estimator_rank_probability WHERE league_id = $1 AND season_id = $2",
+                        league_id, season_id,
+                    )
                     await conn.executemany(
                         """
-                        INSERT INTO estimator_rank_probability (team_id, team_name, rank, prob)
-                        VALUES ($1, $2, $3, $4)
+                        INSERT INTO estimator_rank_probability (league_id, season_id, team_id, team_name, rank, prob)
+                        VALUES ($1, $2, $3, $4, $5, $6)
                         """,
                         [
-                            (int(row['team_id']), str(row['team_name']), int(row['rank']), float(row['prob']))
+                            (league_id, season_id, int(row['team_id']), str(row['team_name']), int(row['rank']), float(row['prob']))
                             for _, row in df.iterrows()
                         ],
                     )
-            logger.info("Upserted estimator_rank_probability")
+            logger.info(f"Upserted estimator_rank_probability for league_id={league_id} season_id={season_id}")
         except Exception as e:
             logger.error(f"Failed to upsert estimator_rank_probability: {e}")
 
-    async def get_estimator_latest(self) -> dict:
+    async def get_estimator_latest(self, league_id: int, season_id: int) -> dict:
         pool = await self._get_pool()
         if pool is None:
             return {}
         try:
             async with pool.acquire() as conn:
                 predictions = await conn.fetch(
-                    "SELECT * FROM estimator_prediction ORDER BY team_id"
+                    "SELECT * FROM estimator_prediction WHERE league_id = $1 AND season_id = $2 ORDER BY team_id",
+                    league_id, season_id,
                 )
                 rankings = await conn.fetch(
-                    "SELECT * FROM estimator_ranking ORDER BY rank"
+                    "SELECT * FROM estimator_ranking WHERE league_id = $1 AND season_id = $2 ORDER BY rank",
+                    league_id, season_id,
                 )
                 rank_probs = await conn.fetch(
-                    "SELECT * FROM estimator_rank_probability ORDER BY team_id, rank"
+                    "SELECT * FROM estimator_rank_probability WHERE league_id = $1 AND season_id = $2 "
+                    "ORDER BY team_id, rank",
+                    league_id, season_id,
                 )
                 return {
                     "predictions": [dict(r) for r in predictions],
@@ -556,13 +616,16 @@ class DBService:
             logger.error(f"Failed to fetch estimator latest: {e}")
             return {}
 
-    async def estimator_has_data(self) -> bool:
+    async def estimator_has_data(self, league_id: int, season_id: int) -> bool:
         pool = await self._get_pool()
         if pool is None:
             return False
         try:
             async with pool.acquire() as conn:
-                count = await conn.fetchval("SELECT COUNT(*) FROM estimator_ranking")
+                count = await conn.fetchval(
+                    "SELECT COUNT(*) FROM estimator_ranking WHERE league_id = $1 AND season_id = $2",
+                    league_id, season_id,
+                )
                 return (count or 0) > 0
         except Exception as e:
             logger.error(f"Failed to check estimator data: {e}")

--- a/backend/app/services/estimator_service.py
+++ b/backend/app/services/estimator_service.py
@@ -41,8 +41,10 @@ class EstimatorService:
                        gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
                        three_pm, reb, ast, stl, blk, pts
                 FROM team_daily_snapshot
+                WHERE league_id = $1 AND season_id = $2
                 ORDER BY team_id, scoring_period_id
-                """
+                """,
+                settings.league_id, settings.season_id,
             )
         if not rows:
             raise RuntimeError("No snapshot data in DB")
@@ -54,8 +56,11 @@ class EstimatorService:
     async def _get_nba_avg_pace(self) -> float:
         try:
             nba_service = NBAStatsService()
+            # NBAStatsService is a shared singleton (closed once at app
+            # shutdown) — this runs concurrently with get_team_slot_pace_df's
+            # own use of it via the same asyncio.gather, so closing here would
+            # break whichever call is still in flight.
             pace = await nba_service.get_nba_average_pace(settings.season_id)
-            await nba_service.close()
             if pace is not None:
                 return pace
         except Exception as e:
@@ -69,12 +74,14 @@ class EstimatorService:
             logger.info("Estimator already ran today (cached), skipping")
             return False
 
-        if await self.db_service.estimator_has_data():
+        if await self.db_service.estimator_has_data(settings.league_id, settings.season_id):
             pool = await self.db_service._get_pool()
             if pool:
                 async with pool.acquire() as conn:
                     stored_date = await conn.fetchval(
-                        "SELECT as_of_date FROM estimator_prediction LIMIT 1"
+                        "SELECT as_of_date FROM estimator_prediction "
+                        "WHERE league_id = $1 AND season_id = $2 LIMIT 1",
+                        settings.league_id, settings.season_id,
                     )
                 if stored_date == today:
                     logger.info("Estimator data already up to date for today, skipping")
@@ -95,9 +102,9 @@ class EstimatorService:
             )
 
             await asyncio.gather(
-                self.db_service.upsert_estimator_prediction(prediction_df),
-                self.db_service.upsert_estimator_ranking(ranking_df),
-                self.db_service.upsert_estimator_rank_probability(rank_prob_df),
+                self.db_service.upsert_estimator_prediction(prediction_df, settings.league_id, settings.season_id),
+                self.db_service.upsert_estimator_ranking(ranking_df, settings.league_id, settings.season_id),
+                self.db_service.upsert_estimator_rank_probability(rank_prob_df, settings.league_id, settings.season_id),
             )
 
             self._cache = {
@@ -118,7 +125,7 @@ class EstimatorService:
         if self._cache and self._cache_date == today:
             return self._cache
 
-        result = await self.db_service.get_estimator_latest()
+        result = await self.db_service.get_estimator_latest(settings.league_id, settings.season_id)
         if result.get("rankings"):
             self._cache = result
             predictions = result.get("predictions", [])

--- a/backend/app/services/league_service.py
+++ b/backend/app/services/league_service.py
@@ -36,7 +36,7 @@ class LeagueService:
             nba_service = NBAStatsService()
             nba_avg_pace, nba_game_days_left = await asyncio.gather(
                 nba_service.get_nba_average_pace(settings.season_id),
-                nba_service.get_nba_game_days_remaining(),
+                nba_service.get_nba_game_days_remaining(settings.season_id),
             )
         except Exception as e:
             self.logger.warning(f"Failed to fetch NBA stats: {e}")
@@ -86,7 +86,9 @@ class LeagueService:
         from app.services.data_transformer import DataTransformer
 
         actual_end_date, actual_start_date, rows_end, rows_start = \
-            await self.data_provider.db_service.get_snapshots_for_date_range(start_date, end_date)
+            await self.data_provider.db_service.get_snapshots_for_date_range(
+                start_date, end_date, settings.league_id, settings.season_id
+            )
 
         if actual_end_date is None or not rows_end:
             raise ResourceNotFoundError("No data available for the requested date range")

--- a/backend/app/services/nba_matchup_service.py
+++ b/backend/app/services/nba_matchup_service.py
@@ -162,6 +162,18 @@ class NbaMatchupService:
                 resolved_date = base + timedelta(days=offset)
                 break
 
+        # Preseason: nothing within the normal lookahead window, but the real
+        # season opener (settings.season_start, now derived from the NBA
+        # schedule) is a known future date — preview it instead of reporting
+        # a flat offseason "no games".
+        if resolved_date is None and base < settings.season_start:
+            opener_events = (await self._countable_events_by_day(settings.season_start, 0)).get(
+                settings.season_start, []
+            )
+            if opener_events:
+                games = self._games_from(opener_events)
+                resolved_date = settings.season_start
+
         self._resolved_date = resolved_date.isoformat() if resolved_date else None
         return games
 

--- a/backend/app/services/nba_stats_service.py
+++ b/backend/app/services/nba_stats_service.py
@@ -30,7 +30,7 @@ class NBAStatsService:
             limits=httpx.Limits(max_keepalive_connections=10, max_connections=20)
         )
         self._pace_cache: dict = {'season_id': None, 'value': None, 'ts': None}
-        self._days_left_cache: dict = {'value': None, 'ts': None}
+        self._days_left_cache: dict = {'season_id': None, 'value': None, 'ts': None}
         NBAStatsService._initialized = True
 
     async def get_nba_average_pace(self, season_id: int) -> Optional[float]:
@@ -108,45 +108,106 @@ class NBAStatsService:
             self.logger.warning(f"Unexpected error fetching NBA average pace: {e}")
             return None
 
-    async def get_nba_game_days_remaining(self) -> Optional[int]:
+    async def get_nba_game_days_remaining(self, season_id: int) -> Optional[int]:
         """
         Calculate remaining game days in NBA regular season, cached 30 min.
+
+        Args:
+            season_id: NBA season year (e.g., 2026 for "2025-26")
 
         Returns:
             Number of days with NBA games remaining until end of regular season, or None if fetch fails
         """
         cache = self._days_left_cache
-        if cache['ts'] is not None and datetime.now() - cache['ts'] < _CACHE_TTL:
+        if (
+            cache['season_id'] == season_id
+            and cache['ts'] is not None
+            and datetime.now() - cache['ts'] < _CACHE_TTL
+        ):
             return cache['value']
 
-        value = await self._fetch_nba_game_days_remaining()
-        self._days_left_cache = {'value': value, 'ts': datetime.now()}
+        value = await self._fetch_nba_game_days_remaining(season_id)
+        self._days_left_cache = {'season_id': season_id, 'value': value, 'ts': datetime.now()}
         return value
 
-    async def _fetch_nba_game_days_remaining(self) -> Optional[int]:
+    async def get_regular_season_start_date(self, season_id: int):
+        """The actual first regular-season game date for `season_id` (skips
+        preseason), derived from ESPN's whitelist calendar — not cached here,
+        meant to be called once at app startup and stored on settings."""
         try:
-            url = "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?calendartype=whitelist"
+            dates, start_idx, _ = await self._get_regular_season_calendar(season_id)
+            return dates[start_idx]
+        except Exception as e:
+            self.logger.warning(f"Failed to derive regular season start for {season_id}: {e}")
+            return None
+
+    async def _get_event_season_type(self, day) -> Optional[int]:
+        """season.type for the first event on `day` (1=preseason, 2=regular, 3+=postseason/play-in),
+        or None if the fetch fails / no events that day."""
+        try:
+            url = f"https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?dates={day.strftime('%Y%m%d')}"
             response = await self._client.get(url)
             response.raise_for_status()
-            data = response.json()
+            events = response.json().get('events', [])
+            return events[0].get('season', {}).get('type') if events else None
+        except Exception as e:
+            self.logger.warning(f"Failed to fetch season type for {day}: {e}")
+            return None
 
-            calendar = data.get('leagues', [{}])[0].get('calendar', [])
-            if not calendar:
-                self.logger.warning("No calendar data found in NBA scoreboard response")
-                return None
+    async def _binary_search_first(self, calendar_dates: list, min_type: int) -> Optional[int]:
+        """Leftmost index in sorted `calendar_dates` whose season.type >= min_type,
+        or None if no probed date qualifies."""
+        lo, hi = 0, len(calendar_dates) - 1
+        result = None
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            season_type = await self._get_event_season_type(calendar_dates[mid])
+            if season_type is not None and season_type >= min_type:
+                result = mid
+                hi = mid - 1
+            else:
+                lo = mid + 1
+        return result
 
+    async def _get_regular_season_calendar(self, season_id: int) -> tuple[list, int, int]:
+        """(all_game_dates, start_idx, end_idx) bounding the regular season for
+        `season_id` (ESPN convention: season_id = year the season ends, e.g.
+        2026 for "2025-26"). Anchors the calendar query to a date safely inside
+        that season instead of ESPN's default (which reflects whichever season
+        is nearest to *today*, not necessarily the one this app is configured
+        for) — an already-completed or future SEASON_ID would otherwise derive
+        the wrong season's boundaries entirely. An anchored/historical calendar
+        also includes playoffs, so both ends are probed rather than just the
+        start."""
+        anchor = datetime(season_id - 1, 11, 1).strftime('%Y%m%d')
+        url = f"https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?calendartype=whitelist&dates={anchor}"
+        response = await self._client.get(url)
+        response.raise_for_status()
+        data = response.json()
+
+        calendar = data.get('leagues', [{}])[0].get('calendar', [])
+        if not calendar:
+            raise ValueError("No calendar data found in NBA scoreboard response")
+
+        all_game_dates = [datetime.fromisoformat(d.replace('Z', '+00:00')).date() for d in calendar]
+
+        start_idx = await self._binary_search_first(all_game_dates, min_type=2)
+        if start_idx is None:
+            self.logger.warning(f"Could not determine regular-season start for {season_id}; not filtering preseason")
+            start_idx = 0
+
+        postseason_idx = await self._binary_search_first(all_game_dates, min_type=3)
+        end_idx = (postseason_idx - 1) if postseason_idx is not None else len(all_game_dates) - 1
+
+        return all_game_dates, start_idx, end_idx
+
+    async def _fetch_nba_game_days_remaining(self, season_id: int) -> Optional[int]:
+        try:
+            all_game_dates, start_idx, end_idx = await self._get_regular_season_calendar(season_id)
             today = datetime.now().date()
-            regular_season_end = datetime.fromisoformat('2026-04-12T23:59:59+00:00').date()
-
-            future_game_dates = [
-                datetime.fromisoformat(date.replace('Z', '+00:00')).date()
-                for date in calendar
-                if datetime.fromisoformat(date.replace('Z', '+00:00')).date() >= today
-                and datetime.fromisoformat(date.replace('Z', '+00:00')).date() <= regular_season_end
-            ]
-
+            regular_season_dates = all_game_dates[start_idx:end_idx + 1]
+            future_game_dates = [d for d in regular_season_dates if d >= today]
             return len(future_game_dates)
-
         except httpx.RequestError as e:
             self.logger.warning(f"Failed to fetch NBA calendar: {e}")
             return None

--- a/backend/app/services/ranking_service.py
+++ b/backend/app/services/ranking_service.py
@@ -7,6 +7,7 @@ from app.exceptions import InvalidParameterError, ResourceNotFoundError
 from app.services.data_provider import DataProvider
 from app.builders.response_builder import ResponseBuilder
 from app.utils.constants import RANKING_CATEGORIES, PER_GAME_CATEGORIES
+from app.config import settings
 
 class RankingService:
     """Service for ranking-related operations"""
@@ -45,7 +46,9 @@ class RankingService:
     async def _get_rankings_for_range(self, start_date: date, end_date: date,
                                        sort_by: Optional[str], order: str) -> LeagueRankings:
         actual_end_date, actual_start_date, rows_end, rows_start = \
-            await self.data_provider.db_service.get_snapshots_for_date_range(start_date, end_date)
+            await self.data_provider.db_service.get_snapshots_for_date_range(
+                start_date, end_date, settings.league_id, settings.season_id
+            )
 
         if actual_end_date is None or not rows_end:
             raise ResourceNotFoundError("No data available for the requested date range")

--- a/backend/app/services/team_service.py
+++ b/backend/app/services/team_service.py
@@ -1,9 +1,9 @@
 import asyncio
 import logging
-from datetime import date
+from datetime import date, datetime
 from typing import List, Optional
 from app.models import TeamDetail, TeamPlayers, Team, StatTimePeriod
-from app.exceptions import InvalidParameterError, ResourceNotFoundError
+from app.exceptions import InvalidParameterError, ResourceNotFoundError, DataSourceError
 from app.services.data_provider import DataProvider
 from app.services.player_service import build_windowed_players_df
 from app.builders.response_builder import ResponseBuilder
@@ -74,16 +74,22 @@ class TeamService:
         )
     
     async def get_teams_list(self) -> List[Team]:
-        """Get list of all teams"""
-        totals_df = await self.data_provider.get_totals_df()
-        if totals_df is None:
-            raise Exception("Unable to fetch teams data from ESPN API")
-        
-        teams = self._extract_teams_from_dataframe(totals_df)
-        
+        """Get list of all teams. Falls back to identity-only data (no stats
+        yet, e.g. preseason) when stat totals aren't available — the teams
+        themselves still exist on ESPN's side even before games are played."""
+        try:
+            totals_df = await self.data_provider.get_totals_df()
+            teams = self._extract_teams_from_dataframe(totals_df)
+            if teams:
+                return teams
+        except DataSourceError:
+            pass
+
+        team_names = await self.data_provider.get_team_names()
+        teams = [Team(team_id=int(t['team_id']), team_name=t['team_name']) for t in team_names]
         if not teams:
             raise ResourceNotFoundError("No teams found in the data")
-        
+
         return teams
     
     async def get_team_players(self, team_id: int) -> TeamPlayers:
@@ -95,7 +101,10 @@ class TeamService:
         team_players = self._filter_team_players(players_df, team_id)
 
         if team_players.empty:
-            raise ResourceNotFoundError(f"No players found for team ID {team_id}")
+            # A valid team with no roster yet (e.g. pre-draft) is a real, empty
+            # state — not a lookup failure. team_id validity is already checked
+            # by the caller via is_team_exists.
+            return TeamPlayers(team_id=team_id, players=[], last_updated=datetime.now())
 
         return self.response_builder.build_team_players_response(team_players)
     

--- a/backend/app/services/team_slot_pace.py
+++ b/backend/app/services/team_slot_pace.py
@@ -27,11 +27,14 @@ async def get_team_slot_pace_df() -> pd.DataFrame:
     slot_usage = await data_provider.get_slot_usage()
     totals_df = await data_provider.get_totals_df()
 
+    # NBAStatsService is a shared singleton (closed once at app shutdown in
+    # main.py's lifespan) — must not be closed here, since other concurrent
+    # callers (e.g. estimator_service's own pace fetch, run via the same
+    # asyncio.gather) may still be using its httpx client.
     nba_avg_pace, game_days_remaining = await asyncio.gather(
         nba_service.get_nba_average_pace(settings.season_id),
-        nba_service.get_nba_game_days_remaining(),
+        nba_service.get_nba_game_days_remaining(settings.season_id),
     )
-    await nba_service.close()
 
     team_name_map = dict(zip(totals_df['team_id'], totals_df['team_name']))
     resolved_pace = nba_avg_pace if nba_avg_pace is not None else _NBA_AVG_PACE_FALLBACK

--- a/backend/tests/routes/test_analytics.py
+++ b/backend/tests/routes/test_analytics.py
@@ -6,6 +6,7 @@ from app.models import HeatmapData
 from app.models.base import Team
 from app.models import RankingsOverTimeResponse
 from app.services.db_service import DBService
+from app.config import settings
 
 
 def test_get_heatmap(test_client):
@@ -38,7 +39,7 @@ def test_get_over_time_snapshot_source(test_client):
     try:
         response = test_client.get("/api/analytics/over-time?source=snapshot")
         assert response.status_code == 200
-        inst.get_snapshot_over_time.assert_awaited_once_with(None)
+        inst.get_snapshot_over_time.assert_awaited_once_with(None, settings.league_id, settings.season_id)
     finally:
         app.dependency_overrides.pop(DBService, None)
 

--- a/backend/tests/routes/test_trends_route.py
+++ b/backend/tests/routes/test_trends_route.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.exceptions import DataSourceError, ResourceNotFoundError
 from app.models.trend_models import (
     GameLogEntry,
     GameLogResponse,
@@ -255,3 +256,29 @@ def test_in_range_off_preset_window_days_is_honoured(mock_services):
     assert resp.status_code == 200
     svc.get_minutes_movers.assert_awaited_once()
     assert svc.get_minutes_movers.call_args.args[1] == 21
+
+
+class TestGlobalExceptionHandlers:
+    """trends routes don't catch DataSourceError/ResourceNotFoundError
+    themselves, so they're a good probe for main.py's app-wide handlers that
+    map these to 503/404 instead of a generic 500."""
+
+    def test_data_source_error_surfaces_as_503(self, mock_services):
+        _, provider = mock_services
+        provider.get_players_df = AsyncMock(side_effect=DataSourceError("ESPN unavailable"))
+        client = TestClient(app)
+
+        resp = client.get('/api/trends/regression')
+
+        assert resp.status_code == 503
+        assert resp.json()['detail'] == "ESPN unavailable"
+
+    def test_resource_not_found_error_surfaces_as_404(self, mock_services):
+        _, provider = mock_services
+        provider.get_players_df = AsyncMock(side_effect=ResourceNotFoundError("No players found"))
+        client = TestClient(app)
+
+        resp = client.get('/api/trends/regression')
+
+        assert resp.status_code == 404
+        assert resp.json()['detail'] == "No players found"

--- a/backend/tests/services/test_data_provider.py
+++ b/backend/tests/services/test_data_provider.py
@@ -242,3 +242,86 @@ async def test_get_all_dataframes_tuple(provider):
 
     t, a, r = await provider.get_all_dataframes()
     assert len(t) == len(a) == len(r)
+
+
+@pytest.mark.asyncio
+async def test_fallback_from_db_raises_when_no_rows(provider):
+    """No DB fallback data for this league/season is a real 'nothing to
+    serve' state, not a generic crash — the route layer maps DataSourceError
+    to 503 so the frontend can show a specific message."""
+    provider.db_service.get_latest_snapshot = AsyncMock(return_value=(None, []))
+
+    with pytest.raises(DataSourceError, match="ESPN unavailable and no DB fallback data"):
+        await provider._fallback_from_db()
+
+
+@pytest.mark.asyncio
+async def test_fallback_from_db_casts_decimal_columns_to_float(provider):
+    """asyncpg returns Decimal for NUMERIC columns; the DB-fallback totals
+    DataFrame must be uniformly float (like the ESPN path) so downstream
+    consumers (e.g. the heatmap) don't crash mixing Decimal and float."""
+    from decimal import Decimal
+
+    rows = [{
+        "team_id": 1, "team_name": "T", "date": "2025-01-01",
+        "fg_pct": Decimal("46.7"), "ft_pct": Decimal("74.9"),
+        "three_pm": Decimal("15"), "reb": Decimal("43"), "ast": Decimal("28"),
+        "stl": Decimal("9"), "blk": Decimal("4"), "pts": Decimal("112"),
+        "gp": Decimal("10"), "fgm": Decimal("40"), "fga": Decimal("85"),
+        "ftm": Decimal("20"), "fta": Decimal("27"),
+    }]
+    provider.db_service.get_latest_snapshot = AsyncMock(return_value=("2025-01-01", rows))
+
+    df = await provider._fallback_from_db()
+
+    for col in ["FG%", "FT%", "3PM", "REB", "AST", "STL", "BLK", "PTS", "GP"]:
+        assert df[col].dtype == float, f"{col} should be cast to float, got {df[col].dtype}"
+
+
+@pytest.mark.asyncio
+async def test_get_team_names_reuses_cached_raw_payload(provider):
+    """Reuses the raw standings payload already cached by get_totals_df —
+    doesn't make an extra ESPN request when one is already in memory."""
+    provider.cache_manager.totals_cache["raw"] = {"teams": [{"id": 1, "name": "Alpha"}]}
+    provider.data_transformer.raw_standings_to_team_names.return_value = [
+        {"team_id": 1, "team_name": "Alpha"}
+    ]
+    provider._client.get = AsyncMock()
+
+    result = await provider.get_team_names()
+
+    provider._client.get.assert_not_awaited()
+    provider.data_transformer.raw_standings_to_team_names.assert_called_once_with(
+        {"teams": [{"id": 1, "name": "Alpha"}]}
+    )
+    assert result == [{"team_id": 1, "team_name": "Alpha"}]
+
+
+@pytest.mark.asyncio
+async def test_get_team_names_fetches_fresh_when_nothing_cached(provider):
+    """No cached payload yet (e.g. totals were never successfully fetched
+    this run, as in preseason) -> a fresh standings request is made."""
+    provider.cache_manager.totals_cache["raw"] = None
+    raw_payload = {"teams": [{"id": 2, "name": "Beta"}]}
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = raw_payload
+    provider._client.get = AsyncMock(return_value=mock_resp)
+    provider.data_transformer.raw_standings_to_team_names.return_value = [
+        {"team_id": 2, "team_name": "Beta"}
+    ]
+
+    result = await provider.get_team_names()
+
+    provider._client.get.assert_awaited_once()
+    mock_resp.raise_for_status.assert_called_once()
+    assert provider.cache_manager.totals_cache["raw"] == raw_payload
+    assert result == [{"team_id": 2, "team_name": "Beta"}]
+
+
+@pytest.mark.asyncio
+async def test_get_team_names_raises_data_source_error_on_fetch_failure(provider):
+    provider.cache_manager.totals_cache["raw"] = None
+    provider._client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+    with pytest.raises(DataSourceError, match="Error fetching team names"):
+        await provider.get_team_names()

--- a/backend/tests/services/test_data_transformer.py
+++ b/backend/tests/services/test_data_transformer.py
@@ -92,6 +92,67 @@ class TestRawStandingsToTotals:
         with pytest.raises(Exception, match="Error transforming ESPN standings"):
             transformer.raw_standings_to_totals_df({"teams": []})
 
+    def test_team_without_values_by_stat_gets_zero_row(self, transformer):
+        """ESPN omits valuesByStat entirely before any games are played
+        (preseason) — that's a real zero-stat team, not a missing one, so it
+        must be synthesized rather than silently dropped."""
+        payload = {"teams": [{"id": 5, "name": " New Team "}]}
+
+        df = transformer.raw_standings_to_totals_df(payload)
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["team_id"] == 5
+        assert row["team_name"] == "New Team"
+        assert row["PTS"] == 0
+        assert row["GP"] == 0
+
+    def test_mix_of_teams_with_and_without_stats(self, transformer):
+        """A preseason league can have some teams already synced and others
+        not — both must survive in the same DataFrame."""
+        payload = _standings_payload(team_ids=(1,))
+        payload["teams"].append({"id": 2, "name": "No Stats Yet"})
+
+        df = transformer.raw_standings_to_totals_df(payload)
+
+        assert set(df["team_id"].tolist()) == {1, 2}
+        no_stats_row = df[df["team_id"] == 2].iloc[0]
+        assert no_stats_row["PTS"] == 0
+
+
+class TestRawStandingsToTeamNames:
+    def test_extracts_id_and_stripped_name(self, transformer):
+        payload = {"teams": [{"id": 1, "name": " Team Alpha "}, {"id": 2, "name": "Team Beta"}]}
+
+        result = transformer.raw_standings_to_team_names(payload)
+
+        assert result == [
+            {"team_id": 1, "team_name": "Team Alpha"},
+            {"team_id": 2, "team_name": "Team Beta"},
+        ]
+
+    def test_independent_of_values_by_stat(self, transformer):
+        """Team identity exists on ESPN's side even before any games are
+        played, unlike per-team stat totals — no valuesByStat required."""
+        payload = {"teams": [{"id": 9, "name": "Preseason Team"}]}
+
+        result = transformer.raw_standings_to_team_names(payload)
+
+        assert result == [{"team_id": 9, "team_name": "Preseason Team"}]
+
+    def test_skips_teams_missing_id_or_name(self, transformer):
+        payload = {"teams": [{"id": 1, "name": "Has Both"}, {"name": "Missing Id"}, {"id": 2, "name": ""}]}
+
+        result = transformer.raw_standings_to_team_names(payload)
+
+        assert result == [{"team_id": 1, "team_name": "Has Both"}]
+
+    def test_missing_teams_key_returns_empty_list(self, transformer):
+        assert transformer.raw_standings_to_team_names({}) == []
+
+    def test_none_input_returns_empty_list(self, transformer):
+        assert transformer.raw_standings_to_team_names(None) == []
+
 
 class TestTotalsToAverages:
     def test_divides_by_gp(self, transformer, sample_totals_df):
@@ -115,7 +176,71 @@ class TestRawPlayersToDf:
             transformer.raw_players_to_df({"teams": []})
 
 
+def _player_entry(player_id, name, team_id=1, stats=None, season_id=2026):
+    return {
+        "player": {
+            "id": player_id,
+            "fullName": name,
+            "proTeamId": 13,
+            "injured": False,
+            "eligibleSlots": [0, 1],
+            "stats": [
+                {
+                    "scoringPeriodId": 0,
+                    "statSplitTypeId": 0,
+                    "seasonId": season_id,
+                    "stats": stats if stats is not None else {},
+                }
+            ],
+        },
+        "status": "ONTEAM",
+        "onTeamId": team_id,
+        "ratings": {},
+    }
+
+
 class TestRawAllPlayersToDf:
     def test_invalid_raises(self, transformer):
         with pytest.raises(Exception, match="Error transforming ESPN players"):
             transformer.raw_all_players_to_df({})
+
+    def test_success_maps_stat_columns(self, transformer):
+        payload = {"players": [_player_entry(101, "Player A", stats={
+            "0": 25.0, "1": 1.2, "2": 1.5, "3": 4.0, "6": 8.0,
+            "13": 9.0, "14": 18.0, "15": 5.0, "16": 6.0, "17": 2.0,
+            "19": 0.5, "20": 0.83, "42": 70, "40": 32.0,
+        })]}
+
+        df = transformer.raw_all_players_to_df(payload)
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["Name"] == "Player A"
+        assert row["player_id"] == 101
+        assert row["PTS"] == 25.0
+        assert row["GP"] == 70
+
+    def test_zero_gp_stat_split_synthesizes_zero_row_instead_of_dropping_player(self, transformer):
+        """ESPN tags the current-season split before any games are played but
+        leaves 'stats' empty — that's a real 0 GP row, not a missing player."""
+        payload = {"players": [_player_entry(102, "Rookie R", stats={})]}
+
+        df = transformer.raw_all_players_to_df(payload)
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["Name"] == "Rookie R"
+        assert row["GP"] == 0
+        assert row["PTS"] == 0
+
+    def test_mix_of_players_with_and_without_stats(self, transformer):
+        payload = {"players": [
+            _player_entry(101, "Veteran V", stats={"0": 10.0, "42": 5}),
+            _player_entry(102, "Rookie R", stats={}),
+        ]}
+
+        df = transformer.raw_all_players_to_df(payload)
+
+        assert len(df) == 2
+        rookie_row = df[df["Name"] == "Rookie R"].iloc[0]
+        assert rookie_row["GP"] == 0

--- a/backend/tests/services/test_db_service.py
+++ b/backend/tests/services/test_db_service.py
@@ -311,12 +311,14 @@ async def test_get_rankings_over_time_joins_gp(db_service, monkeypatch):
     conn = FakeConn(fetch_result=rows)
     monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=FakePool(conn)))
 
-    result = await db_service.get_rankings_over_time("team_rankings_totals", None)
+    result = await db_service.get_rankings_over_time("team_rankings_totals", None, 1234567890, 2026)
 
     assert result == rows
     query = conn.fetch.call_args[0][0]
     assert "LEFT JOIN team_daily_snapshot" in query
     assert "s.gp" in query
+    query_args = conn.fetch.call_args[0]
+    assert query_args[1:] == (1234567890, 2026)
 
 
 @pytest.mark.asyncio
@@ -324,11 +326,11 @@ async def test_get_rankings_over_time_with_team_ids_joins_gp(db_service, monkeyp
     conn = FakeConn(fetch_result=[])
     monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=FakePool(conn)))
 
-    await db_service.get_rankings_over_time("team_rankings_averages", [1, 2])
+    await db_service.get_rankings_over_time("team_rankings_averages", [1, 2], 1234567890, 2026)
 
     args = conn.fetch.call_args[0]
     assert "LEFT JOIN team_daily_snapshot" in args[0]
-    assert args[1] == [1, 2]
+    assert args[1:] == (1234567890, 2026, [1, 2])
 
 
 @pytest.mark.asyncio
@@ -342,10 +344,12 @@ async def test_upsert_rankings_averages_preserves_tie_fraction(db_service, monke
         "TOTAL_POINTS": 52.0,
     }])
 
-    await db_service.upsert_rankings_averages(5, df)
+    await db_service.upsert_rankings_averages(5, df, 1234567890, 2026)
 
     params = conn.executemany.call_args[0][1][0]
-    assert params[4] == 6.5
+    assert params[0] == 1234567890
+    assert params[1] == 2026
+    assert params[6] == 6.5
     assert params[-1] == 52.0
     assert isinstance(params[-1], float)
 

--- a/backend/tests/services/test_estimator_service.py
+++ b/backend/tests/services/test_estimator_service.py
@@ -1,0 +1,60 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.services.estimator_service as estimator_service_module
+from app.services.estimator_service import EstimatorService, _NBA_AVG_PACE_FALLBACK
+
+
+@pytest.fixture(autouse=True)
+def reset_estimator_service_singleton():
+    EstimatorService._instance = None
+    EstimatorService._initialized = False
+    yield
+    EstimatorService._instance = None
+    EstimatorService._initialized = False
+
+
+@pytest.fixture
+def estimator_service():
+    return EstimatorService()
+
+
+@pytest.mark.asyncio
+async def test_get_nba_avg_pace_does_not_close_shared_nba_service(estimator_service, monkeypatch):
+    """NBAStatsService is a shared singleton closed once at app shutdown —
+    this caller runs concurrently with get_team_slot_pace_df's own use of it
+    via the same asyncio.gather, so closing it here would break whichever
+    call is still in flight. Regression test for that race condition."""
+    nba_service = MagicMock()
+    nba_service.get_nba_average_pace = AsyncMock(return_value=101.2)
+    nba_service.close = AsyncMock()
+    monkeypatch.setattr(estimator_service_module, 'NBAStatsService', lambda: nba_service)
+
+    pace = await estimator_service._get_nba_avg_pace()
+
+    assert pace == 101.2
+    nba_service.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_nba_avg_pace_falls_back_on_none(estimator_service, monkeypatch):
+    nba_service = MagicMock()
+    nba_service.get_nba_average_pace = AsyncMock(return_value=None)
+    nba_service.close = AsyncMock()
+    monkeypatch.setattr(estimator_service_module, 'NBAStatsService', lambda: nba_service)
+
+    pace = await estimator_service._get_nba_avg_pace()
+
+    assert pace == _NBA_AVG_PACE_FALLBACK
+
+
+@pytest.mark.asyncio
+async def test_get_nba_avg_pace_falls_back_on_exception(estimator_service, monkeypatch):
+    nba_service = MagicMock()
+    nba_service.get_nba_average_pace = AsyncMock(side_effect=RuntimeError("network down"))
+    monkeypatch.setattr(estimator_service_module, 'NBAStatsService', lambda: nba_service)
+
+    pace = await estimator_service._get_nba_avg_pace()
+
+    assert pace == _NBA_AVG_PACE_FALLBACK

--- a/backend/tests/services/test_nba_matchup_service.py
+++ b/backend/tests/services/test_nba_matchup_service.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.services.nba_matchup_service import NbaMatchupService
+from app.config import settings
 
 _ET = ZoneInfo('America/New_York')
 
@@ -376,3 +377,61 @@ async def test_get_games_today_and_get_upcoming_game_dates_share_one_fetch(servi
 
     assert first_call_count > 0
     assert len(get.call_args_list) == first_call_count
+
+
+class TestPreseasonOpenerPreview:
+    """Preseason: nothing within the normal lookahead window, but the real
+    season opener (settings.season_start) is a known future date — it should
+    be previewed instead of reporting a flat offseason 'no games'."""
+
+    @pytest.mark.asyncio
+    async def test_previews_season_opener_when_nothing_in_lookahead_window(self, service, monkeypatch):
+        today = _today()
+        opener = today + timedelta(days=30)  # well beyond the 7-day lookahead window
+        monkeypatch.setattr(settings, 'season_start', opener)
+        events_by_day = {
+            opener: [_scoreboard_event(13, 30, 'LAL', 'CHA', completed=False, game_date=opener)],
+        }
+
+        with patch.object(
+            service._client, 'get', new_callable=AsyncMock, side_effect=_client_get_by_day(events_by_day),
+        ):
+            games = await service.get_games_today()
+
+        assert games['LAL'].opponent == 'CHA'
+        assert service.get_schedule_date() == opener.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_stays_empty_when_opener_itself_has_no_events_yet(self, service, monkeypatch):
+        """The opener date is known but ESPN hasn't published its events yet
+        (whitelist calendar doesn't include it) — still a flat empty result,
+        not a crash."""
+        today = _today()
+        opener = today + timedelta(days=30)
+        monkeypatch.setattr(settings, 'season_start', opener)
+
+        with patch.object(
+            service._client, 'get', new_callable=AsyncMock, side_effect=_client_get_by_day({}),
+        ):
+            games = await service.get_games_today()
+
+        assert games == {}
+        assert service.get_schedule_date() is None
+
+    @pytest.mark.asyncio
+    async def test_does_not_preview_opener_once_season_has_started(self, service, monkeypatch):
+        """base >= season_start (regular season underway) must never trigger
+        the preseason preview branch, even with an empty lookahead window."""
+        today = _today()
+        monkeypatch.setattr(settings, 'season_start', today - timedelta(days=1))
+
+        with patch.object(
+            service._client, 'get', new_callable=AsyncMock, side_effect=_client_get_by_day({}),
+        ) as get:
+            games = await service.get_games_today()
+
+        assert games == {}
+        assert service.get_schedule_date() is None
+        # only the single whitelist call from the normal lookahead scan —
+        # no extra opener-day probe
+        assert len(get.call_args_list) == 1

--- a/backend/tests/services/test_nba_stats_service.py
+++ b/backend/tests/services/test_nba_stats_service.py
@@ -1,7 +1,7 @@
 import pytest
 import httpx
 from unittest.mock import Mock, patch, AsyncMock
-from datetime import datetime
+from datetime import datetime, date
 from app.services.nba_stats_service import NBAStatsService
 
 
@@ -231,7 +231,7 @@ class TestNBAStatsServiceGameDaysRemaining:
                 mock_datetime.now.return_value.date.return_value = datetime(2026, 2, 28).date()
                 mock_datetime.fromisoformat = datetime.fromisoformat
 
-                result = await nba_stats_service.get_nba_game_days_remaining()
+                result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
                 assert result is not None
                 assert isinstance(result, int)
@@ -259,41 +259,52 @@ class TestNBAStatsServiceGameDaysRemaining:
                 mock_datetime.now.return_value.date.return_value = datetime(2026, 2, 15).date()
                 mock_datetime.fromisoformat = datetime.fromisoformat
 
-                result = await nba_stats_service.get_nba_game_days_remaining()
+                result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
                 assert result == 2
 
     @pytest.mark.asyncio
     async def test_get_nba_game_days_remaining_filters_post_season(self, nba_stats_service):
-        """Test that dates after regular season end are filtered out"""
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            'leagues': [
-                {
-                    'calendar': [
-                        '2026-04-01T00:00:00Z',
-                        '2026-04-15T00:00:00Z',
-                        '2026-05-01T00:00:00Z'
-                    ]
-                }
-            ]
-        }
-        mock_response.raise_for_status = Mock()
+        """Dates at/after the detected postseason boundary are excluded, even
+        though they're still in the future relative to `today`."""
+        nba_stats_service._get_regular_season_calendar = AsyncMock(
+            return_value=(
+                [date(2026, 4, 1), date(2026, 4, 15), date(2026, 5, 1)],
+                0,  # start_idx: whole window is regular season or later
+                0,  # end_idx: only index 0 (04-01) is still regular season
+            )
+        )
+        with patch('app.services.nba_stats_service.datetime') as mock_datetime:
+            mock_datetime.now.return_value.date.return_value = datetime(2026, 3, 1).date()
 
-        with patch.object(nba_stats_service._client, 'get', new_callable=AsyncMock, return_value=mock_response):
-            with patch('app.services.nba_stats_service.datetime') as mock_datetime:
-                mock_datetime.now.return_value.date.return_value = datetime(2026, 3, 1).date()
-                mock_datetime.fromisoformat = datetime.fromisoformat
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
-                result = await nba_stats_service.get_nba_game_days_remaining()
+            assert result == 1
 
-                assert result == 1
+    @pytest.mark.asyncio
+    async def test_get_nba_game_days_remaining_uses_resolved_window(self, nba_stats_service):
+        """Only dates within [start_idx, end_idx] of the resolved calendar count,
+        regardless of how many extra dates the raw ESPN calendar contains."""
+        nba_stats_service._get_regular_season_calendar = AsyncMock(
+            return_value=(
+                [date(2026, 1, 1), date(2026, 2, 1), date(2026, 3, 1), date(2026, 4, 1), date(2026, 6, 1)],
+                1,  # start_idx: preseason date at index 0 excluded
+                3,  # end_idx: postseason date at index 4 excluded
+            )
+        )
+        with patch('app.services.nba_stats_service.datetime') as mock_datetime:
+            mock_datetime.now.return_value.date.return_value = datetime(2026, 1, 15).date()
+
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
+
+            # window is [02-01, 03-01, 04-01]; all >= 2026-01-15
+            assert result == 3
 
     @pytest.mark.asyncio
     async def test_get_nba_game_days_remaining_http_error(self, nba_stats_service):
         """Test handling of HTTP request error"""
         with patch.object(nba_stats_service._client, 'get', side_effect=httpx.RequestError("Connection failed")):
-            result = await nba_stats_service.get_nba_game_days_remaining()
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
             assert result is None
 
@@ -305,7 +316,7 @@ class TestNBAStatsServiceGameDaysRemaining:
         mock_response.raise_for_status = Mock()
 
         with patch.object(nba_stats_service._client, 'get', new_callable=AsyncMock, return_value=mock_response):
-            result = await nba_stats_service.get_nba_game_days_remaining()
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
             assert result is None
 
@@ -317,7 +328,7 @@ class TestNBAStatsServiceGameDaysRemaining:
         mock_response.raise_for_status = Mock()
 
         with patch.object(nba_stats_service._client, 'get', new_callable=AsyncMock, return_value=mock_response):
-            result = await nba_stats_service.get_nba_game_days_remaining()
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
             assert result is None
 
@@ -335,9 +346,91 @@ class TestNBAStatsServiceGameDaysRemaining:
         mock_response.raise_for_status = Mock()
 
         with patch.object(nba_stats_service._client, 'get', new_callable=AsyncMock, return_value=mock_response):
-            result = await nba_stats_service.get_nba_game_days_remaining()
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
             assert result is None
+
+
+def _routed_client_mock(calendar_dates, season_types):
+    """Fake httpx client 'get' that returns the whitelist calendar for the
+    calendar-lookup URL, and a per-day season-type event payload for the
+    single-day scoreboard probe URLs used by the start/end binary search.
+    `season_types` maps 'YYYYMMDD' -> ESPN season.type (1=pre, 2=regular, 3+=post)."""
+    import re
+
+    async def _get(url, *args, **kwargs):
+        resp = Mock()
+        resp.raise_for_status = Mock()
+        if 'calendartype=whitelist' in url:
+            resp.json.return_value = {'leagues': [{'calendar': calendar_dates}]}
+        else:
+            m = re.search(r'dates=(\d{8})', url)
+            season_type = season_types.get(m.group(1)) if m else None
+            events = [{'season': {'type': season_type}}] if season_type is not None else []
+            resp.json.return_value = {'events': events}
+        return resp
+
+    return AsyncMock(side_effect=_get)
+
+
+class TestNBAStatsServiceRegularSeasonCalendar:
+    """Test suite for _get_regular_season_calendar / _binary_search_first /
+    get_regular_season_start_date — the ESPN-calendar-derived season window
+    that replaced the old hand-maintained SEASON_START/SEASON_END dates."""
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_calendar_finds_start_and_end(self, nba_stats_service):
+        calendar_dates = [
+            '2025-10-15T00:00:00Z',  # preseason
+            '2025-10-22T00:00:00Z',  # regular season start
+            '2026-03-01T00:00:00Z',  # regular season
+            '2026-04-15T00:00:00Z',  # postseason start
+        ]
+        season_types = {
+            '20251015': 1,
+            '20251022': 2,
+            '20260301': 2,
+            '20260415': 3,
+        }
+        with patch.object(nba_stats_service._client, 'get', _routed_client_mock(calendar_dates, season_types)):
+            dates, start_idx, end_idx = await nba_stats_service._get_regular_season_calendar(2026)
+
+        assert dates[start_idx] == date(2025, 10, 22)
+        assert dates[end_idx] == date(2026, 3, 1)
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_calendar_no_postseason_probed_keeps_last_date(self, nba_stats_service):
+        """When every probed date resolves to regular season (no postseason
+        detected), the window runs through the end of the raw calendar."""
+        calendar_dates = ['2025-10-22T00:00:00Z', '2026-03-01T00:00:00Z']
+        season_types = {'20251022': 2, '20260301': 2}
+        with patch.object(nba_stats_service._client, 'get', _routed_client_mock(calendar_dates, season_types)):
+            dates, start_idx, end_idx = await nba_stats_service._get_regular_season_calendar(2026)
+
+        assert start_idx == 0
+        assert end_idx == len(dates) - 1
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_calendar_empty_calendar_raises(self, nba_stats_service):
+        with patch.object(nba_stats_service._client, 'get', _routed_client_mock([], {})):
+            with pytest.raises(ValueError, match="No calendar data"):
+                await nba_stats_service._get_regular_season_calendar(2026)
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_start_date_returns_first_regular_season_day(self, nba_stats_service):
+        calendar_dates = ['2025-10-15T00:00:00Z', '2025-10-22T00:00:00Z']
+        season_types = {'20251015': 1, '20251022': 2}
+        with patch.object(nba_stats_service._client, 'get', _routed_client_mock(calendar_dates, season_types)):
+            start = await nba_stats_service.get_regular_season_start_date(2026)
+
+        assert start == date(2025, 10, 22)
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_start_date_returns_none_on_failure(self, nba_stats_service):
+        with patch.object(nba_stats_service._client, 'get', side_effect=httpx.RequestError("boom")):
+            start = await nba_stats_service.get_regular_season_start_date(2026)
+
+        assert start is None
 
 
 class TestNBAStatsServiceClose:

--- a/backend/tests/services/test_team_service.py
+++ b/backend/tests/services/test_team_service.py
@@ -6,7 +6,7 @@ import pandas as pd
 from unittest.mock import Mock, patch, AsyncMock, MagicMock
 from app.services.team_service import TeamService
 from app.models import Team, TeamDetail, TeamPlayers, Player, ShotChartStats, AverageStats, RankingStats, PlayerStats, StatTimePeriod
-from app.exceptions import InvalidParameterError, ResourceNotFoundError
+from app.exceptions import InvalidParameterError, ResourceNotFoundError, DataSourceError
 import app.services.player_service as player_service_module
 
 @pytest.fixture(autouse=True)
@@ -168,13 +168,31 @@ class TestTeamService:
         team_service.data_provider.get_totals_df.assert_called_once()
     
     @pytest.mark.asyncio
-    async def test_get_teams_list_data_provider_returns_none(self, team_service):
-        """Test get_teams_list when data provider returns None"""
-        team_service.data_provider.get_totals_df.return_value = None
-        
-        with pytest.raises(Exception, match="Unable to fetch teams data from ESPN API"):
+    async def test_get_teams_list_totals_unavailable_falls_back_to_team_names(self, team_service):
+        """When ESPN stat totals aren't available yet (e.g. preseason), get_teams_list
+        falls back to team identity data instead of raising."""
+        team_service.data_provider.get_totals_df.side_effect = DataSourceError("ESPN unavailable")
+        team_service.data_provider.get_team_names.return_value = [
+            {"team_id": 1, "team_name": "Team Alpha"},
+            {"team_id": 2, "team_name": "Team Beta"},
+        ]
+
+        result = await team_service.get_teams_list()
+
+        assert len(result) == 2
+        assert all(isinstance(team, Team) for team in result)
+        assert {t.team_id for t in result} == {1, 2}
+        assert {t.team_name for t in result} == {"Team Alpha", "Team Beta"}
+
+    @pytest.mark.asyncio
+    async def test_get_teams_list_totals_unavailable_and_no_team_names_raises(self, team_service):
+        """When both stat totals and team identity data are unavailable, raise ResourceNotFoundError."""
+        team_service.data_provider.get_totals_df.side_effect = DataSourceError("ESPN unavailable")
+        team_service.data_provider.get_team_names.return_value = []
+
+        with pytest.raises(ResourceNotFoundError, match="No teams found in the data"):
             await team_service.get_teams_list()
-    
+
     @pytest.mark.asyncio
     async def test_get_teams_list_empty_data(self, team_service):
         """Test get_teams_list with empty DataFrame"""
@@ -207,12 +225,16 @@ class TestTeamService:
     
     @pytest.mark.asyncio
     async def test_get_team_players_no_players_found(self, team_service, team_service_players_df):
-        """Test get_team_players when no players found for team"""
+        """A valid team with no roster yet (e.g. pre-draft) returns an empty
+        players list rather than a lookup failure"""
         team_id = 999
         team_service.data_provider.get_players_df.return_value = team_service_players_df
-        
-        with pytest.raises(ResourceNotFoundError, match=f"No players found for team ID {team_id}"):
-            await team_service.get_team_players(team_id)
+
+        result = await team_service.get_team_players(team_id)
+
+        assert result.team_id == team_id
+        assert result.players == []
+        team_service.response_builder.build_team_players_response.assert_not_called()
 
 
 class TestTeamServiceResponseBuilding:

--- a/backend/tests/services/test_team_slot_pace.py
+++ b/backend/tests/services/test_team_slot_pace.py
@@ -1,0 +1,79 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+import app.services.team_slot_pace as team_slot_pace_module
+from app.services.team_slot_pace import get_team_slot_pace_df
+
+
+@pytest.fixture
+def mock_data_provider(monkeypatch):
+    provider = MagicMock()
+    provider.get_slot_usage = AsyncMock(return_value={
+        1: {'PG': 10, 'SG': 5, 'UTIL': 3},
+        2: {'PG': 8},
+    })
+    provider.get_totals_df = AsyncMock(return_value=pd.DataFrame({
+        'team_id': [1, 2], 'team_name': ['Team Alpha', 'Team Beta'],
+    }))
+    monkeypatch.setattr(team_slot_pace_module, 'DataProvider', lambda: provider)
+    return provider
+
+
+@pytest.fixture
+def mock_nba_service(monkeypatch):
+    service = MagicMock()
+    service.get_nba_average_pace = AsyncMock(return_value=99.5)
+    service.get_nba_game_days_remaining = AsyncMock(return_value=42)
+    service.close = AsyncMock()
+    monkeypatch.setattr(team_slot_pace_module, 'NBAStatsService', lambda: service)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_get_team_slot_pace_df_does_not_close_shared_nba_service(mock_data_provider, mock_nba_service):
+    """NBAStatsService is a shared singleton closed once at app shutdown —
+    this caller must not close it, since a concurrent caller (e.g.
+    estimator_service's own pace fetch, run via the same asyncio.gather) may
+    still be using its httpx client. Regression test for that race condition."""
+    await get_team_slot_pace_df()
+
+    mock_nba_service.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_team_slot_pace_df_builds_rows_per_team(mock_data_provider, mock_nba_service):
+    df = await get_team_slot_pace_df()
+
+    assert set(df['team_id']) == {1, 2}
+    row1 = df[df['team_id'] == 1].iloc[0]
+    assert row1['team_name'] == 'Team Alpha'
+    assert row1['PG'] == 10
+    assert row1['SG'] == 5
+    assert row1['C'] == 0  # slot with no usage defaults to 0
+    assert row1['nba_avg_pace'] == 99.5
+    assert row1['nba_game_days_remaining'] == 42
+
+
+@pytest.mark.asyncio
+async def test_get_team_slot_pace_df_falls_back_when_pace_unavailable(mock_data_provider, mock_nba_service):
+    """When NBA pace can't be fetched (e.g. ESPN calendar unreachable), fall
+    back to the known league-average constant rather than propagating None."""
+    mock_nba_service.get_nba_average_pace = AsyncMock(return_value=None)
+
+    df = await get_team_slot_pace_df()
+
+    assert (df['nba_avg_pace'] == 65.9).all()
+
+
+@pytest.mark.asyncio
+async def test_get_team_slot_pace_df_unknown_team_id_gets_placeholder_name(mock_data_provider, mock_nba_service):
+    """A team present in slot usage but missing from totals_df (e.g. a
+    just-created fantasy team not yet reflected in ESPN standings) still
+    gets a row instead of crashing on the team_name lookup."""
+    mock_data_provider.get_slot_usage = AsyncMock(return_value={99: {'PG': 1}})
+
+    df = await get_team_slot_pace_df()
+
+    assert df.iloc[0]['team_name'] == 'Team 99'

--- a/frontend/src/components/ShootingStatsSection.tsx
+++ b/frontend/src/components/ShootingStatsSection.tsx
@@ -3,6 +3,7 @@ import { useGetLeagueShotsQuery } from '../store/api/fantasyApi'
 import { Link } from 'react-router'
 import LoadingSpinner from './LoadingSpinner'
 import ErrorMessage from './ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import DataDateBadge from './DataDateBadge'
 import type { TeamShotStats } from '../types/api'
 
@@ -46,7 +47,7 @@ const ShootingStatsSection = () => {
   }
 
   if (isLoading) return <LoadingSpinner />
-  if (error) return <ErrorMessage message="Failed to load shots data" />
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load shots data')} />
 
   const rawShots = data?.shots || []
 

--- a/frontend/src/components/TrendGameLogChart.tsx
+++ b/frontend/src/components/TrendGameLogChart.tsx
@@ -14,6 +14,7 @@ import {
 import { useGetTrendGameLogQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from './LoadingSpinner'
 import ErrorMessage from './ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import type { GameLogEntry, GameLogResponse, RegressionStat, RegressionMode } from '../types/api'
 import { BASELINE_LABEL } from '../utils/trendBaseline'
 
@@ -206,7 +207,7 @@ export default function TrendGameLogChart({
   const rows = useMemo(() => (log ? buildRows(log, mode, stat) : []), [log, mode, stat])
 
   if (isLoading) return <div className="py-6"><LoadingSpinner /></div>
-  if (error) return <ErrorMessage message={`Could not load ${playerName}'s game log.`} />
+  if (error) return <ErrorMessage message={getErrorMessage(error, `Could not load ${playerName}'s game log.`)} />
   if (!log || rows.length === 0) {
     return <p className="py-4 text-xs text-gray-500 dark:text-gray-400">No games on record for {playerName} this season.</p>
   }

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, type JSX } from 'react'
 import { useGetHeatmapDataQuery, useGetLeagueSummaryQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import DataDateBadge from '../components/DataDateBadge'
 import StandingsRace from './StandingsRace'
 import ShootingStatsSection from '../components/ShootingStatsSection'
@@ -105,10 +106,12 @@ const Analytics = () => {
     setAppliedDates({})
   }
 
-  if (isLoading) return <LoadingSpinner />
-  if (error) return <ErrorMessage message="Failed to load analytics data" />
+  const isDateRangeActive = !!(appliedDates.startDate && appliedDates.endDate)
 
-  const isDateRangeActive = appliedDates.startDate && appliedDates.endDate
+  if (isLoading) return <LoadingSpinner />
+  // Same reasoning as Rankings: a bad custom range shouldn't take down the
+  // whole page — only a failure on the default (no range) query is fatal.
+  if (error && !isDateRangeActive) return <ErrorMessage message={getErrorMessage(error, 'Failed to load analytics data')} />
   const hasDateMismatch = heatmapData && isDateRangeActive && (
     (heatmapData.actual_start_date && heatmapData.actual_start_date !== heatmapData.date_range_start) ||
     (heatmapData.actual_end_date && heatmapData.actual_end_date !== heatmapData.date_range_end)
@@ -248,6 +251,12 @@ const Analytics = () => {
         {hasDateMismatch && (
           <div className="mb-3 px-4 py-2 bg-amber-50 dark:bg-gray-700 border border-amber-200 dark:border-gray-600 rounded-md text-sm text-amber-700 dark:text-amber-300">
             Note: closest available data used - showing {formatDate(heatmapData!.actual_start_date!)} - {formatDate(heatmapData!.actual_end_date!)}
+          </div>
+        )}
+
+        {error && isDateRangeActive && (
+          <div className="mb-3 px-4 py-2 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-md text-sm text-red-700 dark:text-red-300">
+            {getErrorMessage(error, 'Could not load analytics data for this date range.')}
           </div>
         )}
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useGetLeagueSummaryQuery, useGetRankingsQuery } from '../store/api/fant
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import DeadlineCountdown from '../components/DeadlineCountdown'
+import { getErrorMessage } from '../utils/errorMessage'
 
 const Dashboard = () => {
   const { data: summary, error: summaryError, isLoading: summaryLoading } = useGetLeagueSummaryQuery()
@@ -12,7 +13,7 @@ const Dashboard = () => {
   }
 
   if (summaryError || rankingsError) {
-    return <ErrorMessage message="Failed to load dashboard data" />
+    return <ErrorMessage message={getErrorMessage(summaryError ?? rankingsError, 'Failed to load dashboard data')} />
   }
 
   const topTeams = rankings?.averages_rankings.slice(0, 5) || []
@@ -23,26 +24,22 @@ const Dashboard = () => {
       <div className="bg-white rounded-lg shadow p-6">
         <h2 className="text-2xl font-bold text-gray-900 mb-4">League Overview</h2>
 
-        {(summary?.nba_avg_pace || summary?.nba_game_days_left !== undefined) && (
+        {summary && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-            {summary?.nba_avg_pace && (
-              <div className="bg-gradient-to-br from-amber-50 to-orange-50 p-5 rounded-xl border border-amber-200">
-                <h3 className="font-semibold text-amber-900 mb-1">NBA Avg Pace</h3>
-                <p className="text-3xl font-bold text-amber-600">
-                  {summary.nba_avg_pace.toFixed(1)}
-                </p>
-                <p className="text-xs text-amber-700 mt-2">games played per team</p>
-              </div>
-            )}
-            {summary?.nba_game_days_left !== undefined && summary.nba_game_days_left !== null && (
-              <div className="bg-gradient-to-br from-emerald-50 to-teal-50 p-5 rounded-xl border border-emerald-200">
-                <h3 className="font-semibold text-emerald-900 mb-1">Game Days Left</h3>
-                <p className="text-3xl font-bold text-emerald-600">
-                  {summary.nba_game_days_left}
-                </p>
-                <p className="text-xs text-emerald-700 mt-2">until regular season ends</p>
-              </div>
-            )}
+            <div className="bg-gradient-to-br from-amber-50 to-orange-50 p-5 rounded-xl border border-amber-200">
+              <h3 className="font-semibold text-amber-900 mb-1">NBA Avg Pace</h3>
+              <p className="text-3xl font-bold text-amber-600">
+                {(summary.nba_avg_pace ?? 0).toFixed(1)}
+              </p>
+              <p className="text-xs text-amber-700 mt-2">games played per team</p>
+            </div>
+            <div className="bg-gradient-to-br from-emerald-50 to-teal-50 p-5 rounded-xl border border-emerald-200">
+              <h3 className="font-semibold text-emerald-900 mb-1">Game Days Left</h3>
+              <p className="text-3xl font-bold text-emerald-600">
+                {summary.nba_game_days_left ?? 0}
+              </p>
+              <p className="text-xs text-emerald-700 mt-2">until regular season ends</p>
+            </div>
             <div className="bg-gradient-to-br from-blue-50 to-indigo-50 p-5 rounded-xl border border-blue-200">
               <h3 className="font-semibold text-blue-900 mb-1">Total Teams</h3>
               <p className="text-3xl font-bold text-blue-600">{summary?.total_teams}</p>

--- a/frontend/src/pages/DraftReport.tsx
+++ b/frontend/src/pages/DraftReport.tsx
@@ -3,6 +3,7 @@ import { usePersistedState } from '../hooks/usePersistedState'
 import { useGetDraftReportQuery, useGetAllPlayersQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import { FF_DRAFT_STEALS_BUSTS } from '../config/featureFlags'
 import { buildScoredPicks, buildTeamDiffRanking, topSteals, topBusts, MIN_GP_FOR_RANK, LOW_GP_MIN, type ScoredPick, type DraftBadge } from '../utils/draftReport'
 
@@ -120,7 +121,7 @@ export default function DraftReport() {
   }
 
   if (draftLoading || poolLoading) return <LoadingSpinner />
-  if (draftError || poolError) return <ErrorMessage message="Failed to load draft report." />
+  if (draftError || poolError) return <ErrorMessage message={getErrorMessage(draftError ?? poolError, 'Failed to load draft report.')} />
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">

--- a/frontend/src/pages/Estimator.tsx
+++ b/frontend/src/pages/Estimator.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useGetEstimatorResultsQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import type { TeamRankProbability, TeamRanking, TeamPrediction } from '../types/estimator'
 
 const STAT_LABELS: Record<string, string> = {
@@ -291,7 +292,7 @@ const Estimator = () => {
   const { data, error, isLoading } = useGetEstimatorResultsQuery()
 
   if (isLoading) return <LoadingSpinner />
-  if (error) return <ErrorMessage message="No estimator data available yet. Data is generated daily after NBA games are completed." />
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'No estimator data available yet. Data is generated daily after NBA games are completed.')} />
 
   if (!data) return <ErrorMessage message="No estimator data available yet." />
 

--- a/frontend/src/pages/FeatureStore.tsx
+++ b/frontend/src/pages/FeatureStore.tsx
@@ -7,6 +7,7 @@ import {
 } from '../store/api/fantasyApi';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorMessage from '../components/ErrorMessage';
+import { getErrorMessage } from '../utils/errorMessage';
 
 const fmt = (v: number | null) => {
   if (v == null) return '—';
@@ -98,7 +99,7 @@ export default function FeatureStore() {
   }, [list?.players, playerFilter]);
 
   if (isLoading) return <LoadingSpinner />;
-  if (error) return <ErrorMessage message="Failed to load the feature store. Is the backend running?" />;
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load the feature store. Is the backend running?')} />;
 
   return (
     <div className="p-4 sm:p-6 max-w-6xl mx-auto space-y-6">

--- a/frontend/src/pages/NbaTeams.tsx
+++ b/frontend/src/pages/NbaTeams.tsx
@@ -4,6 +4,7 @@ import { usePersistedState, usePersistedSetState } from '../hooks/usePersistedSt
 import { useGetNbaTeamsListQuery, useGetNbaTeamDepthChartQuery } from '../store/api/fantasyApi';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorMessage from '../components/ErrorMessage';
+import { getErrorMessage } from '../utils/errorMessage';
 import PlayerNameLink from '../components/PlayerNameLink';
 import type { DepthChartPosition } from '../types/api';
 import { applyDepthChartFilters } from '../utils/depthChartFilters';
@@ -102,7 +103,7 @@ function DepthChartView({ teamId }: { teamId: string }) {
   const [removeDuplicates, setRemoveDuplicates] = usePersistedState(`nbaTeams.${teamId}.removeDuplicates`, false);
 
   if (isLoading) return <LoadingSpinner />;
-  if (error) return <ErrorMessage message="Failed to load depth chart" />;
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load depth chart')} />;
   if (!data) return null;
 
   const toggleStatus = (status: string) => {
@@ -174,7 +175,7 @@ export default function NbaTeams() {
       {isLoading ? (
         <LoadingSpinner />
       ) : error ? (
-        <ErrorMessage message="Failed to load teams" />
+        <ErrorMessage message={getErrorMessage(error, 'Failed to load teams')} />
       ) : (
         <>
           <div className="mb-6">

--- a/frontend/src/pages/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile.tsx
@@ -6,6 +6,7 @@ import TimePeriodSelector from '../components/TimePeriodSelector'
 import { CoverageNotice } from '../components/DateRangePicker'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import PlayerTrendsCard from '../components/PlayerTrendsCard'
 import PlayerNextGameCard from '../components/PlayerNextGameCard'
 
@@ -91,7 +92,7 @@ const PlayerProfile = () => {
 
   if (!playerId) return <ErrorMessage message="Missing player id" />
   if (bioLoading) return <LoadingSpinner />
-  if (bioError || !bio) return <ErrorMessage message="Failed to load player" />
+  if (bioError || !bio) return <ErrorMessage message={getErrorMessage(bioError, 'Failed to load player')} />
 
   const stats = showAverages ? statsResponse?.averages : statsResponse?.totals
   const hasData = Boolean(statsResponse?.has_data && stats)
@@ -227,7 +228,7 @@ const PlayerProfile = () => {
             <LoadingSpinner />
           </div>
         ) : statsError ? (
-          <ErrorMessage message="Failed to load player stats" />
+          <ErrorMessage message={getErrorMessage(statsError, 'Failed to load player stats')} />
         ) : !hasData || !stats ? (
           <div className="py-12 text-center text-gray-400 text-sm">
             No stats available for this time range.

--- a/frontend/src/pages/PlayerRankings.tsx
+++ b/frontend/src/pages/PlayerRankings.tsx
@@ -3,6 +3,7 @@ import { usePersistedState } from '../hooks/usePersistedState'
 import { useGetAllPlayersQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import TimePeriodSelector from '../components/TimePeriodSelector'
 import { CoverageNotice } from '../components/DateRangePicker'
 import PlayerNameLink from '../components/PlayerNameLink'
@@ -152,7 +153,7 @@ export default function PlayerRankings() {
   }
 
   if (isLoading) return <LoadingSpinner />
-  if (error) return <ErrorMessage message="Failed to load players." />
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load players.')} />
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">

--- a/frontend/src/pages/Projections.tsx
+++ b/frontend/src/pages/Projections.tsx
@@ -40,10 +40,10 @@ function StatusDot({ status, reason }: { status: 'green' | 'amber' | 'red'; reas
 }
 
 function ProjectionRow({ matchup, integerMode }: { matchup: PlayerMatchup; integerMode: boolean }) {
-  const proj = matchup.projection!;
+  const proj = matchup.projection;
   const [predict] = usePredictProjectionMutation();
-  const [minutes, setMinutes] = useState(proj.default_minutes);
-  const [stats, setStats] = useState<ProjectionStats | null>(proj.stats);
+  const [minutes, setMinutes] = useState(proj?.default_minutes ?? 0);
+  const [stats, setStats] = useState<ProjectionStats | null>(proj?.stats ?? null);
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Re-sync when the underlying slate changes (opponent switches) or the
@@ -54,9 +54,9 @@ function ProjectionRow({ matchup, integerMode }: { matchup: PlayerMatchup; integ
   // background revalidation) can't silently wipe an adjusted slider.
   useEffect(() => {
     clearTimeout(timer.current);
-    setMinutes(proj.default_minutes);
-    setStats(proj.stats);
-  }, [matchup.opponent, proj.default_minutes]);
+    setMinutes(proj?.default_minutes ?? 0);
+    setStats(proj?.stats ?? null);
+  }, [matchup.opponent, proj?.default_minutes]);
 
   const onSlider = (v: number) => {
     setMinutes(v);
@@ -76,21 +76,24 @@ function ProjectionRow({ matchup, integerMode }: { matchup: PlayerMatchup; integ
   // trip; also cancels any pending re-predict so it can't overwrite them).
   const resetToDefault = () => {
     clearTimeout(timer.current);
-    setMinutes(proj.default_minutes);
-    setStats(proj.stats);
+    setMinutes(proj?.default_minutes ?? 0);
+    setStats(proj?.stats ?? null);
   };
-  const isAdjusted = Math.round(minutes) !== Math.round(proj.default_minutes);
+  const isAdjusted = Math.round(minutes) !== Math.round(proj?.default_minutes ?? 0);
 
-  if (proj.status === 'red' || !stats) {
+  // No projection at all (e.g. a rookie with no feature-store history yet) is
+  // the same "not enough data" case as a red-status/no-stats projection —
+  // still show the player and their game, just without projected numbers.
+  if (!proj || proj.status === 'red' || !stats) {
     return (
       <tr className="border-t border-gray-100 dark:border-gray-800">
         <td className="px-3 py-2 whitespace-nowrap font-medium text-gray-900 dark:text-gray-100 sticky left-0 z-10 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700">
-          <StatusDot status="red" reason={proj.reason} /> <span className="ml-1">{matchup.player_name}</span> <InjuryBadge status={matchup.injury_status} />
+          <StatusDot status="red" reason={proj?.reason} /> <span className="ml-1">{matchup.player_name}</span> <InjuryBadge status={matchup.injury_status} />
         </td>
         <td className="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-gray-400">
           {matchup.pro_team} {matchup.is_home ? 'vs' : '@'} {matchup.opponent}
         </td>
-        <td colSpan={9} className="px-3 py-2 italic text-gray-400 text-sm" title={proj.reason}>not enough data</td>
+        <td colSpan={9} className="px-3 py-2 italic text-gray-400 text-sm" title={proj?.reason}>not enough data</td>
       </tr>
     );
   }
@@ -170,7 +173,6 @@ export default function Projections() {
   const isLiveSlate = slateDate === '' && !!currentSlateDate;
 
   const withGames = useMemo(() => matchups.filter((m) => {
-    if (m.projection == null) return false;
     if (!m.on_depth_chart) return false;
     if (isLiveSlate && m.injury_status === 'Out') return false;
     return true;

--- a/frontend/src/pages/Rankings.tsx
+++ b/frontend/src/pages/Rankings.tsx
@@ -3,6 +3,7 @@ import { useGetRankingsQuery, useGetLeagueSummaryQuery } from '../store/api/fant
 import { Link } from 'react-router'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import DataDateBadge from '../components/DataDateBadge'
 import type { RankingStats } from '../types/api'
 import { todayIso, getDateNDaysAgo } from '../utils/dateRange'
@@ -67,8 +68,13 @@ const Rankings = () => {
     }
   }
 
+  const isDateRangeActive = !!(appliedDates.startDate && appliedDates.endDate)
+
   if (isLoading || summaryLoading) return <LoadingSpinner />
-  if (error) return <ErrorMessage message="Failed to load rankings" />
+  // A custom-range failure (e.g. no data for that window) shouldn't blow away
+  // the whole page — the date controls and default-season data stay usable;
+  // only a failure on the default (no range) query is page-fatal.
+  if (error && !isDateRangeActive) return <ErrorMessage message={getErrorMessage(error, 'Failed to load rankings')} />
 
   const rawRankings = mode === 'averages'
     ? (data?.averages_rankings || [])
@@ -102,7 +108,6 @@ const Rankings = () => {
     { key: 'gp', label: 'GP', sortable: true },
   ]
 
-  const isDateRangeActive = appliedDates.startDate && appliedDates.endDate
   const hasDateMismatch = data && isDateRangeActive && (
     (data.actual_start_date && data.actual_start_date !== data.date_range_start) ||
     (data.actual_end_date && data.actual_end_date !== data.date_range_end)
@@ -115,30 +120,26 @@ const Rankings = () => {
           <DataDateBadge dataDate={data.data_date} />
         </div>
       )}
-      {(summary?.nba_avg_pace || summary?.nba_game_days_left !== undefined) && (
+      {summary && (
         <div className="mb-6 grid grid-cols-2 gap-3 sm:flex sm:justify-center sm:gap-4">
-          {summary?.nba_avg_pace && (
-            <div className="flex flex-col items-center gap-2 bg-white dark:bg-gray-800 px-3 py-2 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow sm:flex-row sm:gap-3 sm:px-5 sm:py-3">
-              <div className="flex items-center justify-center w-8 h-8 bg-amber-100 rounded-full sm:w-10 sm:h-10">
-                <span className="text-lg sm:text-xl">⚡</span>
-              </div>
-              <div className="text-center sm:text-left">
-                <div className="text-xs text-gray-500 font-medium">NBA Avg Pace</div>
-                <div className="text-xl font-bold text-gray-900 sm:text-2xl">{summary.nba_avg_pace.toFixed(1)}</div>
-              </div>
+          <div className="flex flex-col items-center gap-2 bg-white dark:bg-gray-800 px-3 py-2 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow sm:flex-row sm:gap-3 sm:px-5 sm:py-3">
+            <div className="flex items-center justify-center w-8 h-8 bg-amber-100 rounded-full sm:w-10 sm:h-10">
+              <span className="text-lg sm:text-xl">⚡</span>
             </div>
-          )}
-          {summary?.nba_game_days_left !== undefined && summary.nba_game_days_left !== null && (
-            <div className="flex flex-col items-center gap-2 bg-white dark:bg-gray-800 px-3 py-2 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow sm:flex-row sm:gap-3 sm:px-5 sm:py-3">
-              <div className="flex items-center justify-center w-8 h-8 bg-emerald-100 rounded-full sm:w-10 sm:h-10">
-                <span className="text-lg sm:text-xl">📅</span>
-              </div>
-              <div className="text-center sm:text-left">
-                <div className="text-xs text-gray-500 font-medium">Days Remaining</div>
-                <div className="text-xl font-bold text-gray-900 sm:text-2xl">{summary.nba_game_days_left}</div>
-              </div>
+            <div className="text-center sm:text-left">
+              <div className="text-xs text-gray-500 font-medium">NBA Avg Pace</div>
+              <div className="text-xl font-bold text-gray-900 sm:text-2xl">{(summary.nba_avg_pace ?? 0).toFixed(1)}</div>
             </div>
-          )}
+          </div>
+          <div className="flex flex-col items-center gap-2 bg-white dark:bg-gray-800 px-3 py-2 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow sm:flex-row sm:gap-3 sm:px-5 sm:py-3">
+            <div className="flex items-center justify-center w-8 h-8 bg-emerald-100 rounded-full sm:w-10 sm:h-10">
+              <span className="text-lg sm:text-xl">📅</span>
+            </div>
+            <div className="text-center sm:text-left">
+              <div className="text-xs text-gray-500 font-medium">Days Remaining</div>
+              <div className="text-xl font-bold text-gray-900 sm:text-2xl">{summary.nba_game_days_left ?? 0}</div>
+            </div>
+          </div>
         </div>
       )}
 
@@ -255,6 +256,12 @@ const Rankings = () => {
         {hasDateMismatch && (
           <div className="px-6 py-2 bg-amber-50 dark:bg-gray-700 border-b border-amber-200 dark:border-gray-600 text-sm text-amber-700 dark:text-amber-300">
             Note: closest available data used - showing {formatDate(data!.actual_start_date!)} - {formatDate(data!.actual_end_date!)}
+          </div>
+        )}
+
+        {error && isDateRangeActive && (
+          <div className="px-6 py-2 bg-red-50 dark:bg-red-900/30 border-b border-red-200 dark:border-red-800 text-sm text-red-700 dark:text-red-300">
+            {getErrorMessage(error, 'Could not load rankings for this date range.')}
           </div>
         )}
 

--- a/frontend/src/pages/Shots.tsx
+++ b/frontend/src/pages/Shots.tsx
@@ -3,6 +3,7 @@ import { useGetLeagueShotsQuery } from '../store/api/fantasyApi'
 import { Link } from 'react-router'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import DataDateBadge from '../components/DataDateBadge'
 import type { TeamShotStats } from '../types/api'
 
@@ -47,7 +48,7 @@ const Shots = () => {
   }
 
   if (isLoading) return <LoadingSpinner />
-  if (error) return <ErrorMessage message="Failed to load shots data" />
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load shots data')} />
 
   const rawShots = data?.shots || []
   

--- a/frontend/src/pages/StandingsRace.tsx
+++ b/frontend/src/pages/StandingsRace.tsx
@@ -14,6 +14,7 @@ import {
 import { useGetRankingsOverTimeQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import type { OverTimeSource, TeamTimeSeriesPoint } from '../types/api'
 
 const TEAM_COLORS = [
@@ -359,7 +360,7 @@ const StandingsRace = () => {
           </div>
 
           {isLoading && <LoadingSpinner />}
-          {error && <ErrorMessage message="Failed to load standings history" />}
+          {error && <ErrorMessage message={getErrorMessage(error, 'Failed to load standings history')} />}
           {!isLoading && !error && chartData.length === 0 && (
             <p className="text-gray-500 dark:text-gray-400 text-sm text-center py-8">No data available yet. Stats accumulate daily.</p>
           )}

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -6,6 +6,7 @@ import { useGetTeamDetailQuery, useGetLeagueSummaryQuery, useGetMatchupsTodayQue
 import type { TimePeriod, PlayerMatchup, CustomDateRange } from '../types/api'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import TimePeriodSelector from '../components/TimePeriodSelector'
 import { CoverageNotice } from '../components/DateRangePicker'
 import DataDateBadge from '../components/DataDateBadge'
@@ -107,7 +108,7 @@ const TeamDetail = () => {
   }
 
   if (isLoading) return <LoadingSpinner />
-  if (error) return <ErrorMessage message="Failed to load team details" />
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load team details')} />
   if (!team_detail) return <ErrorMessage message="Team not found" />
 
   const columns = [

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -2,12 +2,13 @@ import { Link } from 'react-router'
 import { useGetTeamsListQuery } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 
 const Teams = () => {
   const { data: teams, error, isLoading } = useGetTeamsListQuery()
 
   if (isLoading) return <LoadingSpinner />
-  if (error) return <ErrorMessage message="Failed to load teams" />
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load teams')} />
   if (!teams || teams.length === 0) return <ErrorMessage message="No teams found" />
 
   return (

--- a/frontend/src/pages/Trade/components/FreeAgentSection.tsx
+++ b/frontend/src/pages/Trade/components/FreeAgentSection.tsx
@@ -4,6 +4,7 @@ import { PlayerStatsCard } from './PlayerStatsCard';
 import { PlayerSearchInput } from '../../../components/PlayerSearchInput';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import ErrorMessage from '../../../components/ErrorMessage';
+import { getErrorMessage } from '../../../utils/errorMessage';
 
 interface FreeAgentSectionProps {
   players: Player[];
@@ -44,7 +45,7 @@ export const FreeAgentSection: React.FC<FreeAgentSectionProps> = ({
         {isLoading ? (
           <LoadingSpinner />
         ) : error ? (
-          <ErrorMessage message="Failed to load free agents" />
+          <ErrorMessage message={getErrorMessage(error, 'Failed to load free agents')} />
         ) : (
           <PlayerSearchInput
             players={players}

--- a/frontend/src/pages/Trade/components/TeamTradeSection.tsx
+++ b/frontend/src/pages/Trade/components/TeamTradeSection.tsx
@@ -5,6 +5,7 @@ import { PlayerDropdown } from './PlayerDropdown';
 import { TeamRankingsBar } from './TeamRankingsBar';
 import LoadingSpinner from '../../../components/LoadingSpinner';
 import ErrorMessage from '../../../components/ErrorMessage';
+import { getErrorMessage } from '../../../utils/errorMessage';
 
 interface TeamTradeSectionProps {
   title: string;
@@ -60,7 +61,7 @@ export const TeamTradeSection: React.FC<TeamTradeSectionProps> = ({
         {isLoadingTeams ? (
           <LoadingSpinner />
         ) : teamsError ? (
-          <ErrorMessage message="Failed to load teams" />
+          <ErrorMessage message={getErrorMessage(teamsError, 'Failed to load teams')} />
         ) : (
           <select
             value={selectedTeam?.team_id ?? ''}
@@ -96,7 +97,7 @@ export const TeamTradeSection: React.FC<TeamTradeSectionProps> = ({
           {isLoadingPlayers ? (
             <LoadingSpinner />
           ) : playersError ? (
-            <ErrorMessage message="Failed to load players" />
+            <ErrorMessage message={getErrorMessage(playersError, 'Failed to load players')} />
           ) : (
             <PlayerDropdown
               players={players}

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -8,6 +8,7 @@ import {
 } from '../store/api/fantasyApi'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
 import TrendGameLogChart from '../components/TrendGameLogChart'
 import InfoTip from '../components/InfoTip'
 import DateRangePicker from '../components/DateRangePicker'
@@ -825,7 +826,7 @@ export default function Trends() {
           </div>
 
           {activeQuery.isLoading && <LoadingSpinner />}
-          {activeQuery.error && <ErrorMessage message="Failed to load trends data." />}
+          {activeQuery.error && <ErrorMessage message={getErrorMessage(activeQuery.error, 'Failed to load trends data.')} />}
 
           {!activeQuery.isLoading && !activeQuery.error && (
             <>

--- a/frontend/src/pages/minigames/HangmanGame.tsx
+++ b/frontend/src/pages/minigames/HangmanGame.tsx
@@ -4,6 +4,7 @@ import LeaderboardCard from '../../components/minigames/LeaderboardCard'
 import NameEntryModal from '../../components/minigames/NameEntryModal'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import ErrorMessage from '../../components/ErrorMessage'
+import { getErrorMessage } from '../../utils/errorMessage'
 import { useMinigamePlayers } from '../../minigames/useMinigamePlayers'
 import { pickRandomPlayer } from '../../minigames/players'
 import { createStreakState, incrementHints, onRoundLoss, onRoundWin } from '../../minigames/streak'
@@ -147,7 +148,7 @@ export default function HangmanGame() {
   }
 
   if (isLoading) return <LoadingSpinner />
-  if (error || !players.length) return <ErrorMessage message="Failed to load players" />
+  if (error || !players.length) return <ErrorMessage message={getErrorMessage(error, 'Failed to load players')} />
 
   return (
     <div className="max-w-5xl mx-auto px-4 pb-12">

--- a/frontend/src/pages/minigames/NowYouSeeMeGame.tsx
+++ b/frontend/src/pages/minigames/NowYouSeeMeGame.tsx
@@ -6,6 +6,7 @@ import PlayerPicker from '../../components/minigames/PlayerPicker'
 import TimerBar from '../../components/minigames/TimerBar'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import ErrorMessage from '../../components/ErrorMessage'
+import { getErrorMessage } from '../../utils/errorMessage'
 import { useMinigamePlayers } from '../../minigames/useMinigamePlayers'
 import { pickRandomPlayerWithPhoto, playersWithPhotos } from '../../minigames/players'
 import { createStreakState, onRoundLoss, onRoundWin } from '../../minigames/streak'
@@ -62,7 +63,7 @@ export default function NowYouSeeMeGame() {
   }
 
   if (isLoading) return <LoadingSpinner />
-  if (error || !players.length) return <ErrorMessage message="Failed to load players" />
+  if (error || !players.length) return <ErrorMessage message={getErrorMessage(error, 'Failed to load players')} />
   if (!photoPlayers.length) return <ErrorMessage message="No players with photos available" />
 
   return (

--- a/frontend/src/pages/minigames/WhoAmIGame.tsx
+++ b/frontend/src/pages/minigames/WhoAmIGame.tsx
@@ -9,6 +9,7 @@ import {
 import PlayerPicker from '../../components/minigames/PlayerPicker'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import ErrorMessage from '../../components/ErrorMessage'
+import { getErrorMessage } from '../../utils/errorMessage'
 import { useConferenceDivisionTree } from '../../minigames/conferenceDivisionTree'
 import { useMinigamePlayers } from '../../minigames/useMinigamePlayers'
 import { pickRandomPlayer } from '../../minigames/players'
@@ -151,7 +152,7 @@ export default function WhoAmIGame() {
   }
 
   if (isLoading) return <LoadingSpinner />
-  if (error || !players.length) return <ErrorMessage message="Failed to load players" />
+  if (error || !players.length) return <ErrorMessage message={getErrorMessage(error, 'Failed to load players')} />
 
   return (
     <div className="max-w-6xl mx-auto px-4 pb-12">

--- a/frontend/src/pages/minigames/WhoHePlayForGame.tsx
+++ b/frontend/src/pages/minigames/WhoHePlayForGame.tsx
@@ -6,6 +6,7 @@ import TeamPicker from '../../components/minigames/TeamPicker'
 import TimerBar from '../../components/minigames/TimerBar'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import ErrorMessage from '../../components/ErrorMessage'
+import { getErrorMessage } from '../../utils/errorMessage'
 import { useMinigamePlayers } from '../../minigames/useMinigamePlayers'
 import { buildNbaTeamOptions, pickRandomPlayer } from '../../minigames/players'
 import { createStreakState, onRoundLoss, onRoundWin } from '../../minigames/streak'
@@ -62,7 +63,7 @@ export default function WhoHePlayForGame() {
   }
 
   if (isLoading) return <LoadingSpinner />
-  if (error || !players.length) return <ErrorMessage message="Failed to load players" />
+  if (error || !players.length) return <ErrorMessage message={getErrorMessage(error, 'Failed to load players')} />
 
   return (
     <div className="max-w-5xl mx-auto px-4 pb-12">

--- a/frontend/src/utils/__tests__/errorMessage.test.ts
+++ b/frontend/src/utils/__tests__/errorMessage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { getErrorMessage } from '../errorMessage';
+
+const FALLBACK = 'Failed to load data.';
+
+describe('getErrorMessage', () => {
+  it('returns the detail from a 503 response', () => {
+    const error = { status: 503, data: { detail: 'No data available yet for this league/season.' } };
+    expect(getErrorMessage(error, FALLBACK)).toBe('No data available yet for this league/season.');
+  });
+
+  it('falls back to a specific 503 message when the response has no detail', () => {
+    const error = { status: 503, data: {} };
+    expect(getErrorMessage(error, FALLBACK)).toBe('No data available yet for this league/season.');
+  });
+
+  it('returns the detail from a 404 response', () => {
+    const error = { status: 404, data: { detail: 'Team with ID 99 not found' } };
+    expect(getErrorMessage(error, FALLBACK)).toBe('Team with ID 99 not found');
+  });
+
+  it('falls back to the generic fallback on a 404 with no detail', () => {
+    const error = { status: 404, data: {} };
+    expect(getErrorMessage(error, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback on a 500 response, ignoring any detail', () => {
+    const error = { status: 500, data: { detail: 'Internal server error' } };
+    expect(getErrorMessage(error, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback for a network/fetch error (string status)', () => {
+    const error = { status: 'FETCH_ERROR', error: 'Failed to fetch' };
+    expect(getErrorMessage(error, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback for a SerializedError (RTK thunk rejection)', () => {
+    const error = { name: 'Error', message: 'Something broke' };
+    expect(getErrorMessage(error, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback for null/undefined errors', () => {
+    expect(getErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+    expect(getErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback when detail is present but not a string', () => {
+    const error = { status: 503, data: { detail: { nested: true } } };
+    expect(getErrorMessage(error, FALLBACK)).toBe('No data available yet for this league/season.');
+  });
+});

--- a/frontend/src/utils/errorMessage.ts
+++ b/frontend/src/utils/errorMessage.ts
@@ -1,0 +1,32 @@
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
+
+type ApiError = FetchBaseQueryError | SerializedError | unknown
+
+const isFetchBaseQueryError = (error: ApiError): error is FetchBaseQueryError =>
+  typeof error === 'object' && error !== null && 'status' in error
+
+const extractDetail = (error: FetchBaseQueryError): string | undefined => {
+  const data = error.data
+  if (data && typeof data === 'object' && 'detail' in data && typeof (data as { detail: unknown }).detail === 'string') {
+    return (data as { detail: string }).detail
+  }
+  return undefined
+}
+
+/**
+ * Backend distinguishes 503 (no data yet, e.g. season hasn't started / league
+ * not synced) from 404/500 — surface that instead of always showing the same
+ * generic fallback string regardless of what actually happened.
+ */
+export const getErrorMessage = (error: ApiError, fallback: string): string => {
+  if (!isFetchBaseQueryError(error)) return fallback
+
+  if (error.status === 503) {
+    return extractDetail(error) ?? 'No data available yet for this league/season.'
+  }
+  if (error.status === 404) {
+    return extractDetail(error) ?? fallback
+  }
+  return fallback
+}


### PR DESCRIPTION
## Summary
- Adds `league_id`/`season_id` scoping to the 6 tables that previously mixed data across leagues/seasons (team snapshots, rankings averages/totals, estimator predictions/rankings/probabilities) — the DB fallback no longer serves one league's stale data under a different league/season.
- Fixes several bugs only visible when a configured season/league has no games played yet:
  - players list crashed instead of showing real players at 0 GP
  - Decimal/float crash in the DB-fallback path (heatmap)
  - team standings/rankings crashed instead of showing a real all-tied board
  - matchup quality hid players entirely instead of falling back to neutral defense ranks
  - a race condition where two callers closed the shared `NBAStatsService` httpx client mid-flight
- Derives the NBA regular-season start/end dates from ESPN's schedule at backend startup instead of a hand-maintained date that drifts every year (`SEASON_START` is now a fallback, not the primary source).
- Previews the season opener's matchups/projections before the season actually starts, including rookies with no feature-store history yet (shown as "not enough data" instead of dropped).
- Surfaces real backend error status (503/404) in the frontend instead of the same generic "failed to load" message everywhere.

## Test plan
- [ ] Manually verified against both the real league (season 2026, ended) and a demo league (season 2027, not started) — full endpoint sweep clean on both, no regressions.
- [ ] `backend/migrations/add_league_season_scope.sql` already applied manually to the shared Neon DB (not included in this PR per usual migration workflow — DB migrations are applied manually, not committed as executable in CI).
- [ ] `npx tsc --noEmit` clean (frontend pre-push hook).
- [ ] No automated backend/frontend tests added in this PR — flagging for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)