### PR TITLE
fix: restore the nightly model pipeline (ESPN 403) + end-to-end verification

### DIFF
--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from datetime import date, timedelta
 from typing import Optional
 import asyncpg
@@ -1119,9 +1120,17 @@ class DBService:
             logger.error(f"Failed to count games since {since_date}: {e}")
             return {}
 
-    async def insert_fs_rows(self, player_rows: list[tuple], team_rows: list[tuple]) -> bool:
+    async def insert_fs_rows(
+        self, player_rows: list[tuple], team_rows: list[tuple], use_copy: bool = False
+    ) -> bool:
         """Append raw game rows. Tuple order must match the column lists below.
-        ON CONFLICT DO NOTHING makes re-runs of the same night no-ops."""
+        ON CONFLICT DO NOTHING makes re-runs of the same night no-ops.
+
+        ``use_copy`` swaps the per-row INSERT for COPY, which has no conflict
+        handling — only valid when the tables are known to be empty (bootstrap,
+        which truncates first). A nightly's ~200 rows don't need it; a
+        bootstrap's ~95k rows take minutes as individual INSERTs.
+        """
         pool = await self._get_pool()
         if pool is None:
             return False
@@ -1133,6 +1142,8 @@ class DBService:
             "team_id, game_id, season, game_date, team_name, matchup, "
             "pts, reb, ast, stl, blk, fg3m, fg_pct, fga, fta, tov"
         )
+        if use_copy:
+            return await self._copy_fs_rows(pool, player_rows, team_rows, player_cols, team_cols)
         try:
             async with pool.acquire() as conn:
                 async with conn.transaction():
@@ -1154,6 +1165,34 @@ class DBService:
             return True
         except Exception as e:
             logger.error(f"Failed to insert fs rows: {e}")
+            return False
+
+    async def _copy_fs_rows(
+        self, pool, player_rows: list[tuple], team_rows: list[tuple],
+        player_cols: str, team_cols: str,
+    ) -> bool:
+        """COPY path for insert_fs_rows(use_copy=True). Empty tables only."""
+        try:
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    for table, cols, rows in (
+                        ("fs_player_games", player_cols, player_rows),
+                        ("fs_team_games", team_cols, team_rows),
+                    ):
+                        if not rows:
+                            continue
+                        t0 = time.perf_counter()
+                        await conn.copy_records_to_table(
+                            table,
+                            records=rows,
+                            columns=[c.strip() for c in cols.split(",")],
+                        )
+                        logger.info(
+                            f"COPY {len(rows)} rows into {table} in {time.perf_counter() - t0:.1f}s"
+                        )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to COPY fs rows: {e}")
             return False
 
     async def truncate_fs_tables(self) -> bool:

--- a/backend/app/services/model_nightly_service.py
+++ b/backend/app/services/model_nightly_service.py
@@ -461,13 +461,21 @@ class ModelNightlyService:
                 f"for {', '.join(rconfig.SEASONS)}"
                 + (f" (until {until_date})" if until_date else "")
             )
+            logger.info("Bootstrap: writing raw game rows...")
+            # Tables are empty here (either freshly created or just truncated), so
+            # COPY is safe and turns a multi-minute per-row insert into seconds.
             if not await self._db.insert_fs_rows(
                 _frame_to_tuples(players, _FS_PLAYER_COLS),
                 _frame_to_tuples(team_games, _FS_TEAM_COLS),
+                use_copy=True,
             ):
                 return "db_write_failed"
 
+            logger.info("Bootstrap: building feature vectors (this is the slow step)...")
             vectors = await asyncio.to_thread(self._vectors_from_frames, players, team_games)
+            logger.info(
+                f"Bootstrap: writing {len(vectors[0])} player / {len(vectors[1])} team vectors..."
+            )
             if not await self._db.upsert_feature_vectors(*vectors):
                 return "db_write_failed"
             self._invalidate_inference_store()

--- a/backend/model_stats_inference/espn/client.py
+++ b/backend/model_stats_inference/espn/client.py
@@ -19,11 +19,12 @@ REQUEST_TIMEOUT = 30
 SLEEP_BETWEEN_CALLS = 0.15
 RETRY_DELAYS = [2.0, 5.0, 15.0]
 
+# No User-Agent override: ESPN's edge 403s browser-style UAs sent by a non-browser
+# client (a Chrome UA without Chrome's TLS fingerprint reads as a bot), and 403s
+# unrecognized custom UAs too. Library defaults (python-requests/*, python-httpx/*,
+# curl/*) are served normally — so the honest default is the one that works. The
+# async path already relies on httpx's default for the same reason.
 HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
-    ),
     "Accept": "application/json",
 }
 

--- a/backend/model_stats_inference/espn/games.py
+++ b/backend/model_stats_inference/espn/games.py
@@ -315,23 +315,31 @@ def fetch_seasons(
 
     With ``cache_dir`` each month's frames are parquet-cached, so an
     interrupted multi-thousand-request pull resumes where it stopped.
+
+    Only *finished* months are cached: caching the current (or a future) month
+    would freeze a half-played month's games into a file that is never refetched,
+    silently thinning every later pull.
     """
+    current_month = date.today().strftime("%Y%m")
     player_frames: list[pd.DataFrame] = []
     team_frames: list[pd.DataFrame] = []
     for season in seasons:
         for month in season_months(season):
