### PR TITLE
fix(nightly): don't seal no-games night on an empty scoreboard glitch

### DIFF
--- a/backend/app/services/model_nightly_service.py
+++ b/backend/app/services/model_nightly_service.py
@@ -225,15 +225,18 @@ class ModelNightlyService:
             return "store_already_ingested"
 
         night = await asyncio.to_thread(nightly.fetch_night, game_date)
-        if night.expected_games == 0:
-            await db.upsert_model_nightly_run(game_date, "no_games", 0, 0)
-            return "no_games"
         if not night.complete:
+            # Checked before the expected_games==0 branch below: a zero-events
+            # scoreboard that ESPN's whitelist says should have games comes back
+            # as expected_games=0, complete=False too, and must retry, not seal.
             logger.info(
                 f"Night {game_date} not complete yet "
                 f"(expected {night.expected_games} games); will retry next slot"
             )
             return "incomplete_data"
+        if night.expected_games == 0:
+            await db.upsert_model_nightly_run(game_date, "no_games", 0, 0)
+            return "no_games"
 
         players, team_games = await db.get_fs_rows_before(game_date)
         if players.empty or team_games.empty:

--- a/backend/model_stats_inference/espn/client.py
+++ b/backend/model_stats_inference/espn/client.py
@@ -121,6 +121,12 @@ def scoreboard(dates: str) -> dict:
     return get_json("scoreboard", {"dates": dates, "limit": 1000})
 
 
+def calendar_whitelist() -> list[str]:
+    """Sync twin of ``calendar_whitelist_async`` for the pure-sync nightly path."""
+    data = get_json("scoreboard", {"calendartype": "whitelist"})
+    return data["leagues"][0]["calendar"]
+
+
 def game_summary(event_id: str) -> dict:
     """Full game summary (boxscore, header) for one event."""
     return get_json("summary", {"event": event_id})

--- a/backend/model_stats_inference/espn/games.py
+++ b/backend/model_stats_inference/espn/games.py
@@ -62,6 +62,7 @@ class DayFetch:
     teams: pd.DataFrame
     expected_games: int   # countable games on the scoreboard
     all_final: bool       # every countable game is final
+    total_events: int = 0  # raw scoreboard event count, before the countability filter
 
 
 def season_for(d: date) -> str:
