### PR TITLE
test: fix CI failures and add coverage for league/season scoping PR

### DIFF
--- a/backend/tests/routes/test_analytics.py
+++ b/backend/tests/routes/test_analytics.py
@@ -6,6 +6,7 @@ from app.models import HeatmapData
 from app.models.base import Team
 from app.models import RankingsOverTimeResponse
 from app.services.db_service import DBService
+from app.config import settings
 
 
 def test_get_heatmap(test_client):
@@ -38,7 +39,7 @@ def test_get_over_time_snapshot_source(test_client):
     try:
         response = test_client.get("/api/analytics/over-time?source=snapshot")
         assert response.status_code == 200
-        inst.get_snapshot_over_time.assert_awaited_once_with(None)
+        inst.get_snapshot_over_time.assert_awaited_once_with(None, settings.league_id, settings.season_id)
     finally:
         app.dependency_overrides.pop(DBService, None)
 

--- a/backend/tests/routes/test_trends_route.py
+++ b/backend/tests/routes/test_trends_route.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.exceptions import DataSourceError, ResourceNotFoundError
 from app.models.trend_models import (
     GameLogEntry,
     GameLogResponse,
@@ -255,3 +256,29 @@ def test_in_range_off_preset_window_days_is_honoured(mock_services):
     assert resp.status_code == 200
     svc.get_minutes_movers.assert_awaited_once()
     assert svc.get_minutes_movers.call_args.args[1] == 21
+
+
+class TestGlobalExceptionHandlers:
+    """trends routes don't catch DataSourceError/ResourceNotFoundError
+    themselves, so they're a good probe for main.py's app-wide handlers that
+    map these to 503/404 instead of a generic 500."""
+
+    def test_data_source_error_surfaces_as_503(self, mock_services):
+        _, provider = mock_services
+        provider.get_players_df = AsyncMock(side_effect=DataSourceError("ESPN unavailable"))
+        client = TestClient(app)
+
+        resp = client.get('/api/trends/regression')
+
+        assert resp.status_code == 503
+        assert resp.json()['detail'] == "ESPN unavailable"
+
+    def test_resource_not_found_error_surfaces_as_404(self, mock_services):
+        _, provider = mock_services
+        provider.get_players_df = AsyncMock(side_effect=ResourceNotFoundError("No players found"))
+        client = TestClient(app)
+
+        resp = client.get('/api/trends/regression')
+
+        assert resp.status_code == 404
+        assert resp.json()['detail'] == "No players found"

--- a/backend/tests/services/test_data_provider.py
+++ b/backend/tests/services/test_data_provider.py
@@ -242,3 +242,86 @@ async def test_get_all_dataframes_tuple(provider):
 
     t, a, r = await provider.get_all_dataframes()
     assert len(t) == len(a) == len(r)
+
+
+@pytest.mark.asyncio
+async def test_fallback_from_db_raises_when_no_rows(provider):
+    """No DB fallback data for this league/season is a real 'nothing to
+    serve' state, not a generic crash — the route layer maps DataSourceError
+    to 503 so the frontend can show a specific message."""
+    provider.db_service.get_latest_snapshot = AsyncMock(return_value=(None, []))
+
+    with pytest.raises(DataSourceError, match="ESPN unavailable and no DB fallback data"):
+        await provider._fallback_from_db()
+
+
+@pytest.mark.asyncio
+async def test_fallback_from_db_casts_decimal_columns_to_float(provider):
+    """asyncpg returns Decimal for NUMERIC columns; the DB-fallback totals
+    DataFrame must be uniformly float (like the ESPN path) so downstream
+    consumers (e.g. the heatmap) don't crash mixing Decimal and float."""
+    from decimal import Decimal
+
+    rows = [{
+        "team_id": 1, "team_name": "T", "date": "2025-01-01",
+        "fg_pct": Decimal("46.7"), "ft_pct": Decimal("74.9"),
+        "three_pm": Decimal("15"), "reb": Decimal("43"), "ast": Decimal("28"),
+        "stl": Decimal("9"), "blk": Decimal("4"), "pts": Decimal("112"),
+        "gp": Decimal("10"), "fgm": Decimal("40"), "fga": Decimal("85"),
+        "ftm": Decimal("20"), "fta": Decimal("27"),
+    }]
+    provider.db_service.get_latest_snapshot = AsyncMock(return_value=("2025-01-01", rows))
+
+    df = await provider._fallback_from_db()
+
+    for col in ["FG%", "FT%", "3PM", "REB", "AST", "STL", "BLK", "PTS", "GP"]:
+        assert df[col].dtype == float, f"{col} should be cast to float, got {df[col].dtype}"
+
+
+@pytest.mark.asyncio
+async def test_get_team_names_reuses_cached_raw_payload(provider):
+    """Reuses the raw standings payload already cached by get_totals_df —
+    doesn't make an extra ESPN request when one is already in memory."""
+    provider.cache_manager.totals_cache["raw"] = {"teams": [{"id": 1, "name": "Alpha"}]}
+    provider.data_transformer.raw_standings_to_team_names.return_value = [
+        {"team_id": 1, "team_name": "Alpha"}
+    ]
+    provider._client.get = AsyncMock()
+
+    result = await provider.get_team_names()
+
+    provider._client.get.assert_not_awaited()
+    provider.data_transformer.raw_standings_to_team_names.assert_called_once_with(
+        {"teams": [{"id": 1, "name": "Alpha"}]}
+    )
+    assert result == [{"team_id": 1, "team_name": "Alpha"}]
+
+
+@pytest.mark.asyncio
+async def test_get_team_names_fetches_fresh_when_nothing_cached(provider):
+    """No cached payload yet (e.g. totals were never successfully fetched
+    this run, as in preseason) -> a fresh standings request is made."""
+    provider.cache_manager.totals_cache["raw"] = None
+    raw_payload = {"teams": [{"id": 2, "name": "Beta"}]}
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = raw_payload
+    provider._client.get = AsyncMock(return_value=mock_resp)
+    provider.data_transformer.raw_standings_to_team_names.return_value = [
+        {"team_id": 2, "team_name": "Beta"}
+    ]
+
+    result = await provider.get_team_names()
+
+    provider._client.get.assert_awaited_once()
+    mock_resp.raise_for_status.assert_called_once()
+    assert provider.cache_manager.totals_cache["raw"] == raw_payload
+    assert result == [{"team_id": 2, "team_name": "Beta"}]
+
+
+@pytest.mark.asyncio
+async def test_get_team_names_raises_data_source_error_on_fetch_failure(provider):
+    provider.cache_manager.totals_cache["raw"] = None
+    provider._client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+    with pytest.raises(DataSourceError, match="Error fetching team names"):
+        await provider.get_team_names()

--- a/backend/tests/services/test_data_transformer.py
+++ b/backend/tests/services/test_data_transformer.py
@@ -92,6 +92,67 @@ class TestRawStandingsToTotals:
         with pytest.raises(Exception, match="Error transforming ESPN standings"):
             transformer.raw_standings_to_totals_df({"teams": []})
 
+    def test_team_without_values_by_stat_gets_zero_row(self, transformer):
+        """ESPN omits valuesByStat entirely before any games are played
+        (preseason) — that's a real zero-stat team, not a missing one, so it
+        must be synthesized rather than silently dropped."""
+        payload = {"teams": [{"id": 5, "name": " New Team "}]}
+
+        df = transformer.raw_standings_to_totals_df(payload)
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["team_id"] == 5
+        assert row["team_name"] == "New Team"
+        assert row["PTS"] == 0
+        assert row["GP"] == 0
+
+    def test_mix_of_teams_with_and_without_stats(self, transformer):
+        """A preseason league can have some teams already synced and others
+        not — both must survive in the same DataFrame."""
+        payload = _standings_payload(team_ids=(1,))
+        payload["teams"].append({"id": 2, "name": "No Stats Yet"})
+
+        df = transformer.raw_standings_to_totals_df(payload)
+
+        assert set(df["team_id"].tolist()) == {1, 2}
+        no_stats_row = df[df["team_id"] == 2].iloc[0]
+        assert no_stats_row["PTS"] == 0
+
+
+class TestRawStandingsToTeamNames:
+    def test_extracts_id_and_stripped_name(self, transformer):
+        payload = {"teams": [{"id": 1, "name": " Team Alpha "}, {"id": 2, "name": "Team Beta"}]}
+
+        result = transformer.raw_standings_to_team_names(payload)
+
+        assert result == [
+            {"team_id": 1, "team_name": "Team Alpha"},
+            {"team_id": 2, "team_name": "Team Beta"},
+        ]
+
+    def test_independent_of_values_by_stat(self, transformer):
+        """Team identity exists on ESPN's side even before any games are
+        played, unlike per-team stat totals — no valuesByStat required."""
+        payload = {"teams": [{"id": 9, "name": "Preseason Team"}]}
+
+        result = transformer.raw_standings_to_team_names(payload)
+
+        assert result == [{"team_id": 9, "team_name": "Preseason Team"}]
+
+    def test_skips_teams_missing_id_or_name(self, transformer):
+        payload = {"teams": [{"id": 1, "name": "Has Both"}, {"name": "Missing Id"}, {"id": 2, "name": ""}]}
+
+        result = transformer.raw_standings_to_team_names(payload)
+
+        assert result == [{"team_id": 1, "team_name": "Has Both"}]
+
+    def test_missing_teams_key_returns_empty_list(self, transformer):
+        assert transformer.raw_standings_to_team_names({}) == []
+
+    def test_none_input_returns_empty_list(self, transformer):
+        assert transformer.raw_standings_to_team_names(None) == []
+
 
 class TestTotalsToAverages:
     def test_divides_by_gp(self, transformer, sample_totals_df):
@@ -115,7 +176,71 @@ class TestRawPlayersToDf:
             transformer.raw_players_to_df({"teams": []})
 
 
+def _player_entry(player_id, name, team_id=1, stats=None, season_id=2026):
+    return {
+        "player": {
+            "id": player_id,
+            "fullName": name,
+            "proTeamId": 13,
+            "injured": False,
+            "eligibleSlots": [0, 1],
+            "stats": [
+                {
+                    "scoringPeriodId": 0,
+                    "statSplitTypeId": 0,
+                    "seasonId": season_id,
+                    "stats": stats if stats is not None else {},
+                }
+            ],
+        },
+        "status": "ONTEAM",
+        "onTeamId": team_id,
+        "ratings": {},
+    }
+
+
 class TestRawAllPlayersToDf:
     def test_invalid_raises(self, transformer):
         with pytest.raises(Exception, match="Error transforming ESPN players"):
             transformer.raw_all_players_to_df({})
+
+    def test_success_maps_stat_columns(self, transformer):
+        payload = {"players": [_player_entry(101, "Player A", stats={
+            "0": 25.0, "1": 1.2, "2": 1.5, "3": 4.0, "6": 8.0,
+            "13": 9.0, "14": 18.0, "15": 5.0, "16": 6.0, "17": 2.0,
+            "19": 0.5, "20": 0.83, "42": 70, "40": 32.0,
+        })]}
+
+        df = transformer.raw_all_players_to_df(payload)
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["Name"] == "Player A"
+        assert row["player_id"] == 101
+        assert row["PTS"] == 25.0
+        assert row["GP"] == 70
+
+    def test_zero_gp_stat_split_synthesizes_zero_row_instead_of_dropping_player(self, transformer):
+        """ESPN tags the current-season split before any games are played but
+        leaves 'stats' empty — that's a real 0 GP row, not a missing player."""
+        payload = {"players": [_player_entry(102, "Rookie R", stats={})]}
+
+        df = transformer.raw_all_players_to_df(payload)
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["Name"] == "Rookie R"
+        assert row["GP"] == 0
+        assert row["PTS"] == 0
+
+    def test_mix_of_players_with_and_without_stats(self, transformer):
+        payload = {"players": [
+            _player_entry(101, "Veteran V", stats={"0": 10.0, "42": 5}),
+            _player_entry(102, "Rookie R", stats={}),
+        ]}
+
+        df = transformer.raw_all_players_to_df(payload)
+
+        assert len(df) == 2
+        rookie_row = df[df["Name"] == "Rookie R"].iloc[0]
+        assert rookie_row["GP"] == 0

--- a/backend/tests/services/test_db_service.py
+++ b/backend/tests/services/test_db_service.py
@@ -311,12 +311,14 @@ async def test_get_rankings_over_time_joins_gp(db_service, monkeypatch):
     conn = FakeConn(fetch_result=rows)
     monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=FakePool(conn)))
 