-            if cache_dir is not None:
-                p_path = cache_dir / f"espn_{month}_players.parquet"
-                t_path = cache_dir / f"espn_{month}_teams.parquet"
-                if p_path.exists() and t_path.exists():
-                    player_frames.append(pd.read_parquet(p_path))
-                    team_frames.append(pd.read_parquet(t_path))
-                    continue
+            paths = (
+                (cache_dir / f"espn_{month}_players.parquet",
+                 cache_dir / f"espn_{month}_teams.parquet")
+                if cache_dir is not None and month < current_month
+                else None
+            )
+            if paths is not None and paths[0].exists() and paths[1].exists():
+                player_frames.append(pd.read_parquet(paths[0]))
+                team_frames.append(pd.read_parquet(paths[1]))
+                continue
             players, teams = fetch_month(month)
-            if cache_dir is not None:
-                cache_dir.mkdir(parents=True, exist_ok=True)
-                players.to_parquet(p_path, index=False)
-                teams.to_parquet(t_path, index=False)
+            if paths is not None:
+                paths[0].parent.mkdir(parents=True, exist_ok=True)
+                players.to_parquet(paths[0], index=False)
+                teams.to_parquet(paths[1], index=False)
             player_frames.append(players)
             team_frames.append(teams)
 

--- a/backend/model_stats_inference/research/config.py
+++ b/backend/model_stats_inference/research/config.py
@@ -12,7 +12,7 @@ from pathlib import Path
 # --- Data scope ------------------------------------------------------------
 
 # Last 4 full seasons. NBA season string format is "YYYY-YY".
-SEASONS: list[str] = ["2022-23", "2023-24", "2024-25", "2025-26"]
+SEASONS: list[str] = ["2022-23", "2023-24", "2024-25", "2025-26", "2026-27"]
 
 # Regular season only (excludes playoffs / play-in / preseason / all-star).
 SEASON_TYPE = "Regular Season"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,7 +30,9 @@ ml-research = ["shap>=0.52.0", "matplotlib>=3.11.0", "lightgbm>=4.6.0"]
 default-groups = ["test"]
 
 [tool.pytest.ini_options]
+addopts = "-m 'not live'"
 markers = [
     "real_dataprovider: use real DataProvider singleton (nested patch) for unit tests",
+    "live: hits a real external API (ESPN); excluded by default, run with -m live",
 ]
 

--- a/backend/scripts/refresh_feature_vectors.py
+++ b/backend/scripts/refresh_feature_vectors.py
@@ -66,6 +66,59 @@ def _print_counts(title: str, counts: dict[str, int]) -> None:
         print(f"  {t:<28} {'(missing)' if n < 0 else f'{n:,}'}")
 
 
+async def _feature_gap(db, service_cls) -> set[str] | None:
+    """Features the deployed models need that the stored vectors don't carry.
+
+    Same comparison the nightly makes on startup (_ensure_vectors_current), so a
+    clean result here means that warning will not fire. None = not bootstrapped.
+    """
+    stored = await db.get_feature_vector_keys()
+    if stored is None:
+        return None
+    return service_cls._required_stored_features() - stored
+
+
+async def _report_gap(db, service_cls, pool, header: str) -> int:
+    """Print the missing-feature verdict. Returns a process exit code."""
+    missing = await _feature_gap(db, service_cls)
+    print(f"\n{header}")
+    if missing is None:
+        print("  vectors not bootstrapped (or DB unreachable) - nothing to check")
+        return 1
+    if missing:
+        print(f"  FAIL: {len(missing)} feature(s) the models need are absent from the vectors:")
+        for f in sorted(missing):
+            print(f"    - {f}")
+        print("  The nightly will log its 'Feature vectors are missing N feature(s)' warning")
+        print("  and read these as NaN. Re-run this script without --check to rebuild.")
+        return 1
+    print("  PASS: every feature the deployed models need is present in the stored vectors")
+
+    # get_feature_vector_keys samples one row per table, which only characterises
+    # the table while every row carries the same keys. A player who drops out of a
+    # rebuild keeps their old blob, so check uniformity rather than trusting it.
+    odd = await _nonuniform_player_vectors(pool)
+    if odd:
+        print(f"  WARN: {odd} player vector(s) carry a different feature-key set than the "
+              "majority - stale rows the last rebuild did not rewrite")
+    return 0
+
+
+async def _nonuniform_player_vectors(pool) -> int:
+    """Player vectors whose feature-key count differs from the most common one."""
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            """
+            WITH sizes AS (
+                SELECT player_id, (SELECT COUNT(*) FROM jsonb_object_keys(features)) AS n
+                FROM fs_player_vectors
+            ),
+            modal AS (SELECT n FROM sizes GROUP BY n ORDER BY COUNT(*) DESC LIMIT 1)
+            SELECT COUNT(*) FROM sizes WHERE n <> (SELECT n FROM modal)
+            """
+        )
+
+
 async def _main(args: argparse.Namespace) -> int:
     # Imported here so --database-url (exported below) is seen by app settings.
     from app.services.db_service import DBService
@@ -84,6 +137,11 @@ async def _main(args: argparse.Namespace) -> int:
         else datetime.now(ZoneInfo("Asia/Jerusalem")).date()
     )
     _print_counts("Current vector counts:", await _counts(pool, VECTOR_TABLES))
+
+    if args.check:
+        code = await _report_gap(db, ModelNightlyService, pool, "Feature check (read-only, nothing written):")
+        await db.close()
+        return code
 
     # Steps are inlined rather than calling ModelNightlyService._refresh_vectors_through
     # so the upsert result is actually checked — that helper discards it, which would
