### PR TITLE
feat: add season schedule fantasy lens

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.routes.matchups import router as matchups_router
 from app.routes.projections import router as projections_router
 from app.routes.feature_store import router as feature_store_router
 from app.routes.trends import router as trends_router
+from app.routes.schedule import router as schedule_router
 from dotenv import load_dotenv
 from app.config import settings
 import logging
@@ -132,6 +133,7 @@ app.include_router(matchups_router, prefix='/api/matchups', tags=['Matchups'])
 app.include_router(projections_router, prefix='/api/projections', tags=['Projections'])
 app.include_router(feature_store_router, prefix='/api/feature-store', tags=['Feature Store'])
 app.include_router(trends_router, prefix='/api/trends', tags=['Trends'])
+app.include_router(schedule_router, prefix='/api/nba', tags=['NBA Schedule'])
 
 
 

--- a/backend/app/routes/schedule.py
+++ b/backend/app/routes/schedule.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+
+from model_stats_inference.espn.client import EspnUnavailableError
+from app.services.schedule_service import get_schedule
+
+router = APIRouter()
+
+
+@router.get("/schedule")
+async def season_schedule():
+    try:
+        return await get_schedule()
+    except EspnUnavailableError as exc:
+        raise HTTPException(status_code=503, detail="NBA schedule is temporarily unavailable") from exc