-    result = await db_service.get_rankings_over_time("team_rankings_totals", None)
+    result = await db_service.get_rankings_over_time("team_rankings_totals", None, 1234567890, 2026)
 
     assert result == rows
     query = conn.fetch.call_args[0][0]
     assert "LEFT JOIN team_daily_snapshot" in query
     assert "s.gp" in query
+    query_args = conn.fetch.call_args[0]
+    assert query_args[1:] == (1234567890, 2026)
 
 
 @pytest.mark.asyncio
@@ -324,11 +326,11 @@ async def test_get_rankings_over_time_with_team_ids_joins_gp(db_service, monkeyp
     conn = FakeConn(fetch_result=[])
     monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=FakePool(conn)))
 
-    await db_service.get_rankings_over_time("team_rankings_averages", [1, 2])
+    await db_service.get_rankings_over_time("team_rankings_averages", [1, 2], 1234567890, 2026)
 
     args = conn.fetch.call_args[0]
     assert "LEFT JOIN team_daily_snapshot" in args[0]
-    assert args[1] == [1, 2]
+    assert args[1:] == (1234567890, 2026, [1, 2])
 
 
 @pytest.mark.asyncio
@@ -342,10 +344,12 @@ async def test_upsert_rankings_averages_preserves_tie_fraction(db_service, monke
         "TOTAL_POINTS": 52.0,
     }])
 