@@ -117,7 +175,10 @@ async def _main(args: argparse.Namespace) -> int:
 
     _print_counts("New vector counts:", await _counts(pool, VECTOR_TABLES))
 
-    # Prove the write landed rather than trusting the return value alone.
+    # Prove the write landed rather than trusting the return value alone. Every exit
+    # stays inside the acquire block; closing the pool while a connection is checked
+    # out makes Pool.close() block for 60s waiting on a connection it cannot reclaim.
+    expect_failed = 0
     async with pool.acquire() as conn:
         fresh = await conn.fetchval(
             "SELECT COUNT(*) FROM fs_player_vectors WHERE updated_at >= NOW() - INTERVAL '10 minutes'"
@@ -129,19 +190,28 @@ async def _main(args: argparse.Namespace) -> int:
             )
             total = await conn.fetchval("SELECT COUNT(*) FROM fs_player_vectors")
             print(f"  {have:,}/{total:,} player vectors carry {args.expect_feature!r}")
-            if have < total:
-                print(
-                    f"ERROR: {total - have:,} vectors are missing {args.expect_feature!r} — is the "
-                    "deployed code the version that emits it?",
-                    file=sys.stderr,
-                )
-                await db.close()
-                return 1
+            expect_failed = total - have
+
+    if expect_failed:
+        # Stricter than --check: this counts every stored row, including rows the
+        # rebuild no longer produces (players dropped for staleness / sub-MIN_MINUTES),
+        # which keep their old blob. --check asks the question the models actually ask.
+        print(
+            f"ERROR: {expect_failed:,} vector(s) lack {args.expect_feature!r}. If --check passes, "
+            "these are stale rows no longer rebuilt, not a code-version problem.",
+            file=sys.stderr,
+        )
+        await db.close()
+        return 1
+
+    # The real proof: not "did rows get written" but "does the store now satisfy
+    # every feature the deployed models load". Same check the nightly runs.
+    code = await _report_gap(db, ModelNightlyService, pool, "Verification:")
 
     print(f"\nDone in {time.perf_counter() - t0:.1f}s — vectors re-materialized; "
           "restart the app so it loads them (and any new models).")
     await db.close()
-    return 0
+    return code
 
 
 if __name__ == "__main__":
@@ -152,6 +222,11 @@ if __name__ == "__main__":
         "--expect-feature",
         help="verify every player vector carries this feature key afterwards "
              "(e.g. USG_w10_mean); exits non-zero if any is missing",
+    )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="read-only: report whether the stored vectors satisfy every feature the "
+             "deployed models need, then exit. Writes nothing. Non-zero if any is missing",
     )
     args = parser.parse_args()
 

