### PR TITLE
fix(frontend): stop remounting all Players rows on every sort

### DIFF
--- a/frontend/src/pages/Players.css
+++ b/frontend/src/pages/Players.css
@@ -212,11 +212,43 @@
 }
 
 .player-table {
-  width: 100%;
+  table-layout: fixed;
+  min-width: 1238px;
   border-collapse: collapse;
   background: #fff;
   font-size: 14px;
 }
+
+.player-table th:nth-child(1),
+.player-table td:nth-child(1) { width: 190px; }
+.player-table th:nth-child(2),
+.player-table td:nth-child(2) { width: 80px; }
+.player-table th:nth-child(3),
+.player-table td:nth-child(3) { width: 90px; }
+.player-table th:nth-child(4),
+.player-table td:nth-child(4) { width: 130px; }
+.player-table th:nth-child(5),
+.player-table td:nth-child(5) { width: 60px; }
+.player-table th:nth-child(6),
+.player-table td:nth-child(6) { width: 70px; }
+.player-table th:nth-child(7),
+.player-table td:nth-child(7) { width: 70px; }
+.player-table th:nth-child(8),
+.player-table td:nth-child(8) { width: 58px; }
+.player-table th:nth-child(9),
+.player-table td:nth-child(9) { width: 58px; }
+.player-table th:nth-child(10),
+.player-table td:nth-child(10) { width: 58px; }
+.player-table th:nth-child(11),
+.player-table td:nth-child(11) { width: 58px; }
+.player-table th:nth-child(12),
+.player-table td:nth-child(12) { width: 58px; }
+.player-table th:nth-child(13),
+.player-table td:nth-child(13) { width: 58px; }
+.player-table th:nth-child(14),
+.player-table td:nth-child(14) { width: 50px; }
+.player-table th:nth-child(15),
+.player-table td:nth-child(15) { width: 150px; }
 
 .player-table th {
   background: #f5f5f5;
@@ -250,6 +282,7 @@
   z-index: 11;
   background: #fff;
   border-right: 1px solid #ddd;
+  contain: layout paint;
 }
 
 .player-table th:first-child {
@@ -259,6 +292,16 @@
 
 .player-table tbody tr:hover {
   background: #f9f9f9;
+}
+
+/* Skip paint/layout for off-screen rows so the raster thread doesn't fall
+   behind on a fast fling — rows stay in the DOM (Ctrl-F, selection still
+   work), unlike JS virtualization which was rejected for the same symptom.
+   Excludes the matchup expand row: its height is dynamic (slider UI), and a
+   wrong contain-intrinsic-size guess there would jump the scrollbar. */
+.player-table tbody tr:not(.mq-expand-row) {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 50px;
 }
 
 .status-badge {

--- a/frontend/src/pages/Players.css
+++ b/frontend/src/pages/Players.css
@@ -212,8 +212,7 @@
 }
 
 .player-table {
-  table-layout: fixed;
-  min-width: 1197px;
+  width: 100%;
   border-collapse: collapse;
   background: #fff;
   font-size: 14px;
@@ -251,7 +250,6 @@
   z-index: 11;
   background: #fff;
   border-right: 1px solid #ddd;
-  contain: layout paint;
 }
 
 .player-table th:first-child {
@@ -261,16 +259,6 @@
 
 .player-table tbody tr:hover {
   background: #f9f9f9;
-}
-
-/* Skip paint/layout for off-screen rows so the raster thread doesn't fall
-   behind on a fast fling — rows stay in the DOM (Ctrl-F, selection still
-   work), unlike JS virtualization which was rejected for the same symptom.
-   Excludes the matchup expand row: its height is dynamic (slider UI), and a
-   wrong contain-intrinsic-size guess there would jump the scrollbar. */
-.player-table tbody tr:not(.mq-expand-row) {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 50px;
 }
 
 .status-badge {

--- a/frontend/src/pages/Players.css
+++ b/frontend/src/pages/Players.css
@@ -213,42 +213,11 @@
 
 .player-table {
   table-layout: fixed;
-  min-width: 1238px;
+  min-width: 1197px;
   border-collapse: collapse;
   background: #fff;
   font-size: 14px;
 }
-
-.player-table th:nth-child(1),
-.player-table td:nth-child(1) { width: 190px; }
-.player-table th:nth-child(2),
-.player-table td:nth-child(2) { width: 80px; }
-.player-table th:nth-child(3),
-.player-table td:nth-child(3) { width: 90px; }
-.player-table th:nth-child(4),
-.player-table td:nth-child(4) { width: 130px; }
-.player-table th:nth-child(5),
-.player-table td:nth-child(5) { width: 60px; }
-.player-table th:nth-child(6),
-.player-table td:nth-child(6) { width: 70px; }
-.player-table th:nth-child(7),
-.player-table td:nth-child(7) { width: 70px; }
-.player-table th:nth-child(8),
-.player-table td:nth-child(8) { width: 58px; }
-.player-table th:nth-child(9),
-.player-table td:nth-child(9) { width: 58px; }
-.player-table th:nth-child(10),
-.player-table td:nth-child(10) { width: 58px; }
-.player-table th:nth-child(11),
-.player-table td:nth-child(11) { width: 58px; }
-.player-table th:nth-child(12),
-.player-table td:nth-child(12) { width: 58px; }
-.player-table th:nth-child(13),
-.player-table td:nth-child(13) { width: 58px; }
-.player-table th:nth-child(14),
-.player-table td:nth-child(14) { width: 50px; }
-.player-table th:nth-child(15),
-.player-table td:nth-child(15) { width: 150px; }
 
 .player-table th {
   background: #f5f5f5;

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -474,6 +474,23 @@ const PlayerTable = ({
 
   return (
     <table className="player-table">
+      <colgroup>
+        <col style={{ width: 211 }} />
+        <col style={{ width: 95 }} />
+        <col style={{ width: 67 }} />
+        <col style={{ width: 97 }} />
+        <col style={{ width: 54 }} />
+        <col style={{ width: 79 }} />
+        <col style={{ width: 79 }} />
+        <col style={{ width: 48 }} />
+        <col style={{ width: 49 }} />
+        <col style={{ width: 50 }} />
+        <col style={{ width: 48 }} />
+        <col style={{ width: 49 }} />
+        <col style={{ width: 61 }} />
+        <col style={{ width: 39 }} />
+        {FF_MATCHUP_QUALITY && <col style={{ width: 171 }} />}
+      </colgroup>
       <thead>
         <tr>
           <th onClick={() => handleSort('player_name')}>Name {sortBy === 'player_name' && (sortOrder === 'asc' ? '↑' : '↓')}</th>

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -474,23 +474,6 @@ const PlayerTable = ({
 
   return (
     <table className="player-table">
-      <colgroup>
-        <col style={{ width: 211 }} />
-        <col style={{ width: 95 }} />
-        <col style={{ width: 67 }} />
-        <col style={{ width: 97 }} />
-        <col style={{ width: 54 }} />
-        <col style={{ width: 79 }} />
-        <col style={{ width: 79 }} />
-        <col style={{ width: 48 }} />
-        <col style={{ width: 49 }} />
-        <col style={{ width: 50 }} />
-        <col style={{ width: 48 }} />
-        <col style={{ width: 49 }} />
-        <col style={{ width: 61 }} />
-        <col style={{ width: 39 }} />
-        {FF_MATCHUP_QUALITY && <col style={{ width: 171 }} />}
-      </colgroup>
       <thead>
         <tr>
           <th onClick={() => handleSort('player_name')}>Name {sortBy === 'player_name' && (sortOrder === 'asc' ? '↑' : '↓')}</th>

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -494,12 +494,12 @@ const PlayerTable = ({
         </tr>
       </thead>
       <tbody>
-        {sortedPlayers.map((player, idx) => {
+        {sortedPlayers.map((player) => {
           const matchup = matchupMap.get(player.player_name);
           const isExpanded = expandedRows.has(player.player_name);
           const noData = player.has_data === false;
           return (
-            <React.Fragment key={`${player.player_name}-${idx}`}>
+            <React.Fragment key={player.player_id ?? player.player_name}>
               <tr>
                 <td><PlayerNameLink name={player.player_name} playerId={player.player_id} /> <InjuryBadge status={matchup?.injury_status} /></td>
                 <td>{player.pro_team}</td>


### PR DESCRIPTION
## Summary
- Row `key` now `player_id ?? player_name` instead of `` `${player_name}-${idx}` ``. The index in the key meant every sort changed every row's key, forcing React to unmount+remount all 1095 rows instead of reordering them.

## Why (and why this PR is smaller than it started)
Started investigating Players table scroll/sort lag with a wider CSS approach (`table-layout: fixed` + explicit column widths, `contain: layout paint`, `content-visibility: auto`). Under scrutiny that didn't hold up:

- **Sort-click cost:** a clean, isolated re-measurement (single clicks, warm session, same protocol) put the original code, this key-fix-only version, and the full CSS bundle all in the same 78-135ms noise band — no measurable difference from the CSS.
- **Scroll-paint feel:** the one subjective improvement (steady scroll) was only ever felt with the full CSS bundle, never isolated to confirm the CSS was responsible rather than something else.
- **Real regression:** the fixed-width CSS path forced a horizontal scrollbar on desktop windows that didn't need one (hardcoded widths wider than typical content), which needed a second fix and highlighted how fragile hardcoded column widths are.

Given the CSS never proved a measurable benefit and already caused one bug, dropping it. Keeping the key fix: it's a real correctness issue independent of any timing metric — reordering 1095 rows shouldn't remount all of them.

## Test plan
- [x] `npm test` — 193 passed, 3 skipped
- [x] `npm run build` — type-check + build clean
- [x] Sort still works correctly, no visual regression
- [x] No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)