-    await db_service.upsert_rankings_averages(5, df)
+    await db_service.upsert_rankings_averages(5, df, 1234567890, 2026)
 
     params = conn.executemany.call_args[0][1][0]
-    assert params[4] == 6.5
+    assert params[0] == 1234567890
+    assert params[1] == 2026
+    assert params[6] == 6.5
     assert params[-1] == 52.0
     assert isinstance(params[-1], float)
 

--- a/backend/tests/services/test_estimator_service.py
+++ b/backend/tests/services/test_estimator_service.py
@@ -1,0 +1,60 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.services.estimator_service as estimator_service_module
+from app.services.estimator_service import EstimatorService, _NBA_AVG_PACE_FALLBACK
+
+
+@pytest.fixture(autouse=True)
+def reset_estimator_service_singleton():
+    EstimatorService._instance = None
+    EstimatorService._initialized = False
+    yield
+    EstimatorService._instance = None
+    EstimatorService._initialized = False
+
+
+@pytest.fixture
+def estimator_service():
+    return EstimatorService()
+
+
+@pytest.mark.asyncio
+async def test_get_nba_avg_pace_does_not_close_shared_nba_service(estimator_service, monkeypatch):
+    """NBAStatsService is a shared singleton closed once at app shutdown —
+    this caller runs concurrently with get_team_slot_pace_df's own use of it
+    via the same asyncio.gather, so closing it here would break whichever
+    call is still in flight. Regression test for that race condition."""
+    nba_service = MagicMock()
+    nba_service.get_nba_average_pace = AsyncMock(return_value=101.2)
+    nba_service.close = AsyncMock()
+    monkeypatch.setattr(estimator_service_module, 'NBAStatsService', lambda: nba_service)
+
+    pace = await estimator_service._get_nba_avg_pace()
+
+    assert pace == 101.2
+    nba_service.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_nba_avg_pace_falls_back_on_none(estimator_service, monkeypatch):
+    nba_service = MagicMock()
+    nba_service.get_nba_average_pace = AsyncMock(return_value=None)
+    nba_service.close = AsyncMock()
+    monkeypatch.setattr(estimator_service_module, 'NBAStatsService', lambda: nba_service)
+
+    pace = await estimator_service._get_nba_avg_pace()
+
+    assert pace == _NBA_AVG_PACE_FALLBACK
+
+
+@pytest.mark.asyncio
+async def test_get_nba_avg_pace_falls_back_on_exception(estimator_service, monkeypatch):
+    nba_service = MagicMock()
+    nba_service.get_nba_average_pace = AsyncMock(side_effect=RuntimeError("network down"))
+    monkeypatch.setattr(estimator_service_module, 'NBAStatsService', lambda: nba_service)
+
+    pace = await estimator_service._get_nba_avg_pace()
+
+    assert pace == _NBA_AVG_PACE_FALLBACK