--- a/backend/scripts/verify_nightly_run.py
+++ b/backend/scripts/verify_nightly_run.py
@@ -1,0 +1,274 @@
+"""Verify one nightly run against reality, and print a pass/fail report.
+
+The nightly job's unit tests use fakes, so they prove the orchestration and
+nothing about real data. This script inspects what a real run actually wrote:
+did it cover the whole slate, are the predictions in the accuracy band the models
+were trained to, and are the feature vectors current afterwards.
+
+The accuracy check is the point. A pipeline with a broken opponent map or a
+NaN-filled feature vector still "succeeds" — it just predicts badly. Comparing
+per-stat MAE against the training MAE in ``models/model_card.json`` is what
+separates "ESPN changed and we're silently ingesting garbage" from "one noisy
+night". A single night has ~200 eligible rows and a broader population than the
+training corpus (MIN_INFERENCE_GAMES=10 vs MIN_PLAYER_GAMES=20), so the band is
+deliberately loose — it catches collapse, not drift.
+
+Usage (from backend/):
+    python scripts/verify_nightly_run.py --date 2026-03-05
+    DATABASE_URL=... python scripts/verify_nightly_run.py --date 2026-03-05 --espn
+    python scripts/verify_nightly_run.py --date 2026-03-05 --mae-tolerance 2.0
+
+Exits non-zero if any check fails. Read-only — it never writes to the database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+EVAL_STATS = ["PTS", "REB", "AST", "FG3M", "STL", "BLK", "FGM", "FGA", "FTM", "FTA"]
+
+# Ineligible reasons come from serving/errors.py. "N game(s) of history" is the
+# expected one (rookies, early season). An unknown *team* is never expected — it
+# means the ESPN team-id space no longer matches the feature store. An unknown
+# *player* is normal in small numbers (call-ups) and alarming in bulk.
+BENIGN_REASON = "history"
+TEAM_REASON = "opponent team"
+UNKNOWN_PLAYER_SHARE_LIMIT = 0.15
+
+VECTOR_STALENESS_DAYS = 2
+
+
+class Report:
+    def __init__(self) -> None:
+        self.rows: list[tuple[bool | None, str, str]] = []
+
+    def check(self, ok: bool, name: str, detail: str = "") -> bool:
+        self.rows.append((ok, name, detail))
+        return ok
+
+    def info(self, name: str, detail: str) -> None:
+        self.rows.append((None, name, detail))
+
+    def print(self) -> bool:
+        print()
+        for ok, name, detail in self.rows:
+            tag = "INFO" if ok is None else ("PASS" if ok else "FAIL")
+            print(f"  [{tag}] {name:<38} {detail}")
+        failed = [r for r in self.rows if r[0] is False]
+        print()
+        if failed:
+            print(f"{len(failed)} check(s) FAILED:")
+            for _, name, detail in failed:
+                print(f"  - {name}: {detail}")
+        else:
+            print("All checks passed.")
+        return not failed
+
+
+def load_mae_baselines() -> dict[str, float]:
+    card = Path(__file__).resolve().parents[1] / "model_stats_inference" / "models" / "model_card.json"
+    data = json.loads(card.read_text())
+    return {k: v["mae_mean"] for k, v in data.items() if isinstance(v, dict) and "mae_mean" in v}
+
+
+def espn_countable_games(game_date: date) -> tuple[int, bool]:
+    from model_stats_inference.espn import client, games
+    sb = client.scoreboard(game_date.strftime("%Y%m%d"))
+    events = [e for e in sb.get("events", []) if games.is_countable(e)]
+    return len(events), all(games.is_final(e) for e in events)
+
+
+async def check_ledger(conn, d: date, rep: Report) -> dict | None:
+    row = await conn.fetchrow("SELECT * FROM model_nightly_runs WHERE game_date = $1", d)
+    if not rep.check(row is not None, "ledger row exists", "" if row else "no model_nightly_runs row — the job never ran for this date"):
+        return None
+    row = dict(row)
+    rep.check(
+        row["status"] in ("processed", "no_games"),
+        "ledger status",
+        f"status={row['status']} games={row['num_games']} rows={row['num_rows']}",
+    )
+    return row
+
+
+async def check_coverage(conn, d: date, ledger: dict, rep: Report, use_espn: bool) -> None:
+    eval_games = await conn.fetchval(
+        "SELECT COUNT(DISTINCT game_id) FROM model_eval_results WHERE game_date = $1", d)
+    store_games = await conn.fetchval(
+        "SELECT COUNT(DISTINCT game_id) FROM fs_player_games WHERE game_date = $1", d)
+    team_rows = await conn.fetchval(
+        "SELECT COUNT(*) FROM fs_team_games WHERE game_date = $1", d)
+    player_rows = await conn.fetchval(
+        "SELECT COUNT(*) FROM fs_player_games WHERE game_date = $1", d)
+
+    rep.check(eval_games == ledger["num_games"], "eval games == ledger games",
+              f"eval={eval_games} ledger={ledger['num_games']}")
+    rep.check(store_games == eval_games, "store games == eval games",
+              f"store={store_games} eval={eval_games}")
+    rep.check(team_rows == 2 * store_games, "team rows == 2x games",
+              f"team_rows={team_rows} games={store_games}")
+    if store_games:
+        per_game = player_rows / store_games
+        rep.check(14 <= per_game <= 32, "player rows per game in range",
+                  f"{per_game:.1f} rows/game ({player_rows} total)")
+
+    if use_espn:
+        espn_games, all_final = espn_countable_games(d)
+        rep.check(espn_games == store_games, "ESPN slate fully ingested",
+                  f"espn={espn_games} store={store_games}")
+        rep.check(all_final, "ESPN games all final", "")
+
+
+async def check_eligibility(conn, d: date, rep: Report) -> int:
+    total = await conn.fetchval(
+        "SELECT COUNT(*) FROM model_eval_results WHERE game_date = $1", d)
+    eligible = await conn.fetchval(
+        "SELECT COUNT(*) FROM model_eval_results WHERE game_date = $1 AND eligible", d)
+    if not rep.check(total > 0, "eval rows written", f"{total} rows"):
+        return 0
+
+    share = eligible / total
+    rep.check(share >= 0.4, "eligible share >= 40%", f"{eligible}/{total} = {share:.0%}")
+
+    reasons = await conn.fetch(
+        "SELECT reason, COUNT(*) AS n FROM model_eval_results "
+        "WHERE game_date = $1 AND NOT eligible GROUP BY reason ORDER BY n DESC", d)
+    if not reasons:
+        rep.info("ineligible reasons", "none")
+    unknown_players = 0
+    for r in reasons:
+        reason = (r["reason"] or "").lower()
+        if BENIGN_REASON in reason:
+            rep.info("ineligible: insufficient history", f"{r['n']} rows")
+        elif TEAM_REASON in reason:
+            rep.check(False, "ineligible: unknown opponent team",
+                      f"{r['n']} rows — team-id space broken: {r['reason'][:60]}")
+        else:
+            unknown_players += r["n"]
+    if unknown_players:
+        share = unknown_players / total
+        rep.check(share <= UNKNOWN_PLAYER_SHARE_LIMIT, "unknown players within tolerance",
+                  f"{unknown_players}/{total} = {share:.0%} never seen in the store")
+
+    nulls = await conn.fetchval(
+        "SELECT COUNT(*) FROM model_eval_results WHERE game_date = $1 AND eligible AND pred_pts IS NULL", d)
+    rep.check(nulls == 0, "no NULL predictions on eligible rows", f"{nulls} null")
+    return eligible
+
+
+async def check_accuracy(conn, d: date, rep: Report, tolerance: float) -> None:
+    baselines = load_mae_baselines()
+    selects = ", ".join(
+        f"AVG(ABS(pred_{s.lower()} - actual_{s.lower()})) AS mae_{s.lower()}, "
+        f"STDDEV_POP(pred_{s.lower()}) AS sd_{s.lower()}"
+        for s in EVAL_STATS
+    )
+    row = await conn.fetchrow(
+        f"SELECT {selects} FROM model_eval_results WHERE game_date = $1 AND eligible", d)
+
+    for stat in EVAL_STATS:
+        mae = row[f"mae_{stat.lower()}"]
+        sd = row[f"sd_{stat.lower()}"]
+        base = baselines.get(stat)
+        if mae is None or base is None:
+            rep.check(False, f"MAE {stat}", "no data / no training baseline")
+            continue
+        limit = base * tolerance
+        rep.check(mae <= limit, f"MAE {stat} <= {limit:.2f}",
+                  f"{mae:.2f} (training {base:.2f}, x{mae / base:.2f})")
+        rep.check(sd is not None and sd > 0.01, f"{stat} predictions vary",
+                  f"sd={sd:.3f}" if sd is not None else "sd=None — all predictions identical")
+
+
+async def check_vectors(conn, d: date, rep: Report) -> None:
+    row = await conn.fetchrow(
+        "SELECT COUNT(*) AS n, MAX(updated_at) AS updated, MAX(last_game_date) AS last, "
+        "COUNT(*) FILTER (WHERE eligible) AS eligible FROM fs_player_vectors")
+    rep.check(row["n"] > 300, "player vectors present", f"{row['n']} rows, {row['eligible']} eligible")
+    if row["last"] is not None:
+        rep.check(row["last"] >= d, "vectors include the verified night",
+                  f"max last_game_date={row['last']}")
+    if row["updated"] is not None:
+        age = datetime.now(timezone.utc) - row["updated"]
+        rep.check(age <= timedelta(days=VECTOR_STALENESS_DAYS), "vectors refreshed recently",
+                  f"updated_at={row['updated']:%Y-%m-%d %H:%M} ({age.days}d old)")
+
+    played = await conn.fetch(
+        "SELECT DISTINCT player_id FROM fs_player_games WHERE game_date = $1 LIMIT 50", d)
+    missing = 0
+    null_features = 0
+    for r in played:
+        v = await conn.fetchrow(
+            "SELECT last_game_date, features FROM fs_player_vectors WHERE player_id = $1", r["player_id"])
+        if v is None:
+            missing += 1
+            continue
+        feats = json.loads(v["features"]) if isinstance(v["features"], str) else v["features"]
+        if not feats or all(x is None for x in feats.values()):
+            null_features += 1
+    rep.check(missing == 0, "everyone who played has a vector", f"{missing} missing of {len(played)} sampled")
+    rep.check(null_features == 0, "sampled vectors are not all-NaN", f"{null_features} empty of {len(played)} sampled")
+
+    for table in ("fs_team_allowed_vectors", "fs_team_own_vectors"):
+        n = await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+        rep.check(n == 30, f"{table} has 30 teams", f"{n} rows")
+
+
+async def _main(args: argparse.Namespace) -> int:
+    from app.services.db_service import DBService
+
+    d = date.fromisoformat(args.date)
+    db = DBService()
+    pool = await db._get_pool()
+    if pool is None:
+        print("ERROR: cannot connect — check --database-url / DATABASE_URL", file=sys.stderr)
+        return 1
+
+    rep = Report()
+    print(f"Verifying nightly run for {d} (MAE tolerance x{args.mae_tolerance})")
+    async with pool.acquire() as conn:
+        ledger = await check_ledger(conn, d, rep)
+        if ledger is None:
+            await db.close()
+            rep.print()
+            return 1
+        if ledger["status"] == "no_games":
+            rep.info("no games", "off-night — nothing further to verify")
+            await db.close()
+            return 0 if rep.print() else 1
+
+        await check_coverage(conn, d, ledger, rep, args.espn)
+        eligible = await check_eligibility(conn, d, rep)
+        if eligible:
+            await check_accuracy(conn, d, rep, args.mae_tolerance)
+        await check_vectors(conn, d, rep)
+
+    await db.close()
+    return 0 if rep.print() else 1
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Verify one nightly run against reality, and print a pass/fail report.")
+    parser.add_argument("--date", required=True, help="game date to verify (YYYY-MM-DD)")
+    parser.add_argument("--database-url", help="Postgres URL; falls back to DATABASE_URL env")
+    parser.add_argument("--espn", action="store_true",
+                        help="also fetch the real scoreboard and confirm no game was missed")
+    parser.add_argument("--mae-tolerance", type=float, default=1.6,
+                        help="multiple of training MAE allowed for a single night (default 1.6)")
+    args = parser.parse_args()
+
+    if args.database_url:
+        os.environ["DATABASE_URL"] = args.database_url
+    if not os.environ.get("DATABASE_URL"):
+        parser.error("no database given — pass --database-url or set DATABASE_URL")
+
+    raise SystemExit(asyncio.run(_main(args)))

--- a/backend/scripts/verify_nightly_run.py
+++ b/backend/scripts/verify_nightly_run.py
@@ -143,16 +143,20 @@ async def check_eligibility(conn, d: date, rep: Report) -> int:
         "WHERE game_date = $1 AND NOT eligible GROUP BY reason ORDER BY n DESC", d)
     if not reasons:
         rep.info("ineligible reasons", "none")
+    # Reasons embed the player id, so each is unique — group by kind, not by string.
     unknown_players = 0
+    insufficient_history = 0
     for r in reasons:
         reason = (r["reason"] or "").lower()
         if BENIGN_REASON in reason:
-            rep.info("ineligible: insufficient history", f"{r['n']} rows")
+            insufficient_history += r["n"]
         elif TEAM_REASON in reason:
             rep.check(False, "ineligible: unknown opponent team",
                       f"{r['n']} rows - team-id space broken: {r['reason'][:60]}")
         else:
             unknown_players += r["n"]
+    if insufficient_history:
+        rep.info("ineligible: insufficient history", f"{insufficient_history} rows")
     if unknown_players:
         share = unknown_players / total
         rep.check(share <= UNKNOWN_PLAYER_SHARE_LIMIT, "unknown players within tolerance",

--- a/backend/scripts/verify_nightly_run.py
+++ b/backend/scripts/verify_nightly_run.py
@@ -88,7 +88,7 @@ def espn_countable_games(game_date: date) -> tuple[int, bool]:
 
 async def check_ledger(conn, d: date, rep: Report) -> dict | None:
     row = await conn.fetchrow("SELECT * FROM model_nightly_runs WHERE game_date = $1", d)
-    if not rep.check(row is not None, "ledger row exists", "" if row else "no model_nightly_runs row — the job never ran for this date"):
+    if not rep.check(row is not None, "ledger row exists", "" if row else "no model_nightly_runs row - the job never ran for this date"):
         return None
     row = dict(row)
     rep.check(
@@ -150,7 +150,7 @@ async def check_eligibility(conn, d: date, rep: Report) -> int:
             rep.info("ineligible: insufficient history", f"{r['n']} rows")
         elif TEAM_REASON in reason:
             rep.check(False, "ineligible: unknown opponent team",
-                      f"{r['n']} rows — team-id space broken: {r['reason'][:60]}")
+                      f"{r['n']} rows - team-id space broken: {r['reason'][:60]}")
         else:
             unknown_players += r["n"]
     if unknown_players:
@@ -229,27 +229,23 @@ async def _main(args: argparse.Namespace) -> int:
     db = DBService()
     pool = await db._get_pool()
     if pool is None:
-        print("ERROR: cannot connect — check --database-url / DATABASE_URL", file=sys.stderr)
+        print("ERROR: cannot connect - check --database-url / DATABASE_URL", file=sys.stderr)
         return 1
 
     rep = Report()
     print(f"Verifying nightly run for {d} (MAE tolerance x{args.mae_tolerance})")
+    # Every early exit stays inside the acquire block; closing the pool while a
+    # connection is still checked out makes Pool.close() hang until it times out.
     async with pool.acquire() as conn:
         ledger = await check_ledger(conn, d, rep)
-        if ledger is None:
-            await db.close()
-            rep.print()
-            return 1
-        if ledger["status"] == "no_games":
-            rep.info("no games", "off-night — nothing further to verify")
-            await db.close()
-            return 0 if rep.print() else 1
-
-        await check_coverage(conn, d, ledger, rep, args.espn)
-        eligible = await check_eligibility(conn, d, rep)
-        if eligible:
-            await check_accuracy(conn, d, rep, args.mae_tolerance)
-        await check_vectors(conn, d, rep)
+        if ledger is not None and ledger["status"] == "no_games":
+            rep.info("no games", "off-night - nothing further to verify")
+        elif ledger is not None:
+            await check_coverage(conn, d, ledger, rep, args.espn)
+            eligible = await check_eligibility(conn, d, rep)
+            if eligible:
+                await check_accuracy(conn, d, rep, args.mae_tolerance)
+            await check_vectors(conn, d, rep)
 
     await db.close()
     return 0 if rep.print() else 1

--- a/backend/scripts/verify_nightly_run.py
+++ b/backend/scripts/verify_nightly_run.py
@@ -33,6 +33,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from model_stats_inference.research import config as rconfig  # noqa: E402  (needs sys.path above)
+
 EVAL_STATS = ["PTS", "REB", "AST", "FG3M", "STL", "BLK", "FGM", "FGA", "FTM", "FTA"]
 
 # Ineligible reasons come from serving/errors.py. "N game(s) of history" is the
@@ -205,8 +207,12 @@ async def check_vectors(conn, d: date, rep: Report) -> None:
         rep.check(age <= timedelta(days=VECTOR_STALENESS_DAYS), "vectors refreshed recently",
                   f"updated_at={row['updated']:%Y-%m-%d %H:%M} ({age.days}d old)")
 
+    # Sub-MIN_MINUTES appearances are excluded from the feature store by design
+    # (get_fs_rows_before gates on the same threshold), so a garbage-time debut
+    # legitimately has no vector — only players above the threshold must have one.
     played = await conn.fetch(
-        "SELECT DISTINCT player_id FROM fs_player_games WHERE game_date = $1 LIMIT 50", d)
+        "SELECT DISTINCT player_id FROM fs_player_games "
+        "WHERE game_date = $1 AND min >= $2 LIMIT 50", d, rconfig.MIN_MINUTES)
     missing = 0
     null_features = 0
     for r in played:

--- a/backend/tests/live/test_espn_contract.py
+++ b/backend/tests/live/test_espn_contract.py
@@ -109,7 +109,7 @@ def test_season_and_date_stamped_correctly(night):
 
 
 def test_matchup_format(night):
-    assert night.players["MATCHUP"].str.contains(r"^[A-Z]{2,3} (vs\.|@) [A-Z]{2,3}$", regex=True).all()
+    assert night.players["MATCHUP"].str.contains(r"^[A-Z]{2,3} (?:vs\.|@) [A-Z]{2,3}$", regex=True).all()
 
 
 def test_cup_final_is_excluded():

--- a/backend/tests/live/test_espn_contract.py
+++ b/backend/tests/live/test_espn_contract.py
@@ -1,0 +1,133 @@
+"""Contract tests against the LIVE ESPN site API.
+
+Everything else in the suite feeds `espn.fetch_day` fake JSON, so a schema change
+on ESPN's side (renamed stat labels, a moved athlete id, reworded Cup/All-Star
+notes) passes CI and silently poisons the feature store. These tests hit the real
+endpoint and assert the invariants the whole model pipeline depends on.
+
+Excluded from the default run — they need network and take ~30s:
+
+    uv run pytest -m live tests/live -q
+
+The three dates below are fixed points in a finished season, so the expected
+answers never drift. Each test fails loudly (not vacuously) if its date turns out
+to have no games at all, which is the signal that the date needs updating.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.model_nightly_service import _FS_PLAYER_COLS, _FS_TEAM_COLS
+from model_stats_inference.espn import client, games
+
+pytestmark = pytest.mark.live
+
+REGULAR_NIGHT = date(2026, 1, 14)
+CUP_FINAL_NIGHT = date(2025, 12, 16)
+ALL_STAR_NIGHT = date(2026, 2, 15)
+OFFSEASON_NIGHT = date(2026, 7, 15)
+
+_COUNTING = ["PTS", "REB", "OREB", "DREB", "AST", "FG3M", "FG3A",
+             "STL", "BLK", "TOV", "FGM", "FGA", "FTM", "FTA", "PF"]
+
+
+@pytest.fixture(scope="module")
+def night():
+    return games.fetch_day(REGULAR_NIGHT)
+
+
+def test_slate_is_final_and_non_empty(night):
+    assert night.expected_games >= 2
+    assert night.all_final
+
+
+def test_row_counts_match_slate(night):
+    assert len(night.teams) == 2 * night.expected_games
+    per_game = len(night.players) / night.expected_games
+    assert 14 <= per_game <= 32
+
+
+def test_frame_schema_matches_db_column_order(night):
+    assert list(night.players.columns) == games.PLAYER_COLUMNS
+    assert list(night.teams.columns) == games.TEAM_COLUMNS
+    assert games.PLAYER_COLUMNS == _FS_PLAYER_COLS
+    assert games.TEAM_COLUMNS == _FS_TEAM_COLS
+
+
+def test_no_nulls_in_key_columns(night):
+    for col in ["PLAYER_ID", "GAME_ID", "TEAM_ID", "PLAYER_NAME", "MATCHUP", "MIN"]:
+        assert night.players[col].notna().all(), col
+    assert (night.players["PLAYER_NAME"].str.len() > 0).all()
+    assert night.players["TEAM_ID"].isin(games.TEAM_IDS).all()
+    assert night.teams["TEAM_ID"].isin(games.TEAM_IDS).all()
+
+
+def test_stat_labels_parsed_not_zeroed(night):
+    """A renamed ESPN stat label wouldn't raise — `_num` would quietly yield 0.0
+    for every player. Non-zero league totals are the only proof it still parses."""
+    for col in _COUNTING + ["MIN"]:
+        assert night.players[col].sum() > 0, f"{col} is all zeros — label renamed?"
+
+
+def test_made_never_exceeds_attempted(night):
+    p = night.players
+    assert (p["FGM"] <= p["FGA"]).all()
+    assert (p["FG3M"] <= p["FG3A"]).all()
+    assert (p["FTM"] <= p["FTA"]).all()
+    assert (p["FG3M"] <= p["FGM"]).all()
+
+
+def test_player_points_sum_to_the_final_score(night):
+    """Catches silently dropped player rows: `build_game_rows` skips athletes
+    whose stat list length mismatches, so a schema drift shows up here as a team
+    whose player points no longer add up to its box score."""
+    summed = night.players.groupby(["GAME_ID", "TEAM_ID"])["PTS"].sum()
+    actual = night.teams.set_index(["GAME_ID", "TEAM_ID"])["PTS"]
+    assert (summed == actual.reindex(summed.index)).all()
+
+
+def test_positions_present_on_rotation_players(night):
+    rotation = night.players[night.players["MIN"] >= 20]
+    assert len(rotation) >= 5 * night.expected_games
+    filled = (rotation["POSITION"].str.len() > 0).mean()
+    assert filled >= 0.95
+
+
+def test_minutes_are_plausible(night):
+    assert night.players["MIN"].max() <= 60
+    starters = night.players[night.players["MIN"] >= 25]
+    assert len(starters) >= 4 * night.expected_games
+
+
+def test_season_and_date_stamped_correctly(night):
+    assert set(night.players["SEASON"]) == {games.season_for(REGULAR_NIGHT)}
+    assert set(night.players["GAME_DATE"].dt.date) == {REGULAR_NIGHT}
+    assert not night.players.duplicated(["PLAYER_ID", "GAME_ID"]).any()
+
+
+def test_matchup_format(night):
+    assert night.players["MATCHUP"].str.contains(r"^[A-Z]{2,3} (vs\.|@) [A-Z]{2,3}$", regex=True).all()
+
+
+def test_cup_final_is_excluded():
+    sb = client.scoreboard(CUP_FINAL_NIGHT.strftime("%Y%m%d"))
+    events = sb.get("events", [])
+    assert events, "no events on the Cup final date — update CUP_FINAL_NIGHT"
+    assert [e for e in events if games.is_countable(e)] == []
+
+
+def test_all_star_is_excluded():
+    sb = client.scoreboard(ALL_STAR_NIGHT.strftime("%Y%m%d"))
+    events = sb.get("events", [])
+    assert events, "no events on the All-Star date — update ALL_STAR_NIGHT"
+    assert [e for e in events if games.is_countable(e)] == []
+
+
+def test_offseason_night_is_empty():
+    day = games.fetch_day(OFFSEASON_NIGHT)
+    assert day.expected_games == 0
+    assert day.all_final
+    assert day.players.empty