@@ -252,6 +253,7 @@ def _frames(player_rows: list[dict], team_rows: list[dict]) -> tuple[pd.DataFram
 def fetch_day(game_date: date) -> DayFetch:
     """One night's countable games with box scores (the nightly-ingest fetch)."""
     sb = client.scoreboard(game_date.strftime("%Y%m%d"))
+    total_events = len(sb.get("events", []))
     events = [e for e in sb.get("events", []) if is_countable(e)]
     all_final = all(is_final(e) for e in events) if events else True
 
@@ -274,7 +276,7 @@ def fetch_day(game_date: date) -> DayFetch:
         team_rows.extend(t)
 
     players, teams = _frames(player_rows, team_rows)
-    return DayFetch(game_date, players, teams, len(events), all_final)
+    return DayFetch(game_date, players, teams, len(events), all_final, total_events)
 
 
 def fetch_month(yyyymm: str) -> tuple[pd.DataFrame, pd.DataFrame]:

--- a/backend/model_stats_inference/serving/nightly.py
+++ b/backend/model_stats_inference/serving/nightly.py
@@ -13,8 +13,10 @@ mean "come back later".
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -26,6 +28,38 @@ from .inference import LiveInference, PredictionRequest
 from .eval_row import EvalRow, _actual_line
 
 season_for = espn.season_for
+
+logger = logging.getLogger(__name__)
+
+_WHITELIST_TTL = timedelta(hours=24)
+_whitelist_cache: dict = {'dates': None, 'ts': None}
+
+
+def _whitelist_has(game_date: date) -> bool:
+    """True if ESPN's own whitelist calendar lists ``game_date`` as a game day.
+
+    The whitelist includes preseason/playoffs/All-Star too, so it can only
+    answer "did ESPN schedule *something* this day", not countability — the
+    caller only uses this to tell a real scoreboard gap from a genuine
+    off-night when the day-scoreboard fetch itself came back empty.
+    """
+    now = datetime.now()
+    if _whitelist_cache['ts'] is None or now - _whitelist_cache['ts'] >= _WHITELIST_TTL:
+        try:
+            raw = espn.client.calendar_whitelist()
+        except Exception as e:
+            # A second independent ESPN failure must not stall the pipeline —
+            # fall back to today's behavior (seal the night as a genuine no-games).
+            logger.warning(f"calendar_whitelist fetch failed, treating {game_date} as no-games: {e}")
+            return False
+        _whitelist_cache['dates'] = {
+            datetime.fromisoformat(s.replace('Z', '+00:00'))
+            .astimezone(ZoneInfo('America/New_York'))
+            .date()
+            for s in raw
+        }
+        _whitelist_cache['ts'] = now
+    return game_date in _whitelist_cache['dates']
 
 
 @dataclass
@@ -42,6 +76,10 @@ def fetch_night(game_date: date) -> NightFetch:
     day = espn.fetch_day(game_date)
     if day.expected_games == 0:
         empty = pd.DataFrame()
+        if day.total_events == 0 and _whitelist_has(game_date):
+            # ESPN's own whitelist says this is a game day, but the scoreboard
+            # returned nothing — treat as incomplete data, not a sealed off-night.
+            return NightFetch(game_date, empty, empty, 0, complete=False)
         return NightFetch(game_date, empty, empty, 0, complete=True)
 
     player_games = rdata._to_datetime(day.players)

--- a/backend/model_stats_inference/serving/test_nightly.py
+++ b/backend/model_stats_inference/serving/test_nightly.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import date
 
 import pandas as pd
+import pytest
 
+from model_stats_inference.espn import EspnUnavailableError
 from model_stats_inference.serving import nightly
 from model_stats_inference.serving.inference import LiveInference, PredictionRequest
 
@@ -16,6 +18,15 @@ NIGHT_GID = "0021409900"
 UNKNOWN_GID = "0021409901"
 UNKNOWN_TEAM_A, UNKNOWN_TEAM_B = 30, 999
 UNKNOWN_PID = 999
+
+
+@pytest.fixture(autouse=True)
+def _reset_whitelist_cache():
+    nightly._whitelist_cache['dates'] = None
+    nightly._whitelist_cache['ts'] = None
+    yield
+    nightly._whitelist_cache['dates'] = None
+    nightly._whitelist_cache['ts'] = None
 
 
 def test_season_for_boundaries():
@@ -57,6 +68,99 @@ def test_fetch_night_keeps_any_played_minute(monkeypatch):
 
     assert set(night.player_games["PLAYER_ID"]) == {3, 4}
     assert night.complete
+
+
+def _zero_games_day(game_date: date, total_events: int) -> "nightly.espn.DayFetch":
+    empty = pd.DataFrame()
+    return nightly.espn.DayFetch(
+        game_date=game_date, players=empty, teams=empty,
+        expected_games=0, all_final=True, total_events=total_events,
+    )
+
+
+def test_fetch_night_no_countable_events_seals_complete(monkeypatch):
+    """Preseason/playoffs/All-Star: events exist but none are countable — this
+    must stay a sealed no-games night and never touch the whitelist."""
+    game_date = date(2025, 10, 3)
+    monkeypatch.setattr(nightly.espn, "fetch_day", lambda d: _zero_games_day(game_date, total_events=3))
+    calls = []
+    monkeypatch.setattr(nightly.espn.client, "calendar_whitelist", lambda: calls.append(1) or [])
+
+    night = nightly.fetch_night(game_date)
+
+    assert night.expected_games == 0
+    assert night.complete is True
+    assert calls == []
+
+
+def test_fetch_night_empty_scoreboard_in_whitelist_is_incomplete(monkeypatch):
+    """Scoreboard came back with zero events on a day ESPN's own whitelist lists
+    as a game day — treat as a transient gap, not a sealed off-night."""
+    game_date = date(2025, 12, 25)
+    monkeypatch.setattr(nightly.espn, "fetch_day", lambda d: _zero_games_day(game_date, total_events=0))
+    monkeypatch.setattr(
+        nightly.espn.client, "calendar_whitelist",
+        lambda: [f"{game_date.isoformat()}T17:00Z"],
+    )
+
+    night = nightly.fetch_night(game_date)
+
+    assert night.expected_games == 0
+    assert night.complete is False
+
+
+def test_fetch_night_empty_scoreboard_not_in_whitelist_seals_complete(monkeypatch):
+    """Genuine off-season/off-night: zero events and the day isn't in the
+    whitelist either — unchanged from today's behavior."""
+    game_date = date(2025, 7, 4)
+    monkeypatch.setattr(nightly.espn, "fetch_day", lambda d: _zero_games_day(game_date, total_events=0))
+    monkeypatch.setattr(
+        nightly.espn.client, "calendar_whitelist",
+        lambda: ["2025-10-21T23:00Z"],
+    )
+
+    night = nightly.fetch_night(game_date)
+
+    assert night.expected_games == 0
+    assert night.complete is True
+
+
+def test_fetch_night_whitelist_fetch_failure_falls_back_to_sealed(monkeypatch):
+    """A second ESPN failure (the whitelist call itself) must not stall the
+    pipeline — fall back to today's behavior of sealing the night."""
+    game_date = date(2025, 12, 25)
+    monkeypatch.setattr(nightly.espn, "fetch_day", lambda d: _zero_games_day(game_date, total_events=0))
+
+    def _raise():
+        raise EspnUnavailableError("boom")
+
+    monkeypatch.setattr(nightly.espn.client, "calendar_whitelist", _raise)
+
+    night = nightly.fetch_night(game_date)
+
+    assert night.expected_games == 0
+    assert night.complete is True
+
+
+def test_fetch_night_whitelist_cached_across_calls(monkeypatch):
+    """Two zero-event nights within the TTL window must only hit ESPN once."""
+    d1, d2 = date(2025, 12, 25), date(2025, 12, 26)
+    days = {d1: _zero_games_day(d1, total_events=0), d2: _zero_games_day(d2, total_events=0)}
+    monkeypatch.setattr(nightly.espn, "fetch_day", lambda d: days[d])
+    calls = []
+
+    def _fake_whitelist():
+        calls.append(1)
+        return [f"{d1.isoformat()}T17:00Z", f"{d2.isoformat()}T17:00Z"]
+
+    monkeypatch.setattr(nightly.espn.client, "calendar_whitelist", _fake_whitelist)
+
+    night1 = nightly.fetch_night(d1)
+    night2 = nightly.fetch_night(d2)
+
+    assert night1.complete is False
+    assert night2.complete is False
+    assert len(calls) == 1
 
 
 def test_bootstrap_frames_keeps_any_played_minute(monkeypatch):

--- a/backend/tests/services/test_model_nightly_service.py
+++ b/backend/tests/services/test_model_nightly_service.py
@@ -175,6 +175,16 @@ async def test_incomplete_data_left_unmarked_for_retry(service, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_empty_scoreboard_incomplete_is_retried_not_sealed(service, monkeypatch):
+    """expected_games=0 with complete=False (the whitelist-ambiguity guard in
+    nightly.fetch_night) must be retried, not sealed as 'no_games' — the
+    incomplete check has to run before the expected_games==0 check."""
+    _allow_fetch(monkeypatch, _night(expected_games=0, complete=False))
+    assert await service.run_for_date(GAME_DATE) == "incomplete_data"
+    assert service._db.marked == []
+
+
+@pytest.mark.asyncio
 async def test_empty_store_requires_bootstrap(service, monkeypatch):
     _allow_fetch(monkeypatch, _night())
     service._db.player_recs = pd.DataFrame()


### PR DESCRIPTION
## Summary
- `fetch_day` returning `expected_games == 0` collapsed two cases: a genuine off-night/preseason/playoffs night, and a transient empty ESPN scoreboard response on a date that ESPN's own whitelist calendar says has games. The second case was sealed permanently as `no_games` in the ledger with no retry — a silent, permanent hole in the feature store for that night.
- `DayFetch` now carries `total_events` (raw scoreboard event count, before the countability filter). `fetch_night` only consults the whitelist when `total_events == 0` — if the scoreboard has some events but none are countable (preseason/playoffs/All-Star), it's unchanged and sealed as before.
- When `total_events == 0` and the date IS in ESPN's whitelist, the night is now `complete=False` (`incomplete_data`) instead of sealed, so the scheduler retries it at the next slot / next day's catch-up.
- Fixed an ordering bug in `model_nightly_service._run_for_date`: it checked `expected_games == 0` before `not night.complete`, which would have sealed the new ambiguous case anyway. Swapped so `complete` is checked first — no behavior change for existing cases.
- Fallback: if the whitelist fetch itself fails, falls back to sealing (today's behavior) rather than risking a stall on a second independent ESPN outage.

## Test plan
- [x] `backend/model_stats_inference/serving/test_nightly.py` — 5 new cases: preseason/no-countable unaffected, empty+whitelisted→incomplete, empty+not-whitelisted→sealed, whitelist-fetch-failure→sealed, cache reused across calls (one HTTP call)
- [x] `backend/tests/services/test_model_nightly_service.py` — new case: `expected_games=0, complete=False` → `incomplete_data`, no ledger write
- [x] Full backend suite: `uv run pytest -q` → 532 passed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>