--- a/backend/tests/services/test_nba_matchup_service.py
+++ b/backend/tests/services/test_nba_matchup_service.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.services.nba_matchup_service import NbaMatchupService
+from app.config import settings
 
 _ET = ZoneInfo('America/New_York')
 
@@ -376,3 +377,61 @@ async def test_get_games_today_and_get_upcoming_game_dates_share_one_fetch(servi
 
     assert first_call_count > 0
     assert len(get.call_args_list) == first_call_count
+
+
+class TestPreseasonOpenerPreview:
+    """Preseason: nothing within the normal lookahead window, but the real
+    season opener (settings.season_start) is a known future date — it should
+    be previewed instead of reporting a flat offseason 'no games'."""
+
+    @pytest.mark.asyncio
+    async def test_previews_season_opener_when_nothing_in_lookahead_window(self, service, monkeypatch):
+        today = _today()
+        opener = today + timedelta(days=30)  # well beyond the 7-day lookahead window
+        monkeypatch.setattr(settings, 'season_start', opener)
+        events_by_day = {
+            opener: [_scoreboard_event(13, 30, 'LAL', 'CHA', completed=False, game_date=opener)],
+        }
+
+        with patch.object(
+            service._client, 'get', new_callable=AsyncMock, side_effect=_client_get_by_day(events_by_day),
+        ):
+            games = await service.get_games_today()
+
+        assert games['LAL'].opponent == 'CHA'
+        assert service.get_schedule_date() == opener.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_stays_empty_when_opener_itself_has_no_events_yet(self, service, monkeypatch):
+        """The opener date is known but ESPN hasn't published its events yet
+        (whitelist calendar doesn't include it) — still a flat empty result,
+        not a crash."""
+        today = _today()
+        opener = today + timedelta(days=30)
+        monkeypatch.setattr(settings, 'season_start', opener)
+
+        with patch.object(
+            service._client, 'get', new_callable=AsyncMock, side_effect=_client_get_by_day({}),
+        ):
+            games = await service.get_games_today()
+
+        assert games == {}
+        assert service.get_schedule_date() is None
+
+    @pytest.mark.asyncio
+    async def test_does_not_preview_opener_once_season_has_started(self, service, monkeypatch):
+        """base >= season_start (regular season underway) must never trigger
+        the preseason preview branch, even with an empty lookahead window."""
+        today = _today()
+        monkeypatch.setattr(settings, 'season_start', today - timedelta(days=1))
+
+        with patch.object(
+            service._client, 'get', new_callable=AsyncMock, side_effect=_client_get_by_day({}),
+        ) as get:
+            games = await service.get_games_today()
+
+        assert games == {}
+        assert service.get_schedule_date() is None
+        # only the single whitelist call from the normal lookahead scan —
+        # no extra opener-day probe
+        assert len(get.call_args_list) == 1

--- a/backend/tests/services/test_nba_stats_service.py
+++ b/backend/tests/services/test_nba_stats_service.py
@@ -1,7 +1,7 @@
 import pytest
 import httpx
 from unittest.mock import Mock, patch, AsyncMock
-from datetime import datetime
+from datetime import datetime, date
 from app.services.nba_stats_service import NBAStatsService
 
 
@@ -231,7 +231,7 @@ class TestNBAStatsServiceGameDaysRemaining:
                 mock_datetime.now.return_value.date.return_value = datetime(2026, 2, 28).date()
                 mock_datetime.fromisoformat = datetime.fromisoformat
 
-                result = await nba_stats_service.get_nba_game_days_remaining()
+                result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
                 assert result is not None
                 assert isinstance(result, int)
@@ -259,41 +259,52 @@ class TestNBAStatsServiceGameDaysRemaining:
                 mock_datetime.now.return_value.date.return_value = datetime(2026, 2, 15).date()
                 mock_datetime.fromisoformat = datetime.fromisoformat
 
-                result = await nba_stats_service.get_nba_game_days_remaining()
+                result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
                 assert result == 2
 
     @pytest.mark.asyncio
     async def test_get_nba_game_days_remaining_filters_post_season(self, nba_stats_service):
-        """Test that dates after regular season end are filtered out"""
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            'leagues': [
-                {
-                    'calendar': [
-                        '2026-04-01T00:00:00Z',
-                        '2026-04-15T00:00:00Z',
-                        '2026-05-01T00:00:00Z'
-                    ]
-                }
-            ]
-        }
-        mock_response.raise_for_status = Mock()
+        """Dates at/after the detected postseason boundary are excluded, even
+        though they're still in the future relative to `today`."""
+        nba_stats_service._get_regular_season_calendar = AsyncMock(
+            return_value=(
+                [date(2026, 4, 1), date(2026, 4, 15), date(2026, 5, 1)],
+                0,  # start_idx: whole window is regular season or later
+                0,  # end_idx: only index 0 (04-01) is still regular season
+            )
+        )
+        with patch('app.services.nba_stats_service.datetime') as mock_datetime:
+            mock_datetime.now.return_value.date.return_value = datetime(2026, 3, 1).date()
 