--- a/backend/tests/services/test_model_nightly_service.py
+++ b/backend/tests/services/test_model_nightly_service.py
@@ -56,8 +56,9 @@ class FakeDB:
         self.eval_rows = rows
         return self.eval_insert_ok
 
-    async def insert_fs_rows(self, player_rows, team_rows):
+    async def insert_fs_rows(self, player_rows, team_rows, use_copy=False):
         self.fs_rows = (player_rows, team_rows)
+        self.fs_used_copy = use_copy
         return self.fs_insert_ok
 
     async def upsert_feature_vectors(self, player_rows, team_allowed_rows, team_own_rows):


### PR DESCRIPTION
## Why

The nightly model pipeline has been **failing in production every 30 minutes**, not just at risk of failing. Render logs show `EspnUnavailableError` at `nightly.fetch_night` on every scheduler slot; each attempt burned ~23s, matching `RETRY_DELAYS` (2+5+15) before giving up.

Root cause: ESPN's edge now rejects browser-style User-Agents sent by non-browser clients. `espn/client.py` spoofed Chrome 126, so every sync ESPN call — nightly ingest, bootstrap, roster refresh — got HTTP 403. The site kept working because every request-time caller uses a bare `httpx` client and only this module overrode the UA.

Measured against the live scoreboard endpoint:

