### PR TITLE
chore: improve backend log visibility for silent failures

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -58,7 +58,7 @@ async def lifespan(app: FastAPI):
         else:
             logger.warning(f"Could not derive regular-season start; keeping configured SEASON_START={settings.season_start}")
     except Exception as e:
-        logger.warning(f"Failed to derive regular-season start, keeping configured SEASON_START={settings.season_start}: {e}")
+        logger.warning(f"Failed to derive regular-season start, keeping configured SEASON_START={settings.season_start}: {type(e).__name__}: {e}")
     await injury_service.initialize()
     if settings.injury_scheduler_enabled:
         asyncio.create_task(injury_service.start_scheduler())
@@ -99,7 +99,7 @@ async def data_source_error_handler(request: Request, exc: DataSourceError):
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
-    logger.error(f"Unhandled exception in {request.url}: {str(exc)}", exc_info=True)
+    logger.error(f"Unhandled exception in {request.url}: {type(exc).__name__}: {exc}", exc_info=True)
     return JSONResponse(
         status_code=500,
         content={

--- a/backend/app/routes/nba_teams.py
+++ b/backend/app/routes/nba_teams.py
@@ -24,7 +24,7 @@ async def get_depth_chart(team_id: int):
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.get(url)
     except httpx.HTTPError as e:
-        logger.error(f"ESPN depth chart fetch failed for team {team_id}: {e}")
+        logger.error(f"ESPN depth chart fetch failed for team {team_id}: {type(e).__name__}: {e}")
         raise HTTPException(status_code=502, detail="Failed to fetch depth chart from ESPN")
 
     if resp.status_code != 200:

--- a/backend/app/services/depth_chart_service.py
+++ b/backend/app/services/depth_chart_service.py
@@ -53,5 +53,5 @@ class DepthChartService:
                         names.add(normalize_player_name(display_name))
             return names
         except Exception as e:
-            logger.error(f"Depth chart fetch/parse failed for team {team_id}: {e}")
+            logger.error(f"Depth chart fetch/parse failed for team {team_id}: {type(e).__name__}: {e}")
             return set()

--- a/backend/app/services/injury_service.py
+++ b/backend/app/services/injury_service.py
@@ -58,7 +58,7 @@ async def fetch_pdf_bytes(url: str) -> bytes | None:
             logger.warning(f"Injury PDF fetch got HTTP {response.status_code}: {url}")
             return None
     except httpx.HTTPError as e:
-        logger.warning(f"Injury PDF fetch failed: {e}")
+        logger.warning(f"Injury PDF fetch failed: {type(e).__name__}: {e} (url={url})")
         return None
 
 
@@ -525,7 +525,7 @@ async def start_scheduler() -> None:
             try:
                 success = await _try_update_injury_data()
             except Exception as e:
-                logger.error(f"Injury update cycle error at +{offset}s: {e}", exc_info=True)
+                logger.error(f"Injury update cycle error at +{offset}s: {type(e).__name__}: {e}", exc_info=True)
                 success = False
             if success:
                 break

--- a/backend/app/services/model_nightly_scheduler.py
+++ b/backend/app/services/model_nightly_scheduler.py
@@ -47,5 +47,6 @@ async def start_scheduler():
         try:
             statuses = await service.run_catchup()
             logger.info(f"Model nightly catch-up finished: {statuses}")
-        except Exception:
-            logger.exception("Model nightly pipeline failed; will retry at next slot")
+        except Exception as e:
+            logger.error(f"Model nightly pipeline failed: {type(e).__name__}: {e}; will retry at next slot")
+            logger.exception("Model nightly pipeline failure traceback")

--- a/backend/app/services/model_nightly_service.py
+++ b/backend/app/services/model_nightly_service.py
@@ -186,7 +186,11 @@ class ModelNightlyService:
         statuses: dict[str, str] = {"missing_features": missing} if missing else {}
         for offset in range(CATCHUP_DAYS - 1, -1, -1):
             d = yesterday - timedelta(days=offset)
-            status = await self.run_for_date(d)
+            try:
+                status = await self.run_for_date(d)
+            except Exception as e:
+                logger.error(f"Model nightly run_for_date({d}) raised: {type(e).__name__}: {e}")
+                raise
             statuses[d.isoformat()] = status
             if status not in ("processed", "no_games", "already_processed", "store_already_ingested"):
                 logger.warning(f"Model nightly catch-up stopped at {d}: {status}")
@@ -332,8 +336,8 @@ class ModelNightlyService:
             logger.warning(
                 f"Feature vectors are missing {len(missing)} feature(s) the models need "
                 f"({preview}). Auto-heal is off (MODEL_FEATURE_HEAL_AUTO), so the models "
-                f"will read them as NaN until the vectors are rebuilt. Run:\n"
-                f"    cd backend && python scripts/refresh_feature_vectors.py "
+                f"will read them as NaN until the vectors are rebuilt. Run: "
+                f"cd backend && python scripts/refresh_feature_vectors.py "
                 f"--database-url <url> --expect-feature {sorted(missing)[0]}"
             )
             return "manual_refresh_required"

--- a/backend/app/services/nba_stats_service.py
+++ b/backend/app/services/nba_stats_service.py
@@ -99,13 +99,13 @@ class NBAStatsService:
             return round(average_pace, 1)
 
         except httpx.RequestError as e:
-            self.logger.warning(f"Failed to fetch NBA standings: {e}")
+            self.logger.warning(f"Failed to fetch NBA standings: {type(e).__name__}: {e}")
             return None
         except (KeyError, ValueError, IndexError) as e:
-            self.logger.warning(f"Failed to parse NBA standings response: {e}")
+            self.logger.warning(f"Failed to parse NBA standings response: {type(e).__name__}: {e}")
             return None
         except Exception as e:
-            self.logger.warning(f"Unexpected error fetching NBA average pace: {e}")
+            self.logger.warning(f"Unexpected error fetching NBA average pace: {type(e).__name__}: {e}")
             return None
 
     async def get_nba_game_days_remaining(self, season_id: int) -> Optional[int]:
@@ -138,7 +138,7 @@ class NBAStatsService:
             dates, start_idx, _ = await self._get_regular_season_calendar(season_id)
             return dates[start_idx]
         except Exception as e:
-            self.logger.warning(f"Failed to derive regular season start for {season_id}: {e}")
+            self.logger.warning(f"Failed to derive regular season start for {season_id}: {type(e).__name__}: {e}")
             return None
 
     async def _get_event_season_type(self, day) -> Optional[int]:
@@ -151,7 +151,7 @@ class NBAStatsService:
             events = response.json().get('events', [])
             return events[0].get('season', {}).get('type') if events else None
         except Exception as e:
-            self.logger.warning(f"Failed to fetch season type for {day}: {e}")
+            self.logger.warning(f"Failed to fetch season type for {day}: {type(e).__name__}: {e}")
             return None
 
     async def _binary_search_first(self, calendar_dates: list, min_type: int) -> Optional[int]:
@@ -209,13 +209,13 @@ class NBAStatsService:
             future_game_dates = [d for d in regular_season_dates if d >= today]
             return len(future_game_dates)
         except httpx.RequestError as e:
-            self.logger.warning(f"Failed to fetch NBA calendar: {e}")
+            self.logger.warning(f"Failed to fetch NBA calendar: {type(e).__name__}: {e}")
             return None
         except (KeyError, ValueError, IndexError) as e:
-            self.logger.warning(f"Failed to parse NBA calendar response: {e}")
+            self.logger.warning(f"Failed to parse NBA calendar response: {type(e).__name__}: {e}")
             return None
         except Exception as e:
-            self.logger.warning(f"Unexpected error fetching NBA game days remaining: {e}")
+            self.logger.warning(f"Unexpected error fetching NBA game days remaining: {type(e).__name__}: {e}")
             return None
 
     async def close(self):

--- a/backend/model_stats_inference/espn/client.py
+++ b/backend/model_stats_inference/espn/client.py
@@ -8,10 +8,13 @@ simple. All endpoints are unauthenticated JSON GETs.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 
 import httpx
 import requests
+
+logger = logging.getLogger(__name__)
 
 BASE = "https://site.api.espn.com/apis/site/v2/sports/basketball/nba"
 
@@ -35,8 +38,24 @@ class EspnUnavailableError(RuntimeError):
     """ESPN kept failing after retries — treat like 'come back later'."""
 
 
+def _status_and_body(e: Exception) -> tuple[int | None, str]:
+    """Best-effort HTTP status code + a short response-body snippet from a
+    requests/httpx exception, so a 403/429/5xx is greppable from the log line
+    alone (the exception's own str() doesn't always include the body)."""
+    resp = getattr(e, "response", None)
+    if resp is None:
+        return None, ""
+    status = getattr(resp, "status_code", None)
+    try:
+        body = resp.text[:200]
+    except Exception:
+        body = ""
+    return status, body
+
+
 def get_json(path: str, params: dict | None = None) -> dict:
     url = f"{BASE}/{path}"
+    attempts = len(RETRY_DELAYS) + 1
     last: Exception | None = None
     for attempt, delay in enumerate([0.0, *RETRY_DELAYS]):
         if delay:
@@ -49,7 +68,13 @@ def get_json(path: str, params: dict | None = None) -> dict:
             return data
         except (requests.RequestException, ValueError) as e:
             last = e
-    raise EspnUnavailableError(f"GET {url} failed after {len(RETRY_DELAYS) + 1} attempts: {last}")
+            status, body = _status_and_body(e)
+            logger.warning(
+                f"ESPN GET {url} attempt {attempt + 1}/{attempts} failed (status={status}): "
+                f"{type(e).__name__}: {e}" + (f" body={body!r}" if body else "")
+            )
+    logger.error(f"ESPN GET {url} gave up after {attempts} attempts: {type(last).__name__}: {last}")
+    raise EspnUnavailableError(f"GET {url} failed after {attempts} attempts: {last}")
 
 
 async def async_get_json(client: httpx.AsyncClient, path: str, params: dict | None = None) -> dict:
@@ -57,6 +82,7 @@ async def async_get_json(client: httpx.AsyncClient, path: str, params: dict | No
     SLEEP_BETWEEN_CALLS pacing — that's for the nightly bulk pull's hundreds
     of sequential requests, not a handful of per-request lookups)."""
     url = f"{BASE}/{path}"
+    attempts = len(RETRY_DELAYS) + 1
     last: Exception | None = None
     for attempt, delay in enumerate([0.0, *RETRY_DELAYS]):
         if delay:
@@ -67,7 +93,13 @@ async def async_get_json(client: httpx.AsyncClient, path: str, params: dict | No
             return resp.json()
         except (httpx.HTTPError, ValueError) as e:
             last = e
-    raise EspnUnavailableError(f"GET {url} failed after {len(RETRY_DELAYS) + 1} attempts: {last}")
+            status, body = _status_and_body(e)
+            logger.warning(
+                f"ESPN GET {url} attempt {attempt + 1}/{attempts} failed (status={status}): "
+                f"{type(e).__name__}: {e}" + (f" body={body!r}" if body else "")
+            )
+    logger.error(f"ESPN GET {url} gave up after {attempts} attempts: {type(last).__name__}: {last}")
+    raise EspnUnavailableError(f"GET {url} failed after {attempts} attempts: {last}")
 
 
 async def scoreboard_async(client: httpx.AsyncClient, dates: str) -> dict:


### PR DESCRIPTION
## Summary

Motivated by real Render production logs where the nightly model pipeline failed repeatedly and the actual cause (an ESPN 403) was invisible:

```
2026-08-14 06:00:27,447 - app.services.model_nightly_scheduler - ERROR - Model nightly pipeline failed; will retry at next slot
  File "/app/app/services/model_nightly_scheduler.py", line 48, in start_scheduler
  ...
  File "/app/model_stats_inference/serving/nightly.py", line 42, in fetch_night
```
The `EspnUnavailableError: ... 403 Client Error: Forbidden` line never showed up — only `logger.exception(...)` was used, which relies on the traceback block surviving intact through Render's log pipeline. It didn't.

Two concrete defects fixed:
1. **Exception type/message could vanish along with a mangled traceback.** The only `logger.exception(...)` call in the backend (`model_nightly_scheduler.py`) now also logs `type(e).__name__: e` on its own single line before the traceback, so the cause survives even if the multi-line block gets truncated/split downstream. Applied the same pattern to other logged exceptions that only logged `{e}` without the type (`app/main.py`, `injury_service.py`, `nba_stats_service.py`, `depth_chart_service.py`, `nba_teams.py`).
2. **A multi-line warning silently dropped its payload.** `model_nightly_service.py`'s "Auto-heal is off... Run:\n    cd backend && ..." message embedded a literal `\n`, so the actual command to run never appeared in some log viewers. Flattened to one line. Audited the rest of `backend/` for the same pattern (grep for logger calls with a literal `\n` in the message) — this was the only occurrence.

Broader pass (same evidence, kept to what's actually load-bearing for prod debugging):
- `model_stats_inference/espn/client.py`: `get_json`/`async_get_json` retry loops previously swallowed every failed attempt silently and only raised at the end. Now log each failed attempt at WARNING with the HTTP status code, exception type, and a truncated (~200 char) response-body snippet, plus a final ERROR on give-up. Retry timing/behavior unchanged. `HEADERS` untouched.
- `model_nightly_service.py`: `run_catchup` now logs which date raised before re-raising, so the scheduler's failure log isn't the only place the date appears.

## What I did NOT change
- `db_service.py` has ~40 `except Exception as e: logger.error(f"Failed to X: {e}")` call sites. These already include `{e}` (asyncpg messages are informative) and weren't implicated in the incident, so I left them alone rather than doing a large mechanical sweep — flagging here in case you want that as a separate follow-up.
- No dependency changes, no retry/timing changes, no behavior changes.

## Test plan
- [x] `uv run python -m compileall app model_stats_inference` — no syntax errors
- [x] Imported every touched module directly (`app.main`, `model_stats_inference.espn.client`, `model_nightly_scheduler`, `injury_service`, `depth_chart_service`, `nba_stats_service`) with minimal env vars — no import-time errors
- [x] Manually exercised `_status_and_body()` against a mock `requests.HTTPError` with a 403 response to confirm status/body extraction
- Test suite intentionally not run per task scope (logging-only change, no behavior to regress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)