-        with patch.object(nba_stats_service._client, 'get', new_callable=AsyncMock, return_value=mock_response):
-            with patch('app.services.nba_stats_service.datetime') as mock_datetime:
-                mock_datetime.now.return_value.date.return_value = datetime(2026, 3, 1).date()
-                mock_datetime.fromisoformat = datetime.fromisoformat
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
-                result = await nba_stats_service.get_nba_game_days_remaining()
+            assert result == 1
 
-                assert result == 1
+    @pytest.mark.asyncio
+    async def test_get_nba_game_days_remaining_uses_resolved_window(self, nba_stats_service):
+        """Only dates within [start_idx, end_idx] of the resolved calendar count,
+        regardless of how many extra dates the raw ESPN calendar contains."""
+        nba_stats_service._get_regular_season_calendar = AsyncMock(
+            return_value=(
+                [date(2026, 1, 1), date(2026, 2, 1), date(2026, 3, 1), date(2026, 4, 1), date(2026, 6, 1)],
+                1,  # start_idx: preseason date at index 0 excluded
+                3,  # end_idx: postseason date at index 4 excluded
+            )
+        )
+        with patch('app.services.nba_stats_service.datetime') as mock_datetime:
+            mock_datetime.now.return_value.date.return_value = datetime(2026, 1, 15).date()
+
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
+
+            # window is [02-01, 03-01, 04-01]; all >= 2026-01-15
+            assert result == 3
 
     @pytest.mark.asyncio
     async def test_get_nba_game_days_remaining_http_error(self, nba_stats_service):
         """Test handling of HTTP request error"""
         with patch.object(nba_stats_service._client, 'get', side_effect=httpx.RequestError("Connection failed")):
-            result = await nba_stats_service.get_nba_game_days_remaining()
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
             assert result is None
 
@@ -305,7 +316,7 @@ class TestNBAStatsServiceGameDaysRemaining:
         mock_response.raise_for_status = Mock()
 
         with patch.object(nba_stats_service._client, 'get', new_callable=AsyncMock, return_value=mock_response):
-            result = await nba_stats_service.get_nba_game_days_remaining()
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
             assert result is None
 
@@ -317,7 +328,7 @@ class TestNBAStatsServiceGameDaysRemaining:
         mock_response.raise_for_status = Mock()
 
         with patch.object(nba_stats_service._client, 'get', new_callable=AsyncMock, return_value=mock_response):
-            result = await nba_stats_service.get_nba_game_days_remaining()
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
             assert result is None
 
@@ -335,9 +346,91 @@ class TestNBAStatsServiceGameDaysRemaining:
         mock_response.raise_for_status = Mock()
 
         with patch.object(nba_stats_service._client, 'get', new_callable=AsyncMock, return_value=mock_response):