| User-Agent | result |
|---|---|
| `curl/8.5.0`, `python-requests/*`, `python-httpx/*`, `Python-urllib/*` | 200 |
| Chrome 126 (ours), `Mozilla/5.0`, `fantasyleagueinfo/1.0`, `foo` | 403 |

Known library UAs are served; browser-style and unknown custom UAs are refused. The fix is to send no UA override and let the library identify itself.

## What's in here

**The fix**
- `espn/client.py` — drop the spoofed UA. `Accept: application/json` is innocent and stays.

**Guards so this can't recur silently**
- `tests/live/test_espn_contract.py` — 14 tests against the real ESPN API, marked `live` and deselected by default (`addopts = -m 'not live'`), so CI is unaffected. Run with `uv run pytest -m live tests/live`. Asserts the invariants the pipeline depends on: row counts per slate, stat labels still parsing (non-zero league totals catch a renamed label that `_num` would quietly turn into 0.0), made ≤ attempted, player points summing to the final score (catches silently dropped rows), Cup final and All-Star excluded.
- `scripts/verify_nightly_run.py` — read-only pass/fail report on one processed night: slate coverage (optionally cross-checked against ESPN with `--espn`), eligibility reasons, per-stat MAE against the training baselines in `model_card.json`, prediction variance, vector freshness. Non-zero exit on failure.
- `scripts/refresh_feature_vectors.py --check` — read-only answer to "do the stored vectors satisfy the deployed models?", using the same comparison `_ensure_vectors_current` makes. Every non-check run now ends with the same verdict as its exit code.