--- a/backend/app/services/schedule_service.py
+++ b/backend/app/services/schedule_service.py
@@ -1,0 +1,211 @@
+"""Forward NBA schedule data used by the schedule views.
+
+The schedule is small enough to rebuild from ESPN in seven monthly requests,
+so it stays an in-process cache rather than becoming another database dataset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any
+
+import httpx
+
+from app.config import settings
+from model_stats_inference.espn import client as espn_client
+from model_stats_inference.espn.games import event_game_date, is_countable, season_months
+from model_stats_inference.espn.teams import TEAM_ID_TO_ABBR, TEAM_ID_TO_NAME, TEAM_IDS
+
+HIGH_VOLUME_THRESHOLD = 10
+CACHE_TTL_SECONDS = 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class ScheduledGame:
+    game_id: str
+    game_date: date
+    opponent_id: int
+    is_home: bool
+
+
+@dataclass(frozen=True)
+class ScheduleCacheEntry:
+    season: str
+    fetched_at: float
+    payload: dict[str, Any]
+
+
+_cache: dict[str, ScheduleCacheEntry] = {}
+_cache_lock = asyncio.Lock()
+
+
+def season_label(season_id: int | None = None) -> str:
+    configured_id = settings.season_id if season_id is None else season_id
+    start_year = configured_id - 1
+    return f"{start_year}-{str(start_year + 1)[-2:]}"
+
+
+def invalidate_schedule_cache(season: str | None = None) -> None:
+    """Force the next request to rebuild one season or all cached seasons."""
+    if season is None:
+        _cache.clear()
+    else:
+        _cache.pop(season, None)
+
+
+def _event_teams(event: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    try:
+        competitors = event["competitions"][0]["competitors"]
+        if len(competitors) != 2:
+            return None
+        first, second = competitors
+        first_id = int(first["team"]["id"])
+        second_id = int(second["team"]["id"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if first_id not in TEAM_IDS or second_id not in TEAM_IDS:
+        return None
+    return first, second
+
+
+def _extract_games(scoreboards: list[dict[str, Any]]) -> dict[int, list[ScheduledGame]]:
+    games_by_team: dict[int, list[ScheduledGame]] = {team_id: [] for team_id in TEAM_IDS}
+    seen_game_ids: set[str] = set()
+
+    for scoreboard in scoreboards:
+        for event in scoreboard.get("events", []):
+            game_id = str(event.get("id", ""))
+            if not game_id or game_id in seen_game_ids or not is_countable(event):
+                continue
+            teams = _event_teams(event)
+            if teams is None:
+                continue
+            first, second = teams
+            try:
+                first_id = int(first["team"]["id"])
+                second_id = int(second["team"]["id"])
+                game_date = event_game_date(event)
+            except (KeyError, TypeError, ValueError):
+                continue
+
+            seen_game_ids.add(game_id)
+            first_home = first.get("homeAway") == "home"
+            second_home = second.get("homeAway") == "home"
+            games_by_team[first_id].append(ScheduledGame(game_id, game_date, second_id, first_home))
+            games_by_team[second_id].append(ScheduledGame(game_id, game_date, first_id, second_home))
+
+    for games in games_by_team.values():
+        games.sort(key=lambda game: (game.game_date, game.game_id))
+    return games_by_team
+
+
+def _date_bounds(games_by_team: dict[int, list[ScheduledGame]]) -> tuple[date, date] | None:
+    dates = [game.game_date for games in games_by_team.values() for game in games]
+    if not dates:
+        return None
+    return min(dates), max(dates)
+
+
+def _build_payload(season: str, games_by_team: dict[int, list[ScheduledGame]]) -> dict[str, Any]:
+    all_game_dates = sorted({game.game_date for games in games_by_team.values() for game in games})
+    slate_sizes = {game_date: 0 for game_date in all_game_dates}
+    for games in games_by_team.values():
+        for game in games:
+            slate_sizes[game.game_date] += 1
+    slate_sizes = {game_date: count // 2 for game_date, count in slate_sizes.items()}
+
+    bounds = _date_bounds(games_by_team)
+    calendar_days: list[dict[str, Any]] = []
+    if bounds is not None:
+        current = bounds[0]
+        while current <= bounds[1]:
+            slate_size = slate_sizes.get(current, 0)
+            calendar_days.append({
+                "date": current.isoformat(),
+                "slate_size": slate_size,
+                "high_volume": slate_size >= HIGH_VOLUME_THRESHOLD,
+            })
+            current += timedelta(days=1)
+
+    months = [10, 11, 12, 1, 2, 3, 4]
+    month_labels = ["October", "November", "December", "January", "February", "March", "April"]
+    teams: list[dict[str, Any]] = []
+
+    for team_id in sorted(TEAM_IDS):
+        games = games_by_team[team_id]
+        rest_days: list[int] = []
+        game_rows: list[dict[str, Any]] = []
+        previous_date: date | None = None
+        for game in games:
+            rest = None if previous_date is None else max(0, (game.game_date - previous_date).days - 1)
+            if rest is not None:
+                rest_days.append(rest)
+            slate_size = slate_sizes[game.game_date]
+            game_rows.append({
+                "game_id": game.game_id,
+                "date": game.game_date.isoformat(),
+                "opponent_id": game.opponent_id,
+                "opponent": TEAM_ID_TO_NAME[game.opponent_id],
+                "opponent_abbreviation": TEAM_ID_TO_ABBR[game.opponent_id],
+                "is_home": game.is_home,
+                "rest_days": rest,
+                "slate_size": slate_size,
+                "high_volume": slate_size >= HIGH_VOLUME_THRESHOLD,
+            })
+            previous_date = game.game_date
+
+        monthly_games = {
+            label: sum(1 for game in games if game.game_date.month == month)
+            for month, label in zip(months, month_labels)
+        }
+        high_volume_games = sum(1 for game in games if slate_sizes[game.game_date] >= HIGH_VOLUME_THRESHOLD)
+        teams.append({
+            "team_id": team_id,
+            "abbreviation": TEAM_ID_TO_ABBR[team_id],
+            "team_name": TEAM_ID_TO_NAME[team_id],
+            "games": game_rows,
+            "monthly_games": monthly_games,
+            "total_games": len(games),
+            "b2b_count": sum(rest == 0 for rest in rest_days),
+            "high_volume_games": high_volume_games,
+            "avg_rest_days": round(sum(rest_days) / len(rest_days), 2) if rest_days else None,
+        })
+
+    published_counts = [team["total_games"] for team in teams]
+    return {
+        "season": season,
+        "high_volume_threshold": HIGH_VOLUME_THRESHOLD,
+        "calendar_days": calendar_days,
+        "teams": teams,
+        "published_games_min": min(published_counts) if published_counts else 0,
+        "published_games_max": max(published_counts) if published_counts else 0,
+    }
+
+
+async def _fetch_schedule(season: str) -> dict[str, Any]:
+    async with httpx.AsyncClient() as client:
+        scoreboards = await asyncio.gather(*(
+            espn_client.scoreboard_async(client, month)
+            for month in season_months(season)
+        ))
+    return _build_payload(season, _extract_games(scoreboards))
+
+
+async def get_schedule(season: str | None = None) -> dict[str, Any]:
+    season = season or season_label()
+    now = time.monotonic()
+    cached = _cache.get(season)
+    if cached is not None and now - cached.fetched_at < CACHE_TTL_SECONDS:
+        return cached.payload
+
+    async with _cache_lock:
+        now = time.monotonic()
+        cached = _cache.get(season)
+        if cached is not None and now - cached.fetched_at < CACHE_TTL_SECONDS:
+            return cached.payload
+        payload = await _fetch_schedule(season)
+        _cache[season] = ScheduleCacheEntry(season, time.monotonic(), payload)
+        return payload

--- a/backend/migrations/add_league_season_scope.sql
+++ b/backend/migrations/add_league_season_scope.sql
@@ -1,0 +1,62 @@
+-- Scope league-specific tables by league_id + season_id. Without this, a DB
+-- fallback (ESPN unreachable, or a not-yet-started season with no real ESPN
+-- data) silently serves whichever league/season happened to write last —
+-- e.g. the real league's April snapshot leaking into a demo-league session.
+--
+-- Existing rows predate this column and all belong to the real league/season
+-- in play at the time they were written — backfilled accordingly below.
+
+-- team_daily_snapshot
+ALTER TABLE team_daily_snapshot ADD COLUMN IF NOT EXISTS league_id BIGINT;
+ALTER TABLE team_daily_snapshot ADD COLUMN IF NOT EXISTS season_id INT;
+UPDATE team_daily_snapshot SET league_id = 660330196, season_id = 2026 WHERE league_id IS NULL;
+ALTER TABLE team_daily_snapshot ALTER COLUMN league_id SET NOT NULL;
+ALTER TABLE team_daily_snapshot ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE team_daily_snapshot DROP CONSTRAINT IF EXISTS team_daily_snapshot_pkey;
+ALTER TABLE team_daily_snapshot ADD PRIMARY KEY (league_id, season_id, scoring_period_id, team_id);
+
+-- team_rankings_averages
+ALTER TABLE team_rankings_averages ADD COLUMN IF NOT EXISTS league_id BIGINT;
+ALTER TABLE team_rankings_averages ADD COLUMN IF NOT EXISTS season_id INT;
+UPDATE team_rankings_averages SET league_id = 660330196, season_id = 2026 WHERE league_id IS NULL;
+ALTER TABLE team_rankings_averages ALTER COLUMN league_id SET NOT NULL;
+ALTER TABLE team_rankings_averages ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE team_rankings_averages DROP CONSTRAINT IF EXISTS team_rankings_averages_pkey;
+ALTER TABLE team_rankings_averages ADD PRIMARY KEY (league_id, season_id, scoring_period_id, team_id);
+
+-- team_rankings_totals
+ALTER TABLE team_rankings_totals ADD COLUMN IF NOT EXISTS league_id BIGINT;
+ALTER TABLE team_rankings_totals ADD COLUMN IF NOT EXISTS season_id INT;
+UPDATE team_rankings_totals SET league_id = 660330196, season_id = 2026 WHERE league_id IS NULL;
+ALTER TABLE team_rankings_totals ALTER COLUMN league_id SET NOT NULL;
+ALTER TABLE team_rankings_totals ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE team_rankings_totals DROP CONSTRAINT IF EXISTS team_rankings_totals_pkey;
+ALTER TABLE team_rankings_totals ADD PRIMARY KEY (league_id, season_id, scoring_period_id, team_id);
+
+-- estimator_prediction (was PRIMARY KEY (team_id) — one row per team, overwritten
+-- each run; now scoped so a different league/season doesn't clobber another's row)
+ALTER TABLE estimator_prediction ADD COLUMN IF NOT EXISTS league_id BIGINT;
+ALTER TABLE estimator_prediction ADD COLUMN IF NOT EXISTS season_id INT;
+UPDATE estimator_prediction SET league_id = 660330196, season_id = 2026 WHERE league_id IS NULL;
+ALTER TABLE estimator_prediction ALTER COLUMN league_id SET NOT NULL;
+ALTER TABLE estimator_prediction ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE estimator_prediction DROP CONSTRAINT IF EXISTS estimator_prediction_pkey;
+ALTER TABLE estimator_prediction ADD PRIMARY KEY (league_id, season_id, team_id);
+
+-- estimator_ranking
+ALTER TABLE estimator_ranking ADD COLUMN IF NOT EXISTS league_id BIGINT;
+ALTER TABLE estimator_ranking ADD COLUMN IF NOT EXISTS season_id INT;
+UPDATE estimator_ranking SET league_id = 660330196, season_id = 2026 WHERE league_id IS NULL;
+ALTER TABLE estimator_ranking ALTER COLUMN league_id SET NOT NULL;
+ALTER TABLE estimator_ranking ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE estimator_ranking DROP CONSTRAINT IF EXISTS estimator_ranking_pkey;
+ALTER TABLE estimator_ranking ADD PRIMARY KEY (league_id, season_id, team_id);
+
+-- estimator_rank_probability (was PRIMARY KEY (team_id, rank))
+ALTER TABLE estimator_rank_probability ADD COLUMN IF NOT EXISTS league_id BIGINT;
+ALTER TABLE estimator_rank_probability ADD COLUMN IF NOT EXISTS season_id INT;
+UPDATE estimator_rank_probability SET league_id = 660330196, season_id = 2026 WHERE league_id IS NULL;
+ALTER TABLE estimator_rank_probability ALTER COLUMN league_id SET NOT NULL;
+ALTER TABLE estimator_rank_probability ALTER COLUMN season_id SET NOT NULL;
+ALTER TABLE estimator_rank_probability DROP CONSTRAINT IF EXISTS estimator_rank_probability_pkey;
+ALTER TABLE estimator_rank_probability ADD PRIMARY KEY (league_id, season_id, team_id, rank);

--- a/backend/tests/services/test_schedule_service.py
+++ b/backend/tests/services/test_schedule_service.py
@@ -1,0 +1,112 @@
+import asyncio
+from datetime import date
+
+import pytest
+
+import app.services.schedule_service as schedule_module
+
+
+def _event(event_id: str, game_date: str, home_id: int = 1, away_id: int = 2) -> dict:
+    return {
+        "id": event_id,
+        "date": f"{game_date}T00:00:00Z",
+        "season": {"type": 2},
+        "competitions": [{
+            "competitors": [
+                {"id": str(home_id), "homeAway": "home", "team": {"id": str(home_id)}},
+                {"id": str(away_id), "homeAway": "away", "team": {"id": str(away_id)}},
+            ],
+        }],
+    }
+
+
+@pytest.fixture(autouse=True)
+def clear_schedule_cache():
+    schedule_module.invalidate_schedule_cache()
+    yield
+    schedule_module.invalidate_schedule_cache()
+
+
+@pytest.mark.asyncio
+async def test_schedule_fetches_all_months_in_parallel_and_caches(monkeypatch):
+    active = 0
+    peak_active = 0
+    calls: list[str] = []
+
+    async def scoreboard(_client, month):
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        calls.append(month)
+        await asyncio.sleep(0)
+        active -= 1
+        return {"events": [_event("game-1", "2026-10-21")]} if month == "202610" else {"events": []}
+
+    monkeypatch.setattr(schedule_module.espn_client, "scoreboard_async", scoreboard)
+
+    first = await schedule_module.get_schedule("2026-27")
+    second = await schedule_module.get_schedule("2026-27")
+
+    assert calls == ["202610", "202611", "202612", "202701", "202702", "202703", "202704"]
+    assert peak_active == 7
+    assert first is second
+    assert first["teams"][0]["total_games"] == 1
+    assert first["teams"][1]["total_games"] == 1
+
+
+@pytest.mark.asyncio
+async def test_schedule_filters_non_countable_games(monkeypatch):
+    events = [
+        _event("regular", "2026-10-21"),
+        {**_event("preseason", "2026-10-20"), "season": {"type": 1}},
+    ]
+
+    async def scoreboard(_client, month):
+        return {"events": events} if month == "202610" else {"events": []}
+
+    monkeypatch.setattr(schedule_module.espn_client, "scoreboard_async", scoreboard)
+
+    payload = await schedule_module.get_schedule("2026-27")
+
+    assert payload["published_games_min"] == 0
+    assert payload["teams"][0]["total_games"] == 1
+    assert len(payload["calendar_days"]) == 1
+    assert payload["calendar_days"][0]["slate_size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_schedule_cache_expires_after_24_hours(monkeypatch):
+    calls = 0
+
+    async def scoreboard(_client, _month):
+        nonlocal calls
+        calls += 1
+        return {"events": []}
+
+    clock = 100.0
+    monkeypatch.setattr(schedule_module.espn_client, "scoreboard_async", scoreboard)
+    monkeypatch.setattr(schedule_module.time, "monotonic", lambda: clock)
+
+    await schedule_module.get_schedule("2026-27")
+    await schedule_module.get_schedule("2026-27")
+    assert calls == 7
+
+    clock += schedule_module.CACHE_TTL_SECONDS + 1
+    await schedule_module.get_schedule("2026-27")
+    assert calls == 14
+
+
+def test_schedule_rest_days_are_calendar_days_between_games():
+    games_by_team = {team_id: [] for team_id in schedule_module.TEAM_IDS}
+    games_by_team[1] = [
+        schedule_module.ScheduledGame("g1", date(2026, 10, 1), 2, True),
+        schedule_module.ScheduledGame("g2", date(2026, 10, 2), 2, True),
+        schedule_module.ScheduledGame("g3", date(2026, 10, 5), 2, True),
+    ]
+
+    payload = schedule_module._build_payload("2026-27", games_by_team)
+    team = next(team for team in payload["teams"] if team["team_id"] == 1)
+
+    assert [game["rest_days"] for game in team["games"]] == [None, 0, 2]
+    assert team["b2b_count"] == 1
+    assert team["avg_rest_days"] == 1.0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { Routes, Route, Navigate } from 'react-router'
 import Layout from './components/Layout'
 import GlobalLoadingBar from './components/GlobalLoadingBar'
 import LoadingSpinner from './components/LoadingSpinner'
-import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG, FF_DRAFT_REPORT, FF_TRENDS, FF_MINIGAMES } from './config/featureFlags'
+import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG, FF_DRAFT_REPORT, FF_TRENDS, FF_MINIGAMES, FF_SCHEDULE } from './config/featureFlags'
 
 const Dashboard = lazy(() => import('./pages/Dashboard'))
 const Rankings = lazy(() => import('./pages/Rankings'))
@@ -16,6 +16,7 @@ const Trade = lazy(() => import('./pages/Trade').then(m => ({ default: m.Trade }
 const Players = lazy(() => import('./pages/Players'))
 const Injuries = lazy(() => import('./pages/Injuries'))
 const NbaTeams = lazy(() => import('./pages/NbaTeams'))
+const Schedule = lazy(() => import('./pages/Schedule'))
 const FeatureStore = lazy(() => import('./pages/FeatureStore'))
 const NotFound = lazy(() => import('./pages/NotFound'))
 const PlayerRankings = lazy(() => import('./pages/PlayerRankings'))
@@ -51,6 +52,7 @@ function App() {
             <Route path="players" element={<Players />} />
             <Route path="injuries" element={<Injuries />} />
             <Route path="nba-teams" element={<NbaTeams />} />
+            {FF_SCHEDULE && <Route path="schedule" element={<Schedule />} />}
             <Route path="player/:playerId" element={<PlayerProfile />} />
             {FF_FEATURE_STORE && <Route path="feature-store" element={<FeatureStore />} />}
             {/* <Route path="trade-suggestions" element={<TradeSuggestions />} /> */}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet, Link, useLocation } from 'react-router'
 import { useState, useEffect, useRef } from 'react'
 import Footer from './Footer'
 import CommandPalette from './CommandPalette'
-import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG, FF_DRAFT_REPORT, FF_TRENDS, FF_MINIGAMES, FF_GLOBAL_SEARCH } from '../config/featureFlags'
+import { FF_PLAYER_RANKINGS, FF_FEATURE_STORE, FF_PROJECTIONS, FF_NAV_REORG, FF_DRAFT_REPORT, FF_TRENDS, FF_MINIGAMES, FF_GLOBAL_SEARCH, FF_SCHEDULE } from '../config/featureFlags'
 
 const prefetchMap: Record<string, () => Promise<unknown>> = {
   '/trends': () => import('../pages/Trends'),
@@ -545,7 +545,8 @@ const ReorgLayout = ({ darkMode, setDarkMode, setSearchOpen }: ReorgLayoutProps)
       label: 'NBA',
       icon: '🏀',
       items: [
-        { path: '/nba-teams', label: 'NBA Depth Charts', icon: '🏀' },
+        { path: '/nba-teams', label: 'NBA Teams', icon: '🏀' },
+        ...(FF_SCHEDULE ? [{ path: '/schedule', label: 'Season Schedule', icon: '🗓️' }] : []),
         { path: '/injuries', label: 'Injuries', icon: '🩺' },
       ],
     },

--- a/frontend/src/components/RosterCoverage.tsx
+++ b/frontend/src/components/RosterCoverage.tsx
@@ -1,0 +1,121 @@
+import { useMemo, useState } from 'react'
+import { useGetAllPlayersQuery, useGetScheduleQuery } from '../store/api/fantasyApi'
+import type { Player, ScheduleCalendarDay } from '../types/api'
+import LoadingSpinner from './LoadingSpinner'
+import ErrorMessage from './ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
+
+interface RosterCoverageProps {
+  players: Player[]
+  teamId: number
+}
+
+function daySurface(day: ScheduleCalendarDay): string {
+  return day.slate_size > 0 ? 'bg-white text-gray-800' : 'bg-gray-50 text-gray-500'
+}
+
+function slateTone(day: ScheduleCalendarDay): string {
+  if (day.slate_size >= 12) return 'bg-blue-100 text-blue-900'
+  if (day.high_volume) return 'bg-blue-50 text-blue-800'
+  if (day.slate_size > 0) return 'bg-gray-100 text-gray-700'
+  return 'bg-gray-100 text-gray-500'
+}
+
+function formatDay(date: string, options: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('en-US', options).format(new Date(`${date}T12:00:00`))
+}
+
+function firstScheduleDay(days: ScheduleCalendarDay[]): string {
+  const today = new Date().toISOString().slice(0, 10)
+  return days.find(day => day.date >= today)?.date ?? days[0]?.date ?? ''
+}
+
+export default function RosterCoverage({ players, teamId }: RosterCoverageProps) {
+  const { data: schedule, isLoading, error } = useGetScheduleQuery()
+  const { data: allPlayerData } = useGetAllPlayersQuery({ limit: 500 }, { skip: players.length > 0 })
+  const [horizon, setHorizon] = useState<14 | 28>(14)
+  const [selectedDate, setSelectedDate] = useState('')
+
+  const days = useMemo(() => schedule?.calendar_days ?? [], [schedule])
+  const roster = useMemo(() => {
+    if (players.length > 0) return players
+    return (allPlayerData?.players ?? []).filter(player => player.status === 'ONTEAM' && player.team_id === teamId)
+  }, [allPlayerData, players, teamId])
+  const startDate = useMemo(() => firstScheduleDay(days), [days])
+  const visibleDays = useMemo(() => {
+    if (!startDate) return []
+    const startIndex = days.findIndex(day => day.date === startDate)
+    return days.slice(startIndex, startIndex + horizon)
+  }, [days, horizon, startDate])
+
+  const coverage = useMemo(() => visibleDays.map(day => {
+    const activeTeams = new Set(
+      (schedule?.teams ?? []).filter(team => team.games.some(game => game.date === day.date)).map(team => team.abbreviation)
+    )
+    return { day, count: roster.filter(player => activeTeams.has(player.pro_team)).length }
+  }), [roster, schedule, visibleDays])
+
+  const activeDate = visibleDays.some(day => day.date === selectedDate) ? selectedDate : visibleDays[0]?.date ?? ''
+
+  if (isLoading) return <div className="bg-white rounded-lg shadow p-6"><LoadingSpinner /></div>
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load schedule coverage')} />
+  if (!schedule || !visibleDays.length) return null
+
+  return (
+    <div className="bg-white rounded-lg shadow p-4 sm:p-6">
+      <div className="flex flex-col gap-3 border-b border-gray-100 pb-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-900">Roster coverage</h2>
+          <p className="mt-1 text-xs text-gray-500">Bar height = rostered players with an NBA game. The slate label is the total number of NBA games that day.</p>
+        </div>
+        <div className="flex rounded-lg border border-gray-200 p-1 text-xs">
+          {[14, 28].map(value => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setHorizon(value as 14 | 28)}
+              className={`rounded-md px-3 py-2 ${horizon === value ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'}`}
+            >
+              {value} days
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 flex gap-2 overflow-x-auto pb-2">
+        {coverage.map(({ day, count }) => (
+          <button
+            type="button"
+            key={day.date}
+            onClick={() => setSelectedDate(day.date)}
+            className={`w-16 min-w-16 shrink-0 rounded-lg px-1.5 py-2 text-center leading-none transition-shadow ${daySurface(day)} ${activeDate === day.date ? 'border-[3px] border-blue-700 shadow-sm' : 'border-2 border-gray-200'}`}
+            aria-pressed={activeDate === day.date}
+            aria-label={`${formatDay(day.date, { weekday: 'short', month: 'short', day: 'numeric' })}: ${count} of ${roster.length} rostered players have an NBA game; ${day.slate_size} NBA games on the slate`}
+          >
+            <div className="text-[10px] font-semibold uppercase leading-none">{formatDay(day.date, { weekday: 'short' })}</div>
+            <div className="text-xs leading-none">{formatDay(day.date, { month: 'short', day: 'numeric' })}</div>
+            <div className="mt-2 flex h-24 items-end justify-center" aria-hidden="true">
+              <div className="relative h-full w-6 overflow-hidden rounded-t bg-blue-100">
+                <div
+                  className="absolute inset-x-0 bottom-0 rounded-t bg-blue-600"
+                  style={{ height: `${roster.length ? (count / roster.length) * 100 : 0}%` }}
+                />
+              </div>
+            </div>
+            <div className="mt-2 flex items-baseline justify-center gap-1 leading-none">
+              <span className="text-lg font-bold">{count}</span>
+              <span className="text-[9px] font-semibold uppercase">of {roster.length}</span>
+            </div>
+            <div className="mt-1 text-[9px] leading-none">rostered</div>
+            <div className={`mt-1 rounded-md px-1 py-1 text-[9px] font-medium leading-tight ${slateTone(day)}`}>{day.slate_size} NBA games</div>
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-xs text-gray-500">
+        <span><span className="mr-1 inline-block h-3 w-3 rounded-sm bg-blue-600 align-[-2px]" />Bar height = rostered players with a game</span>
+        <span><span className="mr-1 inline-block h-3 w-3 rounded-sm bg-blue-100 align-[-2px]" />Slate label = total NBA games</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SlotUsageTable.tsx
+++ b/frontend/src/components/SlotUsageTable.tsx
@@ -1,17 +1,12 @@
 import type { SlotUsage } from '../types/api'
-import InfoTip from './InfoTip'
-import { METRIC_GLOSSARY } from '../constants/metricGlossary'
 import {
   SLOT_NAMES,
-  TONE_CLASS,
-  canColor,
-  estimatedTone,
+  SLOT_MULTIPLICITY,
+  SLOT_CAPS,
   formatCap,
   formatRateDelta,
   formatSlotNumber,
-  maxTone,
   projectSlot,
-  rateTone,
   type PaceContext,
 } from '../utils/slotProjection'
 
@@ -21,174 +16,190 @@ interface SlotUsageTableProps {
   gameDaysLeft?: number | null
 }
 
-const ROW_LABELS = {
-  rate: 'Rate',
-  max: 'Max',
-  estimated: 'Est.',
+interface Segment {
+  key: 'played' | 'onTrack' | 'possible' | 'gone'
+  value: number
+  className: string
+}
+
+const SEGMENT_STYLES = {
+  played: 'bg-blue-700',
+  onTrack: 'bg-blue-300',
+  possible: 'bg-slate-200',
+  gone: 'bg-red-500',
 } as const
 
-function LegendSwatch({ className, label }: { className: string; label: string }) {
+function segmentTooltip(segment: Segment, values: { played: number; estimated: number; max: number; cap: number; gameDaysLeft: number | null }) {
+  if (segment.key === 'played') return `Played ${formatSlotNumber(values.played)} of ${formatSlotNumber(values.cap)}`
+  if (segment.key === 'onTrack') return `On track to add ${formatSlotNumber(segment.value)} → est ${formatSlotNumber(values.estimated)}`
+  if (segment.key === 'possible') return `Still possible +${formatSlotNumber(segment.value)} → max reachable ${formatSlotNumber(values.max)}`
+  const days = values.gameDaysLeft === null ? 'the remaining game days' : `${values.gameDaysLeft} game days remain`
+  return `Gone — ${formatSlotNumber(segment.value)}. Only ${days}, so the cap can no longer be reached.`
+}
+
+function Legend({ className, label }: { className: string; label: string }) {
   return (
-    <span className="inline-flex items-center gap-1">
-      <span className={`w-3 h-3 rounded-sm inline-block ${className}`} />
-      <span>{label}</span>
+    <span className="inline-flex items-center gap-1 text-[11px] text-gray-500">
+      <span className={`h-2.5 w-2.5 rounded-sm ${className}`} />
+      {label}
     </span>
   )
 }
 
-export default function SlotUsageTable({ slotUsage, avgPace, gameDaysLeft }: SlotUsageTableProps) {
-  const pace: PaceContext = { avgPace, gameDaysLeft }
-  const colored = canColor(pace)
-
-  const columns = SLOT_NAMES.map(slot => {
-    const usage = slotUsage[slot]
-    return { slot, usage, projection: usage ? projectSlot(usage.games_used, slot, pace) : null }
-  })
-
+function ValueChip({ label, value, dotClass, className = 'bg-gray-100 text-gray-600' }: {
+  label: string
+  value: string | number
+  dotClass?: string
+  className?: string
+}) {
   return (
-    <div className="bg-white rounded-lg shadow p-4 sm:p-6">
-      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-4 mb-4">
-        <div>
-          <h2 className="text-2xl font-bold text-gray-900">Slot Usage</h2>
-          <p className="text-xs text-gray-500 mt-1">
-            Rate is per slot. Max and Est. are the whole column — UTIL cap (246+2).
-          </p>
-        </div>
-        <div className="text-xs text-gray-500 space-y-1 sm:text-right">
-          {typeof avgPace === 'number' && (
-            <div>
-              NBA <span className="font-medium text-gray-700">{avgPace.toFixed(1)}</span> GP/team
-              {typeof gameDaysLeft === 'number' && (
-                <span> · <span className="font-medium text-gray-700">{gameDaysLeft}</span> days left</span>
-              )}
-            </div>
-          )}
-          {!colored && (
-            <div className="text-gray-400">Too early — colors start at 10 GP/team.</div>
-          )}
-        </div>
-      </div>
-
-      {colored && (
-        <div className="space-y-1 text-xs text-gray-600 mb-4">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="font-semibold text-gray-500 w-10">Rate</span>
-            <LegendSwatch className="bg-green-100" label="<5%" />
-            <LegendSwatch className="bg-yellow-100" label="5–10%" />
-            <LegendSwatch className="bg-orange-100" label="10–15%" />
-            <LegendSwatch className="bg-red-100" label="15%+" />
-            <span className="text-gray-400">off the NBA rate, either way</span>
-          </div>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="font-semibold text-gray-500 w-10">Max</span>
-            <LegendSwatch className="bg-green-100" label="still reachable" />
-            <LegendSwatch className="bg-red-100" label="gone" />
-          </div>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="font-semibold text-gray-500 w-10">Est.</span>
-            <LegendSwatch className="bg-green-100" label="82+" />
-            <LegendSwatch className="bg-yellow-100" label="80–82" />
-            <LegendSwatch className="bg-orange-100" label="78–80" />
-            <LegendSwatch className="bg-red-100" label="<78" />
-            <span className="text-gray-400">per slot</span>
-          </div>
-        </div>
-      )}
-
-      <div className="overflow-x-auto">
-        <table className="min-w-full border-collapse">
-          <thead>
-            <tr>
-              <th className="px-3 py-2 text-left text-xs font-semibold text-gray-500 uppercase border border-gray-200 bg-gray-50" />
-              {columns.map(({ slot }) => (
-                <th
-                  key={slot}
-                  className="px-4 py-2 text-center text-xs font-semibold text-gray-500 uppercase border border-gray-200 bg-gray-50"
-                >
-                  {slot}
-                  {slot === 'UTIL' && (
-                    <div className="text-gray-400 font-normal normal-case">×3 slots</div>
-                  )}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th className="relative z-20 px-3 py-3 text-left text-xs font-semibold text-gray-600 border border-gray-200 bg-gray-50 whitespace-nowrap">
-                <span className="inline-flex items-center gap-1">
-                  {ROW_LABELS.rate}
-                  <InfoTip title={METRIC_GLOSSARY.slotRate.title} body={METRIC_GLOSSARY.slotRate.body} />
-                </span>
-                <div className="font-normal text-gray-400 normal-case">used · vs NBA</div>
-              </th>
-              {columns.map(({ slot, projection }) => {
-                if (!projection) return <EmptyCell key={slot} />
-                const tone = rateTone(projection.rate, pace)
-                return (
-                  <td
-                    key={slot}
-                    className={`px-4 py-3 text-center text-sm font-medium border border-gray-200 ${TONE_CLASS[tone]}`}
-                  >
-                    <div>{formatSlotNumber(projection.used)}</div>
-                    <div className="text-xs font-normal opacity-80">
-                      {formatRateDelta(projection.used, avgPace)}
-                    </div>
-                  </td>
-                )
-              })}
-            </tr>
-            <tr>
-              <th className="relative z-20 px-3 py-3 text-left text-xs font-semibold text-gray-600 border border-gray-200 bg-gray-50 whitespace-nowrap">
-                <span className="inline-flex items-center gap-1">
-                  {ROW_LABELS.max}
-                  <InfoTip title={METRIC_GLOSSARY.slotMax.title} body={METRIC_GLOSSARY.slotMax.body} />
-                </span>
-                <div className="font-normal text-gray-400 normal-case">still reachable</div>
-              </th>
-              {columns.map(({ slot, projection }) => {
-                if (!projection) return <EmptyCell key={slot} />
-                const tone = maxTone(projection.maxGamesTotal, slot, pace)
-                return (
-                  <td
-                    key={slot}
-                    className={`px-4 py-3 text-center text-sm font-medium border border-gray-200 ${TONE_CLASS[tone]}`}
-                  >
-                    {formatSlotNumber(projection.maxGamesTotal)}
-                    <span className="opacity-50">/{formatCap(slot)}</span>
-                  </td>
-                )
-              })}
-            </tr>
-            <tr>
-              <th className="relative z-20 px-3 py-3 text-left text-xs font-semibold text-gray-600 border border-gray-200 bg-gray-50 whitespace-nowrap">
-                <span className="inline-flex items-center gap-1">
-                  {ROW_LABELS.estimated}
-                  <InfoTip title={METRIC_GLOSSARY.slotEstimated.title} body={METRIC_GLOSSARY.slotEstimated.body} />
-                </span>
-                <div className="font-normal text-gray-400 normal-case">projected</div>
-              </th>
-              {columns.map(({ slot, projection }) => {
-                if (!projection) return <EmptyCell key={slot} />
-                const tone = estimatedTone(projection.estimatedRounded, slot, pace)
-                return (
-                  <td
-                    key={slot}
-                    className={`px-4 py-3 text-center text-sm font-medium border border-gray-200 ${TONE_CLASS[tone]}`}
-                  >
-                    {formatSlotNumber(projection.estimatedRounded)}
-                    <span className="opacity-50">/{formatCap(slot)}</span>
-                  </td>
-                )
-              })}
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
+    <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold ${className}`}>
+      {dotClass && <span className={`h-2 w-2 rounded-sm ${dotClass}`} />}
+      <span>{label}</span>
+      <b className="tabular-nums">{value}</b>
+    </span>
   )
 }
 
-function EmptyCell() {
-  return <td className="px-4 py-3 text-center text-gray-400 border border-gray-200">-</td>
+function formatVsPace(used: number, avgPace: number | null | undefined): string {
+  if (typeof avgPace !== 'number' || !Number.isFinite(avgPace) || avgPace <= 0) {
+    return used === 0 ? '— 0' : '—'
+  }
+  const delta = formatRateDelta(used, avgPace)
+  return delta === 'on pace' ? '0.0' : delta
+}
+
+export default function SlotUsageTable({ slotUsage, avgPace, gameDaysLeft }: SlotUsageTableProps) {
+  const pace: PaceContext = { avgPace, gameDaysLeft }
+  const columns = SLOT_NAMES.map(slot => {
+    const usage = slotUsage[slot]
+    return { slot, projection: usage ? projectSlot(usage.games_used, slot, pace) : null }
+  })
+  const numericPace = typeof avgPace === 'number' && avgPace > 0 ? avgPace : null
+  const pacePercent = numericPace === null ? null : Math.min(100, (numericPace / 82) * 100)
+
+  return (
+    <div className="bg-white rounded-lg shadow p-4 sm:p-6">
+      <div className="flex flex-col gap-3 border-b border-gray-100 pb-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-900">Slot pace</h2>
+          <p className="mt-1 max-w-2xl text-xs text-gray-500">
+            A report of games already used, the NBA-pace projection, and the remaining ceiling. The cap is a limit, not a target.
+          </p>
+        </div>
+        <div className="text-xs text-gray-500 sm:text-right">
+          NBA pace{' '}
+          {numericPace === null ? (
+            <span className="font-semibold text-gray-600">not available yet</span>
+          ) : (
+            <>
+              <span className="font-semibold text-gray-700">{numericPace.toFixed(1)}</span> GP/team
+            </>
+          )}
+          {typeof gameDaysLeft === 'number' && <span> · {gameDaysLeft} days left</span>}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <Legend className="bg-blue-700" label="Played" />
+        <Legend className="bg-blue-300" label="On track to add" />
+        <Legend className="bg-gray-200" label="Still possible" />
+        <Legend className="bg-red-500" label="Gone" />
+        {pacePercent !== null && (
+          <span className="inline-flex items-center gap-1 text-[11px] text-gray-500">
+            <span className="h-3 w-0.5 bg-blue-900" /> NBA pace marker
+          </span>
+        )}
+      </div>
+
+      <div className="mt-5 space-y-4">
+        <div className="hidden items-center gap-3 sm:flex">
+          <div className="w-16 shrink-0" />
+          <div className="relative h-4 flex-1">
+            {pacePercent !== null && (
+              <span
+                className="absolute -top-2 whitespace-nowrap rounded bg-slate-900 px-1.5 py-0.5 text-[10px] font-extrabold tracking-wide text-white shadow-sm"
+                style={{ left: `${pacePercent}%`, transform: pacePercent > 88 ? 'translateX(-100%)' : 'translateX(-50%)' }}
+              >
+                NBA pace {numericPace?.toFixed(1)}
+              </span>
+            )}
+          </div>
+          <div className="w-16 shrink-0" />
+        </div>
+
+        {columns.map(({ slot, projection }) => {
+          if (!projection) return null
+          const cap = SLOT_CAPS[slot]
+          const played = Math.min(projection.usedTotal, cap)
+          const estimated = projection.estimatedRounded ?? played
+          const max = projection.maxGamesTotal ?? (typeof gameDaysLeft === 'number'
+            ? Math.min(played + gameDaysLeft * SLOT_MULTIPLICITY[slot], cap)
+            : cap)
+          const onTrack = Math.max(0, estimated - played)
+          const possible = Math.max(0, max - Math.max(played, estimated))
+          const gone = Math.max(0, cap - max)
+          const segments: Segment[] = [
+            { key: 'played', value: played, className: SEGMENT_STYLES.played },
+            { key: 'onTrack', value: onTrack, className: SEGMENT_STYLES.onTrack },
+            { key: 'possible', value: possible, className: SEGMENT_STYLES.possible },
+            { key: 'gone', value: gone, className: SEGMENT_STYLES.gone },
+          ]
+          const visibleSegments = segments.filter(segment => segment.value > 0)
+          const values = { played, estimated, max, cap, gameDaysLeft: typeof gameDaysLeft === 'number' ? gameDaysLeft : null }
+          const paceMarkerPercent = pacePercent === null
+            ? null
+            : Math.min(100, (numericPace! * SLOT_MULTIPLICITY[slot] / cap) * 100)
+          const paceTooltip = numericPace === null
+            ? `NBA pace is not available yet${projection.used === 0 ? ' · 0 games used.' : '.'}`
+            : slot === 'UTIL'
+              ? `${numericPace.toFixed(1)} × 3 = ${(numericPace * SLOT_MULTIPLICITY[slot]).toFixed(1)} · ${projection.usedTotal >= numericPace * 3 ? 'ahead' : 'behind'} by ${Math.abs(projection.usedTotal - numericPace * 3).toFixed(1)}.`
+              : `NBA pace ${numericPace.toFixed(1)} · ${projection.used >= numericPace ? 'ahead' : 'behind'} by ${Math.abs(projection.used - numericPace).toFixed(1)}.`
+          const paceChip = formatVsPace(projection.used, avgPace)
+          return (
+            <div key={slot} className="grid grid-cols-1 gap-1 sm:grid-cols-[4rem_minmax(0,1fr)_4rem] sm:items-center sm:gap-3">
+              <div className="flex items-center justify-between sm:block">
+                <div className="text-xs font-bold uppercase tracking-wide text-gray-700">{slot}</div>
+                {slot === 'UTIL' && <div className="text-[10px] text-gray-400">× 3 slots</div>}
+              </div>
+              <div className="relative">
+                <div className="relative flex h-[18px] overflow-visible rounded-full border border-slate-600 bg-gray-50">
+                  {visibleSegments.map((segment, index) => (
+                    <span
+                      key={segment.key}
+                      title={segmentTooltip(segment, values)}
+                      className={`group relative h-full min-w-[2px] ${segment.className} ${index === 0 ? 'rounded-l-full' : ''} ${index === visibleSegments.length - 1 ? 'rounded-r-full' : ''}`}
+                      style={{ width: `${(segment.value / cap) * 100}%` }}
+                    >
+                      <span className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden w-max max-w-[16rem] -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-[10px] font-normal text-white shadow-lg group-hover:block group-focus:block">
+                        {segmentTooltip(segment, values)}
+                      </span>
+                    </span>
+                  ))}
+                  {paceMarkerPercent !== null && (
+                    <span
+                      aria-label={`NBA pace ${numericPace?.toFixed(1)}`}
+                      title={paceTooltip}
+                      className="pointer-events-auto absolute bottom-[-6px] top-[-6px] z-20 w-0.5 -translate-x-px rounded-sm bg-slate-900 shadow-[0_0_0_1.5px_white] after:absolute after:-left-[3px] after:-top-1 after:h-[7px] after:w-[7px] after:rounded-full after:bg-slate-900 after:shadow-[0_0_0_1.5px_white]"
+                      style={{ left: `${paceMarkerPercent}%` }}
+                    />
+                  )}
+                </div>
+              </div>
+              <div className="hidden text-right text-xs text-gray-500 sm:block">cap {formatCap(slot)}</div>
+              <div className="flex flex-wrap gap-1.5 py-0.5 sm:col-start-2">
+                <ValueChip label="played" value={formatSlotNumber(played)} dotClass="bg-blue-700" className="bg-blue-50 text-blue-800" />
+                <ValueChip label="est" value={formatSlotNumber(estimated)} dotClass="bg-blue-300" className="bg-blue-100 text-blue-800" />
+                <ValueChip label="max reachable" value={formatSlotNumber(max)} dotClass="bg-slate-300" className="bg-slate-100 text-slate-700" />
+                {gone > 0 && <ValueChip label="gone" value={formatSlotNumber(gone)} dotClass="bg-red-700" className="bg-red-500 text-white" />}
+                <span className={`inline-flex items-center rounded bg-slate-900 px-1.5 py-0.5 text-[10px] font-bold text-white ${numericPace === null ? 'opacity-75' : ''}`}>
+                  vs pace <b className="ml-1 tabular-nums">{paceChip}</b>
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
 }

--- a/frontend/src/components/SlotUsageTable.tsx
+++ b/frontend/src/components/SlotUsageTable.tsx
@@ -189,7 +189,7 @@ export default function SlotUsageTable({ slotUsage, avgPace, gameDaysLeft }: Slo
               <div className="hidden text-right text-xs text-gray-500 sm:block">cap {formatCap(slot)}</div>
               <div className="flex flex-wrap gap-1.5 py-0.5 sm:col-start-2">
                 <ValueChip label="played" value={formatSlotNumber(played)} dotClass="bg-blue-700" className="bg-blue-50 text-blue-800" />
-                <ValueChip label="est" value={formatSlotNumber(estimated)} dotClass="bg-blue-300" className="bg-blue-100 text-blue-800" />
+                <ValueChip label="estimated" value={formatSlotNumber(estimated)} dotClass="bg-blue-300" className="bg-blue-100 text-blue-800" />
                 <ValueChip label="max reachable" value={formatSlotNumber(max)} dotClass="bg-slate-300" className="bg-slate-100 text-slate-700" />
                 {gone > 0 && <ValueChip label="gone" value={formatSlotNumber(gone)} dotClass="bg-red-700" className="bg-red-500 text-white" />}
                 <span className={`inline-flex items-center rounded bg-slate-900 px-1.5 py-0.5 text-[10px] font-bold text-white ${numericPace === null ? 'opacity-75' : ''}`}>

--- a/frontend/src/components/TeamScheduleView.tsx
+++ b/frontend/src/components/TeamScheduleView.tsx
@@ -53,7 +53,7 @@ export default function TeamScheduleView({ teamId }: TeamScheduleViewProps) {
     <div>
       <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 className="text-xl font-bold text-gray-900">{team.team_name} schedule</h2>
+          <h2 id="nba-team-schedule-heading" className="text-xl font-bold text-gray-900">{team.team_name} schedule</h2>
         </div>
         {team.total_games < 82 && (
           <div className="max-w-md rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900">
@@ -62,27 +62,26 @@ export default function TeamScheduleView({ teamId }: TeamScheduleViewProps) {
         )}
       </div>
 
-      <div className="mb-5 grid grid-cols-2 gap-2 sm:grid-cols-4">
+      <div className="mb-5 grid grid-cols-3 gap-2">
         <Kpi label="Total games" value={team.total_games} metric="scheduleTotal" />
         <Kpi label="Back-to-backs" value={team.b2b_count} metric="scheduleB2B" />
         <Kpi label="High-volume" value={team.high_volume_games} metric="scheduleHighVolume" />
-        <Kpi label="Average rest" value={team.avg_rest_days === null ? '—' : `${team.avg_rest_days.toFixed(2)}d`} metric="scheduleRest" />
       </div>
 
-      <div className="max-h-[34rem] overflow-auto rounded-lg border border-gray-200 lg:max-w-4xl">
+      <div className="max-h-[34rem] overflow-auto rounded-lg border border-gray-200">
         <table className="min-w-[650px] w-full table-fixed border-collapse text-sm">
           <colgroup>
-            <col className="w-40" />
-            <col />
-            <col className="w-36" />
-            <col className="w-32" />
+            <col className="w-40 sm:w-1/4" />
+            <col className="sm:w-1/4" />
+            <col className="w-36 sm:w-1/4" />
+            <col className="w-32 sm:w-1/4" />
           </colgroup>
           <thead className="sticky top-0 z-20 bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
             <tr>
-              <th className="border-b border-gray-200 px-3 py-3 text-left">Date</th>
-              <th className="border-b border-gray-200 px-3 py-3 text-left">Opponent</th>
-              <th className="border-b border-gray-200 px-3 py-3 text-right">Rest days</th>
-              <th className="border-b border-gray-200 px-3 py-3 text-right">Slate size</th>
+              <th className="border-b border-gray-200 px-3 py-3 text-left sm:text-center">Date</th>
+              <th className="border-b border-gray-200 px-3 py-3 text-center">Opponent</th>
+              <th className="border-b border-gray-200 px-3 py-3 text-right sm:text-center">Rest days</th>
+              <th className="border-b border-gray-200 px-3 py-3 text-right sm:text-center">Slate size</th>
             </tr>
           </thead>
           <tbody>
@@ -97,14 +96,14 @@ export default function TeamScheduleView({ teamId }: TeamScheduleViewProps) {
                     </tr>
                   )}
                   <tr className="border-b border-gray-100 last:border-0 hover:bg-gray-50">
-                    <td className="whitespace-nowrap px-3 py-3 text-gray-700">{formatDate(game.date, { weekday: 'short', month: 'short', day: 'numeric' })}</td>
-                    <td className="px-3 py-3 font-medium text-gray-800">
+                    <td className="whitespace-nowrap px-3 py-3 text-left text-gray-700 sm:text-center">{formatDate(game.date, { weekday: 'short', month: 'short', day: 'numeric' })}</td>
+                    <td className="px-3 py-3 text-center font-medium text-gray-800">
                       <span className="mr-2 text-xs font-bold text-gray-400">{game.is_home ? 'vs' : '@'}</span>{game.opponent}
                     </td>
-                    <td className={`px-3 py-3 text-right ${game.rest_days === 0 ? 'font-semibold text-rose-600' : 'text-gray-700'}`}>
+                    <td className={`px-3 py-3 text-right sm:text-center ${game.rest_days === 0 ? 'font-semibold text-rose-600' : 'text-gray-700'}`}>
                       {game.rest_days === null ? '—' : game.rest_days === 0 ? '0 · B2B' : `${game.rest_days}d`}
                     </td>
-                    <td className={`px-3 py-3 text-right font-medium ${slateClass(game)}`}>{game.slate_size}</td>
+                    <td className={`px-3 py-3 text-right sm:text-center font-medium ${slateClass(game)}`}>{game.slate_size}</td>
                   </tr>
                 </Fragment>
               )

--- a/frontend/src/components/TeamScheduleView.tsx
+++ b/frontend/src/components/TeamScheduleView.tsx
@@ -1,0 +1,117 @@
+import { Fragment } from 'react'
+import { useGetScheduleQuery } from '../store/api/fantasyApi'
+import { METRIC_GLOSSARY } from '../constants/metricGlossary'
+import InfoTip from './InfoTip'
+import LoadingSpinner from './LoadingSpinner'
+import ErrorMessage from './ErrorMessage'
+import { getErrorMessage } from '../utils/errorMessage'
+import type { ScheduleGame } from '../types/api'
+
+interface TeamScheduleViewProps {
+  teamId: string
+}
+
+function formatDate(date: string, options: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('en-US', options).format(new Date(`${date}T12:00:00`))
+}
+
+function monthKey(date: string): string {
+  return date.slice(0, 7)
+}
+
+function monthLabel(date: string): string {
+  return formatDate(`${date.slice(0, 7)}-01`, { month: 'long', year: 'numeric' })
+}
+
+function slateClass(game: ScheduleGame): string {
+  if (game.slate_size >= 12) return 'bg-blue-200 text-blue-900 dark:bg-blue-800 dark:text-blue-100'
+  if (game.high_volume || game.slate_size >= 10) return 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200'
+  return 'text-gray-700'
+}
+
+function Kpi({ label, value, metric }: { label: string; value: string | number; metric: keyof typeof METRIC_GLOSSARY }) {
+  const info = METRIC_GLOSSARY[metric]
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-3">
+      <div className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-gray-500">
+        {label}<InfoTip title={info.title} body={info.body} />
+      </div>
+      <div className="mt-1 text-xl font-bold text-gray-900">{value}</div>
+    </div>
+  )
+}
+
+export default function TeamScheduleView({ teamId }: TeamScheduleViewProps) {
+  const { data, isLoading, error } = useGetScheduleQuery()
+  const team = data?.teams.find(item => item.team_id === Number(teamId))
+
+  if (isLoading) return <LoadingSpinner />
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load team schedule')} />
+  if (!team) return <p className="text-sm text-gray-500">Select a team to view its schedule.</p>
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900">{team.team_name} schedule</h2>
+        </div>
+        {team.total_games < 82 && (
+          <div className="max-w-md rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900">
+            <span className="font-semibold">{team.total_games} games are published.</span> Two Cup knockout slots are held for mid-December and will be added when scheduled.
+          </div>
+        )}
+      </div>
+
+      <div className="mb-5 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <Kpi label="Total games" value={team.total_games} metric="scheduleTotal" />
+        <Kpi label="Back-to-backs" value={team.b2b_count} metric="scheduleB2B" />
+        <Kpi label="High-volume" value={team.high_volume_games} metric="scheduleHighVolume" />
+        <Kpi label="Average rest" value={team.avg_rest_days === null ? '—' : `${team.avg_rest_days.toFixed(2)}d`} metric="scheduleRest" />
+      </div>
+
+      <div className="max-h-[34rem] overflow-auto rounded-lg border border-gray-200 lg:max-w-4xl">
+        <table className="min-w-[650px] w-full table-fixed border-collapse text-sm">
+          <colgroup>
+            <col className="w-40" />
+            <col />
+            <col className="w-36" />
+            <col className="w-32" />
+          </colgroup>
+          <thead className="sticky top-0 z-20 bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+            <tr>
+              <th className="border-b border-gray-200 px-3 py-3 text-left">Date</th>
+              <th className="border-b border-gray-200 px-3 py-3 text-left">Opponent</th>
+              <th className="border-b border-gray-200 px-3 py-3 text-right">Rest days</th>
+              <th className="border-b border-gray-200 px-3 py-3 text-right">Slate size</th>
+            </tr>
+          </thead>
+          <tbody>
+            {team.games.map((game, index) => {
+              const previous = team.games[index - 1]
+              const showMonth = !previous || monthKey(previous.date) !== monthKey(game.date)
+              return (
+                <Fragment key={game.game_id}>
+                  {showMonth && (
+                    <tr className="bg-blue-50/70 dark:bg-gray-700">
+                      <th colSpan={4} className="px-3 py-2 text-left text-xs font-bold uppercase tracking-wide text-blue-800 dark:text-blue-200">{monthLabel(game.date)}</th>
+                    </tr>
+                  )}
+                  <tr className="border-b border-gray-100 last:border-0 hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-3 py-3 text-gray-700">{formatDate(game.date, { weekday: 'short', month: 'short', day: 'numeric' })}</td>
+                    <td className="px-3 py-3 font-medium text-gray-800">
+                      <span className="mr-2 text-xs font-bold text-gray-400">{game.is_home ? 'vs' : '@'}</span>{game.opponent}
+                    </td>
+                    <td className={`px-3 py-3 text-right ${game.rest_days === 0 ? 'font-semibold text-rose-600' : 'text-gray-700'}`}>
+                      {game.rest_days === null ? '—' : game.rest_days === 0 ? '0 · B2B' : `${game.rest_days}d`}
+                    </td>
+                    <td className={`px-3 py-3 text-right font-medium ${slateClass(game)}`}>{game.slate_size}</td>
+                  </tr>
+                </Fragment>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -12,3 +12,4 @@ export const FF_DRAFT_STEALS_BUSTS = import.meta.env.VITE_FF_DRAFT_STEALS_BUSTS 
 export const FF_TRENDS = import.meta.env.VITE_FF_TRENDS === 'true';
 export const FF_MINIGAMES = import.meta.env.VITE_FF_MINIGAMES === 'true';
 export const FF_GLOBAL_SEARCH = import.meta.env.VITE_FF_GLOBAL_SEARCH === 'true';
+export const FF_SCHEDULE = import.meta.env.VITE_FF_SCHEDULE === 'true';

--- a/frontend/src/constants/metricGlossary.ts
+++ b/frontend/src/constants/metricGlossary.ts
@@ -26,6 +26,22 @@ export const METRIC_GLOSSARY = {
     title: 'Slot estimated',
     body: 'Realistic projection for this slot by season end — plan around this number.',
   },
+  scheduleTotal: {
+    title: 'Total games',
+    body: 'Published regular-season games for this team in the schedule currently available from ESPN.',
+  },
+  scheduleB2B: {
+    title: 'Back-to-backs',
+    body: 'Games played with no rest day since the previous game. A back-to-back has rest days = 0.',
+  },
+  scheduleHighVolume: {
+    title: 'High-volume games',
+    body: 'Games on nights with at least 10 NBA games league-wide. This is a sparse slate-density flag, not a recommendation.',
+  },
+  scheduleRest: {
+    title: 'Average rest',
+    body: 'Average number of calendar rest days between this team’s published games. The first game has no rest value.',
+  },
 } as const satisfies Record<string, MetricInfo>
 
 export type MetricKey = keyof typeof METRIC_GLOSSARY

--- a/frontend/src/constants/searchablePages.ts
+++ b/frontend/src/constants/searchablePages.ts
@@ -41,6 +41,6 @@ export const SEARCHABLE_PAGES: SearchablePage[] = [
         { label: 'Now You See Me', path: '/minigames/now-you-see-me', icon: '👁️', group: 'Minigames' },
       ]
     : []),
-  { label: 'NBA Depth Charts', path: '/nba-teams', icon: '🏀', group: 'NBA' },
+  { label: 'NBA Teams', path: '/nba-teams', icon: '🏀', group: 'NBA' },
   { label: 'Injuries', path: '/injuries', icon: '🩺', group: 'NBA' },
 ]

--- a/frontend/src/pages/NbaTeams.tsx
+++ b/frontend/src/pages/NbaTeams.tsx
@@ -203,7 +203,6 @@ export default function NbaTeams() {
               </section>
               {FF_SCHEDULE && (
                 <section aria-labelledby="nba-team-schedule-heading">
-                  <h2 id="nba-team-schedule-heading" className="mb-4 text-xl font-semibold text-gray-900">Schedule</h2>
                   <TeamScheduleView key={`schedule-${selectedTeamId}`} teamId={selectedTeamId} />
                 </section>
               )}

--- a/frontend/src/pages/NbaTeams.tsx
+++ b/frontend/src/pages/NbaTeams.tsx
@@ -8,6 +8,8 @@ import { getErrorMessage } from '../utils/errorMessage';
 import PlayerNameLink from '../components/PlayerNameLink';
 import type { DepthChartPosition } from '../types/api';
 import { applyDepthChartFilters } from '../utils/depthChartFilters';
+import TeamScheduleView from '../components/TeamScheduleView';
+import { FF_SCHEDULE } from '../config/featureFlags';
 
 const MAX_DEPTH = 5;
 const DEPTH_LABELS = ['Starter', '2nd', '3rd', '4th', '5th'];
@@ -169,7 +171,7 @@ export default function NbaTeams() {
         <h1 className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent mb-2">
           NBA Teams
         </h1>
-        <p className="text-gray-600">Select a team to view their depth chart</p>
+        <p className="text-gray-600">Select a team to explore its depth chart and schedule</p>
       </div>
 
       {isLoading ? (
@@ -193,7 +195,20 @@ export default function NbaTeams() {
             </select>
           </div>
 
-          {selectedTeamId && <DepthChartView key={selectedTeamId} teamId={selectedTeamId} />}
+          {selectedTeamId && (
+            <div className="space-y-10">
+              <section aria-labelledby="nba-depth-chart-heading">
+                <h2 id="nba-depth-chart-heading" className="mb-4 text-xl font-semibold text-gray-900">Depth chart</h2>
+                <DepthChartView key={`depth-${selectedTeamId}`} teamId={selectedTeamId} />
+              </section>
+              {FF_SCHEDULE && (
+                <section aria-labelledby="nba-team-schedule-heading">
+                  <h2 id="nba-team-schedule-heading" className="mb-4 text-xl font-semibold text-gray-900">Schedule</h2>
+                  <TeamScheduleView key={`schedule-${selectedTeamId}`} teamId={selectedTeamId} />
+                </section>
+              )}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/frontend/src/pages/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile.tsx
@@ -12,7 +12,7 @@ import PlayerNextGameCard from '../components/PlayerNextGameCard'
 
 function backLabel(from: string | undefined): string {
   if (!from) return '← Back'
-  if (from.startsWith('/nba-teams')) return '← Back to NBA Depth Charts'
+  if (from.startsWith('/nba-teams')) return '← Back to NBA Teams'
   if (from.startsWith('/players')) return '← Back to Players'
   if (from.startsWith('/team/')) return '← Back to Team'
   if (from.startsWith('/player-rankings')) return '← Back to Player Rankings'

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { usePersistedState } from '../hooks/usePersistedState';
 import { useDebounce } from '../hooks/useDebounce';
-import { useGetAllPlayersQuery, useGetTeamsListQuery } from '../store/api/fantasyApi';
+import { useGetAllPlayersQuery, useGetScheduleQuery, useGetTeamsListQuery } from '../store/api/fantasyApi';
 import { useGetMatchupsTodayQuery, useGetMatchupDatesQuery, useGetUpcomingDatesQuery, useGetCurrentSlateDateQuery } from '../store/api/fantasyApi';
 import type { PlayerFilters, Player, StatFilter, TimePeriod, ComparisonOperator, PlayerStats, CustomDateRange } from '../types/api';
 import type { PlayerMatchup } from '../types/api';
@@ -10,7 +10,7 @@ import { CoverageNotice } from '../components/DateRangePicker';
 import { MatchupCell, MatchupExpandRow } from '../components/MatchupDisplay';
 import InjuryBadge from '../components/InjuryBadge';
 import PlayerNameLink from '../components/PlayerNameLink';
-import { FF_MATCHUP_QUALITY, FF_PROJECTIONS, FF_PAST_SLATES } from '../config/featureFlags';
+import { FF_MATCHUP_QUALITY, FF_PROJECTIONS, FF_PAST_SLATES, FF_SCHEDULE } from '../config/featureFlags';
 import './Players.css';
 
 const Players = () => {
@@ -27,6 +27,7 @@ const Players = () => {
     ...(timePeriod === 'custom' && customRange ? { start: customRange.start, end: customRange.end } : {}),
   });
   const { data: teams } = useGetTeamsListQuery();
+  const { data: schedule } = useGetScheduleQuery(undefined, { skip: !FF_SCHEDULE || !FF_MATCHUP_QUALITY });
 
   useEffect(() => {
     if (timePeriod !== 'custom' || !customRange || !data?.players) return
@@ -45,6 +46,16 @@ const Players = () => {
   const { data: upcomingDates = [] } = useGetUpcomingDatesQuery(undefined, { skip: !FF_MATCHUP_QUALITY });
   const { data: pastDates = [] } = useGetMatchupDatesQuery(undefined, { skip: !FF_MATCHUP_QUALITY || !FF_PAST_SLATES });
   const { data: currentSlateDate } = useGetCurrentSlateDateQuery(undefined, { skip: !FF_MATCHUP_QUALITY });
+  const selectedSlateDate = slateDate || currentSlateDate || '';
+  const playingTeamsOnSlate = useMemo(() => {
+    if (!selectedSlateDate || !schedule) return null;
+    return new Set(
+      schedule.teams
+        .filter(team => team.games.some(game => game.date === selectedSlateDate))
+        .map(team => team.abbreviation)
+    );
+  }, [schedule, selectedSlateDate]);
+  const [playingOnSlateOnly, setPlayingOnSlateOnly] = useState(false);
   const { data: matchups = [] } = useGetMatchupsTodayQuery(
     slateDate ? slateDate.replaceAll('-', '') : undefined,
     { skip: !FF_MATCHUP_QUALITY }
@@ -89,6 +100,10 @@ const Players = () => {
         if (player.team_id !== filters.team_id) return false;
       }
 
+      if (playingOnSlateOnly && (!playingTeamsOnSlate || !playingTeamsOnSlate.has(player.pro_team))) {
+        return false;
+      }
+
       if (filters.stat_filters?.length) {
         for (const filter of filters.stat_filters) {
           const statValue = player.stats[filter.stat];
@@ -114,7 +129,7 @@ const Players = () => {
 
       return true;
     });
-  }, [data, filters, showAverages, debouncedSearch]);
+  }, [data, filters, showAverages, debouncedSearch, playingOnSlateOnly, playingTeamsOnSlate]);
 
   if (isLoading) return <div className="loading">Loading players...</div>;
   if (error) return <div className="error">Error loading players</div>;
@@ -154,9 +169,42 @@ const Players = () => {
                 {FF_PAST_SLATES && pastDates.length > 0 && (
                   <optgroup label="Past (debug)">
                     {pastDates.map((d) => <option key={d} value={d}>{d}</option>)}
-                  </optgroup>
-                )}
-              </select>
+                </optgroup>
+              )}
+            </select>
+          </label>
+          )}
+          {FF_MATCHUP_QUALITY && FF_SCHEDULE && (
+            <label
+              className={`group inline-flex h-8 items-center gap-2 rounded-md border px-2 text-xs transition-colors focus-within:ring-2 focus-within:ring-blue-300 ${
+                !selectedSlateDate || !playingTeamsOnSlate
+                  ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-500'
+                  : playingOnSlateOnly
+                    ? 'cursor-pointer border-blue-600 bg-blue-50 text-blue-900 shadow-sm dark:border-blue-400 dark:bg-blue-950 dark:text-blue-100'
+                    : 'cursor-pointer border-gray-300 bg-white text-gray-700 hover:border-blue-300 hover:bg-blue-50/40 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-500 dark:hover:bg-gray-700'
+              }`}
+              title="Keep only players whose NBA team plays on the selected slate."
+            >
+              <input
+                className="sr-only"
+                type="checkbox"
+                checked={playingOnSlateOnly}
+                disabled={!selectedSlateDate || !playingTeamsOnSlate}
+                onChange={(e) => setPlayingOnSlateOnly(e.target.checked)}
+              />
+              <span
+                aria-hidden="true"
+                className={`relative inline-flex h-4 w-7 shrink-0 rounded-full transition-colors ${
+                  !selectedSlateDate || !playingTeamsOnSlate
+                    ? 'bg-gray-300 dark:bg-gray-600'
+                    : playingOnSlateOnly
+                      ? 'bg-blue-600'
+                      : 'bg-gray-300 dark:bg-gray-600'
+                }`}
+              >
+                <span className={`absolute left-0.5 top-0.5 h-3 w-3 rounded-full bg-white shadow-sm transition-transform ${playingOnSlateOnly ? 'translate-x-[14px]' : ''}`} />
+              </span>
+              <span className="whitespace-nowrap font-medium">Only playing on slate</span>
             </label>
           )}
           {FF_PROJECTIONS && (

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from 'react'
+import InfoTip from '../components/InfoTip'
+import LoadingSpinner from '../components/LoadingSpinner'
+import ErrorMessage from '../components/ErrorMessage'
+import { useGetScheduleQuery } from '../store/api/fantasyApi'
+import { METRIC_GLOSSARY } from '../constants/metricGlossary'
+import { getErrorMessage } from '../utils/errorMessage'
+
+const MONTHS = ['October', 'November', 'December', 'January', 'February', 'March', 'April']
+
+function heatClass(value: number, min: number, max: number): string {
+  if (value === 0) return 'bg-gray-50 text-gray-400'
+  if (max === min || value === max) return 'bg-blue-200 text-blue-950'
+  const ratio = (value - min) / (max - min)
+  if (ratio >= 0.75) return 'bg-blue-100 text-blue-900'
+  if (ratio >= 0.35) return 'bg-blue-50 text-blue-800'
+  return 'bg-white text-gray-700'
+}
+
+function MetricHeader({ label, metric }: { label: string; metric: keyof typeof METRIC_GLOSSARY }) {
+  const info = METRIC_GLOSSARY[metric]
+  return (
+    <span className="inline-flex items-center gap-1">
+      {label}
+      <InfoTip title={info.title} body={info.body} formula={'formula' in info ? info.formula : undefined} />
+    </span>
+  )
+}
+
+export default function Schedule() {
+  const { data, isLoading, error } = useGetScheduleQuery()
+  const monthlyValues = useMemo(
+    () => data?.teams.flatMap(team => MONTHS.map(month => team.monthly_games[month] ?? 0)) ?? [],
+    [data]
+  )
+  const minMonthly = monthlyValues.length ? Math.min(...monthlyValues) : 0
+  const maxMonthly = monthlyValues.length ? Math.max(...monthlyValues) : 0
+
+  if (isLoading) return <LoadingSpinner />
+  if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load NBA schedule')} />
+  if (!data) return null
+
+  const scheduleGap = data.published_games_min > 0 && data.published_games_min < 82
+
+  return (
+    <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">Season schedule</h1>
+        <p className="mt-2 max-w-3xl text-gray-600">A full-season NBA schedule through a fantasy lens: density, rest, back-to-backs, and where each team’s games land by month.</p>
+      </div>
+
+      {scheduleGap && (
+        <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+          <span className="font-semibold">{data.published_games_min} games are published per team right now.</span>{' '}
+          Two slots are held for the NBA Cup knockout round and are filled around mid-December; this is expected, not missing data.
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+        <span className="font-medium text-gray-700">Season {data.season}</span>
+        <span>·</span>
+        <span>Blue cells show relative month density.</span>
+        <span className="inline-flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-blue-100" /> higher month count</span>
+        <span className="inline-flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-blue-200" /> highest month count</span>
+      </div>
+
+      <div className="max-h-[70vh] overflow-auto rounded-lg border border-gray-200 bg-white shadow">
+        <table className="min-w-[980px] w-full border-collapse text-sm">
+          <thead className="sticky top-0 z-20 bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+            <tr>
+              <th className="sticky left-0 z-30 border-b border-gray-200 bg-gray-50 px-3 py-3 text-left">Team</th>
+              {MONTHS.map(month => <th key={month} className="border-b border-gray-200 px-3 py-3 text-right">{month}</th>)}
+              <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="Total" metric="scheduleTotal" /></th>
+              <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="B2B" metric="scheduleB2B" /></th>
+              <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="High volume" metric="scheduleHighVolume" /></th>
+              <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="Avg rest" metric="scheduleRest" /></th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.teams.map(team => (
+              <tr key={team.team_id} className="border-b border-gray-100 last:border-0 hover:bg-blue-50/40">
+                <th className="sticky left-0 z-10 whitespace-nowrap border-r border-gray-100 bg-white px-3 py-3 text-left font-semibold text-gray-800">
+                  {team.team_name}
+                </th>
+                {MONTHS.map(month => {
+                  const value = team.monthly_games[month] ?? 0
+                  return <td key={month} className={`px-3 py-3 text-right font-medium ${heatClass(value, minMonthly, maxMonthly)}`}>{value}</td>
+                })}
+                <td className="px-3 py-3 text-right font-semibold text-gray-800">{team.total_games}</td>
+                <td className="px-3 py-3 text-right text-gray-700">{team.b2b_count}</td>
+                <td className="px-3 py-3 text-right text-gray-700">{team.high_volume_games}</td>
+                <td className="px-3 py-3 text-right text-gray-700">{team.avg_rest_days === null ? '—' : `${team.avg_rest_days.toFixed(2)}d`}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-xs text-gray-500">High-volume means {data.high_volume_threshold}+ NBA games league-wide on that date. This page reports schedule shape; it does not prescribe roster moves.</p>
+    </div>
+  )
+}

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -61,7 +61,6 @@ export default function Schedule() {
         <span>·</span>
         <span>Blue cells show relative month density.</span>
         <span className="inline-flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-blue-100" /> higher month count</span>
-        <span className="inline-flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-blue-200" /> highest month count</span>
       </div>
 
       <div className="max-h-[70vh] overflow-auto rounded-lg border border-gray-200 bg-white shadow">
@@ -73,7 +72,6 @@ export default function Schedule() {
               <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="Total" metric="scheduleTotal" /></th>
               <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="B2B" metric="scheduleB2B" /></th>
               <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="High volume" metric="scheduleHighVolume" /></th>
-              <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="Avg rest" metric="scheduleRest" /></th>
             </tr>
           </thead>
           <tbody>
@@ -89,7 +87,6 @@ export default function Schedule() {
                 <td className="px-3 py-3 text-right font-semibold text-gray-800">{team.total_games}</td>
                 <td className="px-3 py-3 text-right text-gray-700">{team.b2b_count}</td>
                 <td className="px-3 py-3 text-right text-gray-700">{team.high_volume_games}</td>
-                <td className="px-3 py-3 text-right text-gray-700">{team.avg_rest_days === null ? '—' : `${team.avg_rest_days.toFixed(2)}d`}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -15,6 +15,7 @@ import { MatchupCell, MatchupExpandRow } from '../components/MatchupDisplay'
 import InjuryBadge from '../components/InjuryBadge'
 import SlotUsageTable from '../components/SlotUsageTable'
 import PlayerNameLink from '../components/PlayerNameLink'
+import RosterCoverage from '../components/RosterCoverage'
 import { FF_MATCHUP_QUALITY, FF_PROJECTIONS } from '../config/featureFlags'
 
 const TeamDetail = () => {
@@ -363,6 +364,7 @@ const TeamDetail = () => {
           gameDaysLeft={leagueSummary?.nba_game_days_left}
         />
       )}
+      <RosterCoverage players={team_detail.players ?? []} teamId={teamIdNumber} />
 
       <div className="bg-white rounded-lg shadow p-6">
         <div className="flex flex-col sm:flex-row justify-between items-start mb-4 gap-3">

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -16,7 +16,7 @@ import InjuryBadge from '../components/InjuryBadge'
 import SlotUsageTable from '../components/SlotUsageTable'
 import PlayerNameLink from '../components/PlayerNameLink'
 import RosterCoverage from '../components/RosterCoverage'
-import { FF_MATCHUP_QUALITY, FF_PROJECTIONS } from '../config/featureFlags'
+import { FF_MATCHUP_QUALITY, FF_PROJECTIONS, FF_SCHEDULE } from '../config/featureFlags'
 
 const TeamDetail = () => {
   const { teamId } = useParams<{ teamId: string }>()
@@ -364,7 +364,7 @@ const TeamDetail = () => {
           gameDaysLeft={leagueSummary?.nba_game_days_left}
         />
       )}
-      <RosterCoverage players={team_detail.players ?? []} teamId={teamIdNumber} />
+      {FF_SCHEDULE && <RosterCoverage players={team_detail.players ?? []} teamId={teamIdNumber} />}
 
       <div className="bg-white rounded-lg shadow p-6">
         <div className="flex flex-col sm:flex-row justify-between items-start mb-4 gap-3">

--- a/frontend/src/store/api/fantasyApi.ts
+++ b/frontend/src/store/api/fantasyApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import type { LeagueRankings, TeamDetail, LeagueSummary, HeatmapData, LeagueShotsData, TeamPlayers, Team, TradeSuggestionsResponse, PaginatedPlayers, TimePeriod, RankingsOverTimeResponse, OverTimeSource, NbaTeamInfo, TeamDepthChart, NbaPlayerBio, NbaPlayerStatsResponse, PlayerMatchup, ProjectionStats, PlayerNextGameProjection, PlayersListResponse, PlayerStoreState, TeamsListResponse, TeamStoreState, DraftReport, MinutesResponse, UsageResponse, RegressionResponse, RegressionMode, GameLogResponse } from '../../types/api';
+import type { LeagueRankings, TeamDetail, LeagueSummary, HeatmapData, LeagueShotsData, TeamPlayers, Team, TradeSuggestionsResponse, PaginatedPlayers, TimePeriod, RankingsOverTimeResponse, OverTimeSource, NbaTeamInfo, TeamDepthChart, NbaPlayerBio, NbaPlayerStatsResponse, PlayerMatchup, ProjectionStats, PlayerNextGameProjection, PlayersListResponse, PlayerStoreState, TeamsListResponse, TeamStoreState, DraftReport, MinutesResponse, UsageResponse, RegressionResponse, RegressionMode, GameLogResponse, ScheduleResponse } from '../../types/api';
 import type { GameSlug, LeaderboardRow, MinigamePlayerBundle } from '../../minigames/types';
 import type { EstimatorResults } from '../../types/estimator';
 
@@ -79,6 +79,10 @@ export const fantasyApi = createApi({
     }),
     getNbaTeamDepthChart: builder.query<TeamDepthChart, string>({
       query: (teamId) => `/nba-teams/${teamId}/depthchart`,
+    }),
+    getSchedule: builder.query<ScheduleResponse, void>({
+      query: () => '/nba/schedule',
+      keepUnusedDataFor: 86400,
     }),
     getNbaPlayer: builder.query<NbaPlayerBio, string>({
       query: (playerId) => `/nba-players/${playerId}`,
@@ -197,6 +201,7 @@ export const {
   useGetEstimatorResultsQuery,
   useGetNbaTeamsListQuery,
   useGetNbaTeamDepthChartQuery,
+  useGetScheduleQuery,
   useGetNbaPlayerQuery,
   useGetNbaPlayerStatsQuery,
   useGetMatchupsTodayQuery,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -253,6 +253,45 @@ export interface NbaTeamInfo {
   team_name: string;
 }
 
+export interface ScheduleCalendarDay {
+  date: string;
+  slate_size: number;
+  high_volume: boolean;
+}
+
+export interface ScheduleGame {
+  game_id: string;
+  date: string;
+  opponent_id: number;
+  opponent: string;
+  opponent_abbreviation: string;
+  is_home: boolean;
+  rest_days: number | null;
+  slate_size: number;
+  high_volume: boolean;
+}
+
+export interface ScheduleTeam {
+  team_id: number;
+  abbreviation: string;
+  team_name: string;
+  games: ScheduleGame[];
+  monthly_games: Record<string, number>;
+  total_games: number;
+  b2b_count: number;
+  high_volume_games: number;
+  avg_rest_days: number | null;
+}
+
+export interface ScheduleResponse {
+  season: string;
+  high_volume_threshold: number;
+  calendar_days: ScheduleCalendarDay[];
+  teams: ScheduleTeam[];
+  published_games_min: number;
+  published_games_max: number;
+}
+
 export interface NbaInjury {
   status: string;
 }


### PR DESCRIPTION
## Summary
- add cached season schedule API and season/team schedule views
- add roster coverage and slate-aware player filtering
- refine slot pace colors, rounded bars, dark-mode slate styling, and compact responsive schedule layout
- rename NBA Depth Charts to NBA Teams and stack depth chart with schedule

## Validation
- frontend: npm run build
- frontend targeted tests: Players.test.tsx and NbaTeams.test.tsx (16 passed)
- backend: tests/services/test_schedule_service.py (4 passed)
- browser: desktop and mobile checks at 375px/414px, plus dark-mode verification

Target: dev