-            result = await nba_stats_service.get_nba_game_days_remaining()
+            result = await nba_stats_service.get_nba_game_days_remaining(2026)
 
             assert result is None
+
+
+def _routed_client_mock(calendar_dates, season_types):
+    """Fake httpx client 'get' that returns the whitelist calendar for the
+    calendar-lookup URL, and a per-day season-type event payload for the
+    single-day scoreboard probe URLs used by the start/end binary search.
+    `season_types` maps 'YYYYMMDD' -> ESPN season.type (1=pre, 2=regular, 3+=post)."""
+    import re
+
+    async def _get(url, *args, **kwargs):
+        resp = Mock()
+        resp.raise_for_status = Mock()
+        if 'calendartype=whitelist' in url:
+            resp.json.return_value = {'leagues': [{'calendar': calendar_dates}]}
+        else:
+            m = re.search(r'dates=(\d{8})', url)
+            season_type = season_types.get(m.group(1)) if m else None
+            events = [{'season': {'type': season_type}}] if season_type is not None else []
+            resp.json.return_value = {'events': events}
+        return resp
+
+    return AsyncMock(side_effect=_get)
+
+
+class TestNBAStatsServiceRegularSeasonCalendar:
+    """Test suite for _get_regular_season_calendar / _binary_search_first /
+    get_regular_season_start_date — the ESPN-calendar-derived season window
+    that replaced the old hand-maintained SEASON_START/SEASON_END dates."""
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_calendar_finds_start_and_end(self, nba_stats_service):
+        calendar_dates = [
+            '2025-10-15T00:00:00Z',  # preseason
+            '2025-10-22T00:00:00Z',  # regular season start
+            '2026-03-01T00:00:00Z',  # regular season
+            '2026-04-15T00:00:00Z',  # postseason start
+        ]
+        season_types = {
+            '20251015': 1,
+            '20251022': 2,
+            '20260301': 2,
+            '20260415': 3,
+        }
+        with patch.object(nba_stats_service._client, 'get', _routed_client_mock(calendar_dates, season_types)):
+            dates, start_idx, end_idx = await nba_stats_service._get_regular_season_calendar(2026)
+
+        assert dates[start_idx] == date(2025, 10, 22)
+        assert dates[end_idx] == date(2026, 3, 1)
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_calendar_no_postseason_probed_keeps_last_date(self, nba_stats_service):
+        """When every probed date resolves to regular season (no postseason
+        detected), the window runs through the end of the raw calendar."""
+        calendar_dates = ['2025-10-22T00:00:00Z', '2026-03-01T00:00:00Z']
+        season_types = {'20251022': 2, '20260301': 2}
+        with patch.object(nba_stats_service._client, 'get', _routed_client_mock(calendar_dates, season_types)):
+            dates, start_idx, end_idx = await nba_stats_service._get_regular_season_calendar(2026)
+
+        assert start_idx == 0
+        assert end_idx == len(dates) - 1
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_calendar_empty_calendar_raises(self, nba_stats_service):
+        with patch.object(nba_stats_service._client, 'get', _routed_client_mock([], {})):
+            with pytest.raises(ValueError, match="No calendar data"):
+                await nba_stats_service._get_regular_season_calendar(2026)
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_start_date_returns_first_regular_season_day(self, nba_stats_service):
+        calendar_dates = ['2025-10-15T00:00:00Z', '2025-10-22T00:00:00Z']
+        season_types = {'20251015': 1, '20251022': 2}
+        with patch.object(nba_stats_service._client, 'get', _routed_client_mock(calendar_dates, season_types)):
+            start = await nba_stats_service.get_regular_season_start_date(2026)
+
+        assert start == date(2025, 10, 22)
+
+    @pytest.mark.asyncio
+    async def test_get_regular_season_start_date_returns_none_on_failure(self, nba_stats_service):
+        with patch.object(nba_stats_service._client, 'get', side_effect=httpx.RequestError("boom")):
+            start = await nba_stats_service.get_regular_season_start_date(2026)
+
+        assert start is None
 
 
 class TestNBAStatsServiceClose:

--- a/backend/tests/services/test_team_service.py
+++ b/backend/tests/services/test_team_service.py
@@ -6,7 +6,7 @@ import pandas as pd
 from unittest.mock import Mock, patch, AsyncMock, MagicMock
 from app.services.team_service import TeamService
 from app.models import Team, TeamDetail, TeamPlayers, Player, ShotChartStats, AverageStats, RankingStats, PlayerStats, StatTimePeriod
-from app.exceptions import InvalidParameterError, ResourceNotFoundError
+from app.exceptions import InvalidParameterError, ResourceNotFoundError, DataSourceError
 import app.services.player_service as player_service_module
 
 @pytest.fixture(autouse=True)
@@ -168,13 +168,31 @@ class TestTeamService:
         team_service.data_provider.get_totals_df.assert_called_once()
     
     @pytest.mark.asyncio