**Bugs found along the way**
- `research/config.py` — `SEASONS` lacked `2026-27`; a re-bootstrap during the season would have silently dropped every new-season game.
- `espn/games.py` — `fetch_seasons` parquet-cached the *current* month, freezing a half-played month into a file never refetched. Now caches finished months only.
- `db_service.insert_fs_rows` — bootstrap wrote ~95k rows one INSERT at a time (6+ min, no logging). Bootstrap truncates first so conflicts are impossible; it now opts into COPY (76,518 rows in 1.1s). **The nightly's write path is unchanged** and still uses per-row INSERT with `ON CONFLICT DO NOTHING` — that clause is the idempotency/leakage guard and is worth more than milliseconds on ~200 rows.
- Two `Pool.close()` hangs where a script closed the pool while holding a checked-out connection.

## Verification

Replayed against a local Postgres, in two regimes, with the real ESPN API.

Mid-season:

| night | games | eligible | PTS MAE (training 3.86) |
|---|---|---|---|
| 2026-03-05 | 9 | 182/189 (96%) | 3.37 |
| 2026-03-06 | 7 | 152/154 (99%) | 3.44 |
| 2026-03-07 | 6 | 122/126 (97%) | 3.26 |

Opening week (2025-26), to test the early-season regime:

| night | games | eligible | PTS MAE |
|---|---|---|---|
| 2025-10-21 (opener) | 2 | 37/39 (95%) | 4.87 |
| 2025-10-22 | 12 | 234/269 (87%) | 3.85 |
| 2025-10-23 | 2 | 37/43 (86%) | 5.01 |

ESPN's countable-game count matched the store on every night. All checks pass on all six.

Failure drills on 2026-03-05:
- rerun a processed date → `already_processed`
- delete the ledger row and rerun → `store_already_ingested`, and `model_eval_results` was **byte-identical afterwards** (md5 of the ordered pred/actual rows unchanged) — a crashed-and-retried run cannot produce a prediction that has seen its own outcome
- offseason date → `no_games`

`uv run pytest -q` → 526 passed, 14 deselected. `uv run pytest -m live tests/live` → 14 passed.

## Deploy note

Separately from this PR, prod feature vectors were missing the three USG features the models read (`USG_global_mean`, `USG_w10_mean`, `USG_w5_mean`) and were rebuilt via `refresh_feature_vectors.py`; `--check` now reports PASS against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)