-    async def test_get_teams_list_data_provider_returns_none(self, team_service):
-        """Test get_teams_list when data provider returns None"""
-        team_service.data_provider.get_totals_df.return_value = None
-        
-        with pytest.raises(Exception, match="Unable to fetch teams data from ESPN API"):
+    async def test_get_teams_list_totals_unavailable_falls_back_to_team_names(self, team_service):
+        """When ESPN stat totals aren't available yet (e.g. preseason), get_teams_list
+        falls back to team identity data instead of raising."""
+        team_service.data_provider.get_totals_df.side_effect = DataSourceError("ESPN unavailable")
+        team_service.data_provider.get_team_names.return_value = [
+            {"team_id": 1, "team_name": "Team Alpha"},
+            {"team_id": 2, "team_name": "Team Beta"},
+        ]
+
+        result = await team_service.get_teams_list()
+
+        assert len(result) == 2
+        assert all(isinstance(team, Team) for team in result)
+        assert {t.team_id for t in result} == {1, 2}
+        assert {t.team_name for t in result} == {"Team Alpha", "Team Beta"}
+
+    @pytest.mark.asyncio
+    async def test_get_teams_list_totals_unavailable_and_no_team_names_raises(self, team_service):
+        """When both stat totals and team identity data are unavailable, raise ResourceNotFoundError."""
+        team_service.data_provider.get_totals_df.side_effect = DataSourceError("ESPN unavailable")
+        team_service.data_provider.get_team_names.return_value = []
+
+        with pytest.raises(ResourceNotFoundError, match="No teams found in the data"):
             await team_service.get_teams_list()
-    
+
     @pytest.mark.asyncio
     async def test_get_teams_list_empty_data(self, team_service):
         """Test get_teams_list with empty DataFrame"""
@@ -207,12 +225,16 @@ class TestTeamService:
     
     @pytest.mark.asyncio
     async def test_get_team_players_no_players_found(self, team_service, team_service_players_df):
-        """Test get_team_players when no players found for team"""
+        """A valid team with no roster yet (e.g. pre-draft) returns an empty
+        players list rather than a lookup failure"""
         team_id = 999
         team_service.data_provider.get_players_df.return_value = team_service_players_df
-        
-        with pytest.raises(ResourceNotFoundError, match=f"No players found for team ID {team_id}"):
-            await team_service.get_team_players(team_id)
+
+        result = await team_service.get_team_players(team_id)
+
+        assert result.team_id == team_id
+        assert result.players == []
+        team_service.response_builder.build_team_players_response.assert_not_called()
 
 
 class TestTeamServiceResponseBuilding:

--- a/backend/tests/services/test_team_slot_pace.py
+++ b/backend/tests/services/test_team_slot_pace.py
@@ -1,0 +1,79 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+import app.services.team_slot_pace as team_slot_pace_module
+from app.services.team_slot_pace import get_team_slot_pace_df
+
+
+@pytest.fixture
+def mock_data_provider(monkeypatch):
+    provider = MagicMock()
+    provider.get_slot_usage = AsyncMock(return_value={
+        1: {'PG': 10, 'SG': 5, 'UTIL': 3},
+        2: {'PG': 8},
+    })
+    provider.get_totals_df = AsyncMock(return_value=pd.DataFrame({
+        'team_id': [1, 2], 'team_name': ['Team Alpha', 'Team Beta'],
+    }))
+    monkeypatch.setattr(team_slot_pace_module, 'DataProvider', lambda: provider)
+    return provider
+
+
+@pytest.fixture
+def mock_nba_service(monkeypatch):
+    service = MagicMock()
+    service.get_nba_average_pace = AsyncMock(return_value=99.5)
+    service.get_nba_game_days_remaining = AsyncMock(return_value=42)
+    service.close = AsyncMock()
+    monkeypatch.setattr(team_slot_pace_module, 'NBAStatsService', lambda: service)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_get_team_slot_pace_df_does_not_close_shared_nba_service(mock_data_provider, mock_nba_service):
+    """NBAStatsService is a shared singleton closed once at app shutdown —
+    this caller must not close it, since a concurrent caller (e.g.
+    estimator_service's own pace fetch, run via the same asyncio.gather) may
+    still be using its httpx client. Regression test for that race condition."""
+    await get_team_slot_pace_df()
+
+    mock_nba_service.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_team_slot_pace_df_builds_rows_per_team(mock_data_provider, mock_nba_service):
+    df = await get_team_slot_pace_df()
+
+    assert set(df['team_id']) == {1, 2}
+    row1 = df[df['team_id'] == 1].iloc[0]
+    assert row1['team_name'] == 'Team Alpha'
+    assert row1['PG'] == 10
+    assert row1['SG'] == 5
+    assert row1['C'] == 0  # slot with no usage defaults to 0
+    assert row1['nba_avg_pace'] == 99.5
+    assert row1['nba_game_days_remaining'] == 42
+
+
+@pytest.mark.asyncio
+async def test_get_team_slot_pace_df_falls_back_when_pace_unavailable(mock_data_provider, mock_nba_service):
+    """When NBA pace can't be fetched (e.g. ESPN calendar unreachable), fall
+    back to the known league-average constant rather than propagating None."""
+    mock_nba_service.get_nba_average_pace = AsyncMock(return_value=None)
+
+    df = await get_team_slot_pace_df()
+
+    assert (df['nba_avg_pace'] == 65.9).all()
+
+
+@pytest.mark.asyncio
+async def test_get_team_slot_pace_df_unknown_team_id_gets_placeholder_name(mock_data_provider, mock_nba_service):
+    """A team present in slot usage but missing from totals_df (e.g. a
+    just-created fantasy team not yet reflected in ESPN standings) still
+    gets a row instead of crashing on the team_name lookup."""
+    mock_data_provider.get_slot_usage = AsyncMock(return_value={99: {'PG': 1}})
+
+    df = await get_team_slot_pace_df()
+
+    assert df.iloc[0]['team_name'] == 'Team 99'

--- a/frontend/src/utils/__tests__/errorMessage.test.ts
+++ b/frontend/src/utils/__tests__/errorMessage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { getErrorMessage } from '../errorMessage';
+
+const FALLBACK = 'Failed to load data.';
+
+describe('getErrorMessage', () => {
+  it('returns the detail from a 503 response', () => {
+    const error = { status: 503, data: { detail: 'No data available yet for this league/season.' } };
+    expect(getErrorMessage(error, FALLBACK)).toBe('No data available yet for this league/season.');
+  });
+
+  it('falls back to a specific 503 message when the response has no detail', () => {
+    const error = { status: 503, data: {} };
+    expect(getErrorMessage(error, FALLBACK)).toBe('No data available yet for this league/season.');
+  });
+
+  it('returns the detail from a 404 response', () => {
+    const error = { status: 404, data: { detail: 'Team with ID 99 not found' } };
+    expect(getErrorMessage(error, FALLBACK)).toBe('Team with ID 99 not found');
+  });
+
+  it('falls back to the generic fallback on a 404 with no detail', () => {
+    const error = { status: 404, data: {} };
+    expect(getErrorMessage(error, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback on a 500 response, ignoring any detail', () => {
+    const error = { status: 500, data: { detail: 'Internal server error' } };
+    expect(getErrorMessage(error, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback for a network/fetch error (string status)', () => {
+    const error = { status: 'FETCH_ERROR', error: 'Failed to fetch' };
+    expect(getErrorMessage(error, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback for a SerializedError (RTK thunk rejection)', () => {
+    const error = { name: 'Error', message: 'Something broke' };
+    expect(getErrorMessage(error, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback for null/undefined errors', () => {
+    expect(getErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+    expect(getErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back to the generic fallback when detail is present but not a string', () => {
+    const error = { status: 503, data: { detail: { nested: true } } };
+    expect(getErrorMessage(error, FALLBACK)).toBe('No data available yet for this league/season.');
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on top of `fix/season-league-scoping` (#185) — fixes the 13 failing `test-backend` CI tests on that PR and adds test coverage for logic the PR introduced but didn't yet cover.

**Fixed (test-side drift, not production bugs):**
- `test_db_service.py`, `test_nba_stats_service.py`, `test_analytics.py`: updated calls to pass the now-required `league_id`/`season_id` (or `season_id`) arguments.
- `test_team_service.py`: two tests asserted the old raise-on-missing-data behavior; `get_teams_list`/`get_team_players` now intentionally fall back to team-identity data / an empty roster for preseason. Updated those tests and added coverage for the new fallback success/failure paths.
- `test_nba_stats_service.py`: the hardcoded 2026-04-12 season-end date was replaced by an ESPN-calendar-derived binary search; rewrote the affected test against the new seam (`_get_regular_season_calendar`) instead of the removed fixed cutoff.

**New coverage for previously-untested logic this PR introduced:**
- `data_provider.py`: `get_team_names` (cache reuse / fresh-fetch / failure), and `_fallback_from_db`'s `DataSourceError`-on-empty + Decimal→float cast (the heatmap crash fix).
- `data_transformer.py`: `raw_standings_to_team_names`, and the zero-row/zero-stat synthesis for preseason players and teams.
- `nba_matchup_service.py`: the season-opener preview shown when nothing is in the normal lookahead window but the real opener date is known.
- `team_slot_pace.py` / `estimator_service.py`: regression tests for the race-condition fix — the shared `NBAStatsService` client must not be closed by either concurrent caller.
- `main.py`: the new `DataSourceError`→503 / `ResourceNotFoundError`→404 exception handlers, probed via a route with no local exception handling.
- Frontend `errorMessage.ts`: new util, had no tests.

No production code changed — everything here is test-only.

## Test plan
- [x] `uv run pytest` — 526 passed (up from 479, all 13 original failures fixed)
- [x] `npm run test` — 193 passed (up from 184)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4jghYWAqmnv7AGhJ4ofnJ)_