### PR TITLE
feat(frontend): slate calendar on the schedule page

### DIFF
--- a/frontend/src/components/RosterCoverage.tsx
+++ b/frontend/src/components/RosterCoverage.tsx
@@ -4,6 +4,7 @@ import type { Player, ScheduleCalendarDay } from '../types/api'
 import LoadingSpinner from './LoadingSpinner'
 import ErrorMessage from './ErrorMessage'
 import { getErrorMessage } from '../utils/errorMessage'
+import { firstScheduleDay, formatSlateDate } from '../utils/slateWindow'
 
 interface RosterCoverageProps {
   players: Player[]
@@ -19,15 +20,6 @@ function slateTone(day: ScheduleCalendarDay): string {
   if (day.high_volume) return 'bg-blue-50 text-blue-800'
   if (day.slate_size > 0) return 'bg-gray-100 text-gray-700'
   return 'bg-gray-100 text-gray-500'
-}
-
-function formatDay(date: string, options: Intl.DateTimeFormatOptions): string {
-  return new Intl.DateTimeFormat('en-US', options).format(new Date(`${date}T12:00:00`))
-}
-
-function firstScheduleDay(days: ScheduleCalendarDay[]): string {
-  const today = new Date().toISOString().slice(0, 10)
-  return days.find(day => day.date >= today)?.date ?? days[0]?.date ?? ''
 }
 
 export default function RosterCoverage({ players, teamId }: RosterCoverageProps) {
@@ -90,10 +82,10 @@ export default function RosterCoverage({ players, teamId }: RosterCoverageProps)
             onClick={() => setSelectedDate(day.date)}
             className={`w-16 min-w-16 shrink-0 rounded-lg px-1.5 py-2 text-center leading-none transition-shadow ${daySurface(day)} ${activeDate === day.date ? 'border-[3px] border-blue-700 shadow-sm' : 'border-2 border-gray-200'}`}
             aria-pressed={activeDate === day.date}
-            aria-label={`${formatDay(day.date, { weekday: 'short', month: 'short', day: 'numeric' })}: ${count} of ${roster.length} rostered players have an NBA game; ${day.slate_size} NBA games on the slate`}
+            aria-label={`${formatSlateDate(day.date, { weekday: 'short', month: 'short', day: 'numeric' })}: ${count} of ${roster.length} rostered players have an NBA game; ${day.slate_size} NBA games on the slate`}
           >
-            <div className="text-[10px] font-semibold uppercase leading-none">{formatDay(day.date, { weekday: 'short' })}</div>
-            <div className="text-xs leading-none">{formatDay(day.date, { month: 'short', day: 'numeric' })}</div>
+            <div className="text-[10px] font-semibold uppercase leading-none">{formatSlateDate(day.date, { weekday: 'short' })}</div>
+            <div className="text-xs leading-none">{formatSlateDate(day.date, { month: 'short', day: 'numeric' })}</div>
             <div className="mt-2 flex h-24 items-end justify-center" aria-hidden="true">
               <div className="relative h-full w-6 overflow-hidden rounded-t bg-blue-100">
                 <div

--- a/frontend/src/components/SlateCalendar.tsx
+++ b/frontend/src/components/SlateCalendar.tsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from 'react'
+import InfoTip from './InfoTip'
+import TeamNightGrid from './TeamNightGrid'
+import TeamTraceButton from './TeamTraceButton'
+import { METRIC_GLOSSARY } from '../constants/metricGlossary'
+import type { ScheduleResponse } from '../types/api'
+import {
+  HIGH_VOLUME_GAMES,
+  addDays,
+  buildSlateWindow,
+  firstScheduleDay,
+  formatSlateDate,
+  matchupsByDate,
+} from '../utils/slateWindow'
+
+const BAR_AREA_PX = 110
+const PRESETS = [7, 14, 28] as const
+
+interface SlateCalendarProps {
+  schedule: ScheduleResponse
+}
+
+export default function SlateCalendar({ schedule }: SlateCalendarProps) {
+  const calendarDays = schedule.calendar_days
+  const startDate = useMemo(() => firstScheduleDay(calendarDays), [calendarDays])
+  const lastDate = calendarDays[calendarDays.length - 1]?.date ?? startDate
+
+  const clampEnd = (date: string) => (date > lastDate ? lastDate : date)
+  const [endDate, setEndDate] = useState(() => clampEnd(addDays(firstScheduleDay(calendarDays), 13)))
+  const [selectedDayIndex, setSelectedDayIndex] = useState(0)
+  const [tracedTeam, setTracedTeam] = useState<string | null>(null)
+
+  const matchups = useMemo(() => matchupsByDate(schedule), [schedule])
+  const window = useMemo(
+    () => buildSlateWindow(schedule, startDate, endDate, matchups),
+    [endDate, matchups, schedule, startDate]
+  )
+
+  const { days, rows } = window
+  if (!days.length) return null
+
+  const dayIndex = Math.min(selectedDayIndex, days.length - 1)
+  const selectedDay = days[dayIndex]
+  const maxSlate = Math.max(...days.map(day => day.slateSize), 1)
+  const tracedNights = tracedTeam
+    ? days.filter(day => day.matchups.some(m => m.away === tracedTeam || m.home === tracedTeam)).length
+    : 0
+
+  const applyPreset = (nights: number | 'rest') => {
+    setEndDate(nights === 'rest' ? lastDate : clampEnd(addDays(startDate, nights - 1)))
+    setSelectedDayIndex(0)
+  }
+
+  const toggleTeam = (abbreviation: string) =>
+    setTracedTeam(current => (current === abbreviation ? null : abbreviation))
+
+  const activePreset = PRESETS.find(nights => clampEnd(addDays(startDate, nights - 1)) === endDate)
+  const isRest = endDate === lastDate
+
+  return (
+    <div className="mb-6 space-y-4">
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow sm:p-6">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex rounded-lg border border-gray-200 p-1 text-xs">
+            {PRESETS.map(nights => (
+              <button
+                key={nights}
+                type="button"
+                onClick={() => applyPreset(nights)}
+                className={`rounded-md px-2.5 py-1.5 sm:px-3 sm:py-2 ${
+                  activePreset === nights && !isRest ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                {nights} days
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => applyPreset('rest')}
+              className={`rounded-md px-2.5 py-1.5 sm:px-3 sm:py-2 ${
+                isRest ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'
+              }`}
+            >
+              Rest of season
+            </button>
+          </div>
+          <label className="flex items-center gap-2 rounded-lg bg-gray-100 px-2 py-1.5 text-xs font-semibold text-gray-600">
+            through
+            <input
+              type="date"
+              value={endDate}
+              min={addDays(startDate, 1)}
+              max={lastDate}
+              onChange={event => {
+                if (!event.target.value) return
+                setEndDate(clampEnd(event.target.value))
+                setSelectedDayIndex(0)
+              }}
+              className="rounded-md border border-gray-200 bg-white px-1.5 py-1 text-xs font-bold text-gray-900"
+            />
+          </label>
+        </div>
+
+        {tracedTeam && (
+          <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-blue-700 bg-blue-50 px-3 py-2 text-xs font-semibold text-blue-800">
+            <span>
+              Tracing <span className="font-extrabold">{tracedTeam}</span> — {tracedNights} game{tracedNights === 1 ? '' : 's'} in
+              this window, highlighted below
+            </span>
+            <button
+              type="button"
+              onClick={() => setTracedTeam(null)}
+              className="ml-auto rounded-md bg-white px-2 py-1 text-[11px] font-bold text-blue-700 hover:underline"
+            >
+              Clear
+            </button>
+          </div>
+        )}
+
+        <div className="mt-4 flex flex-wrap items-baseline justify-between gap-2">
+          <h2 className="inline-flex items-center gap-1 text-lg font-bold text-gray-900 sm:text-xl">
+            Games per night
+            <InfoTip title={METRIC_GLOSSARY.slateSize.title} body={METRIC_GLOSSARY.slateSize.body} />
+          </h2>
+          <span className="text-xs text-gray-500">
+            {window.totalGames} games over {days.length} nights · {window.highVolumeNights} at {HIGH_VOLUME_GAMES}+
+            {window.darkNights > 0 && ` · ${window.darkNights} with no games`}
+          </span>
+        </div>
+
+        <div className="relative mt-3">
+          <div className="flex gap-[3px] overflow-x-auto pb-1">
+            {days.map((day, index) => {
+              const playing = tracedTeam
+                ? day.matchups.some(m => m.away === tracedTeam || m.home === tracedTeam)
+                : null
+              return (
+                <button
+                  key={day.date}
+                  type="button"
+                  onClick={() => setSelectedDayIndex(index)}
+                  aria-pressed={index === dayIndex}
+                  title={`${formatSlateDate(day.date, { weekday: 'long', month: 'short', day: 'numeric' })} — ${day.slateSize} game${day.slateSize === 1 ? '' : 's'}`}
+                  className="min-w-[34px] flex-1 shrink-0 text-center sm:min-w-[42px]"
+                >
+                  <span
+                    className={`flex flex-col justify-end rounded p-0.5 ${index === dayIndex ? 'bg-blue-100 ring-1 ring-inset ring-blue-700' : ''}`}
+                    style={{ height: `${BAR_AREA_PX}px` }}
+                  >
+                    <span
+                      className={`rounded-t ${day.slateSize >= HIGH_VOLUME_GAMES ? 'bg-blue-900 dark:bg-blue-300' : 'bg-blue-600'} ${
+                        playing === false ? 'opacity-20' : ''
+                      } ${playing === true ? 'ring-2 ring-inset ring-gray-900 dark:ring-gray-100' : ''}`}
+                      style={{ height: `${(day.slateSize / maxSlate) * 100}%` }}
+                    />
+                    {day.slateSize === 0 && <span className="mx-auto w-1/2 border-t-2 border-dotted border-gray-400" />}
+                  </span>
+                  <span
+                    className={`mt-1 block text-xs font-bold tabular-nums ${
+                      day.slateSize === 0 ? 'text-gray-400' : day.slateSize >= HIGH_VOLUME_GAMES ? 'text-blue-900' : 'text-gray-800'
+                    }`}
+                  >
+                    {day.slateSize}
+                  </span>
+                  <span className={`block text-[9px] leading-tight ${index === dayIndex ? 'font-bold text-blue-700' : 'text-gray-400'}`}>
+                    {formatSlateDate(day.date, { weekday: 'short' })}
+                    <br />
+                    {formatSlateDate(day.date, { month: 'numeric', day: 'numeric' })}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+          {maxSlate >= HIGH_VOLUME_GAMES && (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 border-t border-dashed border-slate-500"
+              style={{ top: `${2 + (BAR_AREA_PX - 4) * (1 - HIGH_VOLUME_GAMES / maxSlate)}px` }}
+            >
+              <span className="absolute right-0 -top-4 bg-white px-1 text-[9px] font-bold text-slate-500">
+                {HIGH_VOLUME_GAMES} games
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-gray-500">
+          <span><span className="mr-1 inline-block h-3 w-3 rounded-sm bg-blue-600 align-[-2px]" />games that night</span>
+          <span><span className="mr-1 inline-block h-3 w-3 rounded-sm bg-blue-900 align-[-2px] dark:bg-blue-300" />high-volume night ({HIGH_VOLUME_GAMES}+)</span>
+          <span><span className="mr-1 inline-block w-3 border-t border-dashed border-slate-500 align-[3px]" />the {HIGH_VOLUME_GAMES}-game line</span>
+          <span><span className="mr-1 inline-block w-3 border-t-2 border-dotted border-gray-400 align-[3px]" />no games</span>
+        </div>
+
+        <div className="mt-4 border-t border-gray-100 pt-3">
+          <div className="flex flex-wrap items-baseline gap-2">
+            <h3 className="text-sm font-bold text-gray-900">
+              {formatSlateDate(selectedDay.date, { weekday: 'long', month: 'short', day: 'numeric' })}
+            </h3>
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${
+                selectedDay.slateSize >= HIGH_VOLUME_GAMES ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-600'
+              }`}
+            >
+              {selectedDay.slateSize === 0 ? 'no games' : `${selectedDay.slateSize} games`}
+              {selectedDay.slateSize >= HIGH_VOLUME_GAMES && ' · high volume'}
+            </span>
+            <span className="text-xs text-gray-500">
+              {selectedDay.slateSize === 0
+                ? 'every team is off'
+                : `${selectedDay.slateSize * 2} of 30 teams active · tap any team to trace it`}
+            </span>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {selectedDay.matchups.map(matchup => (
+              <span
+                key={`${matchup.away}-${matchup.home}`}
+                className="inline-flex items-center gap-1 rounded-lg bg-gray-100 px-1.5 py-1"
+              >
+                <TeamTraceButton abbreviation={matchup.away} traced={matchup.away === tracedTeam} onToggle={toggleTeam} />
+                <span className="text-[10px] font-bold text-gray-400">@</span>
+                <TeamTraceButton abbreviation={matchup.home} traced={matchup.home === tracedTeam} onToggle={toggleTeam} />
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow sm:p-6">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <h2 className="text-lg font-bold text-gray-900 sm:text-xl">Who plays when</h2>
+          <span className="text-xs text-gray-500">
+            tap a team to trace it · tap a column header to sort
+            {days.length > 21 && ' · scroll sideways for the rest of the window'}
+          </span>
+        </div>
+        <p className="mt-1 text-xs text-gray-500">
+          Teams play {window.minGames}–{window.maxGames} games in this window · {window.ordinaryTeams} of {rows.length} at{' '}
+          {window.modalGames}
+        </p>
+        <div className="mt-3">
+          <TeamNightGrid
+            days={days}
+            rows={rows}
+            selectedDayIndex={dayIndex}
+            tracedTeam={tracedTeam}
+            onSelectDay={setSelectedDayIndex}
+            onToggleTeam={toggleTeam}
+          />
+        </div>
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-gray-500">
+          <span><span className="mr-1 inline-block h-3 w-3 rounded-sm bg-blue-600 align-[-2px]" />plays</span>
+          <span><span className="mr-1 inline-block h-3 w-3 rounded-sm bg-amber-500 align-[-2px]" />second night of a back-to-back</span>
+          <span><span className="mr-1 inline-block h-3 w-3 rounded-sm bg-gray-200 align-[-2px] dark:bg-gray-600" />off</span>
+          <span><span className="mr-1 inline-block h-3 w-3 rounded-sm border border-gray-300 align-[-2px]" />league-wide dark night</span>
+        </div>
+        <p className="mt-3 text-xs text-gray-500">
+          <b className="text-gray-600">G</b> = games in the window. <b className="text-gray-600">Δ</b> = whole games above or
+          below the count most teams have; <b className="text-gray-600">—</b> means ordinary.{' '}
+          <b className="text-gray-600">B2B</b> = back-to-backs inside the window.{' '}
+          <b className="text-gray-600">Next</b> = first game from today.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SlateCalendar.tsx
+++ b/frontend/src/components/SlateCalendar.tsx
@@ -284,8 +284,7 @@ export default function SlateCalendar({ schedule }: SlateCalendarProps) {
           <b className="text-gray-600">Next</b> = first game from today.
         </p>
         <p className="mt-2 text-xs text-gray-500">
-          Nights are <b className="text-gray-600">US Eastern game dates</b>, the same dates ESPN scores against — so a night
-          shown here tips overnight Israel time.
+          Nights are <b className="text-gray-600">US Eastern game dates</b>, the same dates ESPN scores against.
         </p>
       </div>
     </div>

--- a/frontend/src/components/SlateCalendar.tsx
+++ b/frontend/src/components/SlateCalendar.tsx
@@ -15,6 +15,7 @@ import {
 
 const BAR_AREA_PX = 110
 const PRESETS = [7, 14, 28] as const
+type WindowMode = (typeof PRESETS)[number] | 'custom'
 
 interface SlateCalendarProps {
   schedule: ScheduleResponse
@@ -26,9 +27,17 @@ export default function SlateCalendar({ schedule }: SlateCalendarProps) {
   const lastDate = calendarDays[calendarDays.length - 1]?.date ?? startDate
 
   const clampEnd = (date: string) => (date > lastDate ? lastDate : date)
-  const [endDate, setEndDate] = useState(() => clampEnd(addDays(firstScheduleDay(calendarDays), 13)))
+  // Mode is explicit rather than inferred from the end date. Inferring it made
+  // a hand-picked date that happened to match a preset flip the active button,
+  // and left no way to say "the user is choosing their own end date".
+  const [mode, setMode] = useState<WindowMode>(14)
+  const [customEnd, setCustomEnd] = useState(lastDate)
+  const [draftEnd, setDraftEnd] = useState<string | null>(null)
   const [selectedDayIndex, setSelectedDayIndex] = useState(0)
   const [tracedTeam, setTracedTeam] = useState<string | null>(null)
+
+  const endDate = mode === 'custom' ? customEnd : clampEnd(addDays(startDate, mode - 1))
+  const minEnd = addDays(startDate, 1)
 
   const matchups = useMemo(() => matchupsByDate(schedule), [schedule])
   const window = useMemo(
@@ -46,16 +55,15 @@ export default function SlateCalendar({ schedule }: SlateCalendarProps) {
     ? days.filter(day => day.matchups.some(m => m.away === tracedTeam || m.home === tracedTeam)).length
     : 0
 
-  const applyPreset = (nights: number | 'rest') => {
-    setEndDate(nights === 'rest' ? lastDate : clampEnd(addDays(startDate, nights - 1)))
+  const chooseMode = (next: WindowMode) => {
+    if (next === 'custom') setCustomEnd(lastDate)
+    setMode(next)
+    setDraftEnd(null)
     setSelectedDayIndex(0)
   }
 
   const toggleTeam = (abbreviation: string) =>
     setTracedTeam(current => (current === abbreviation ? null : abbreviation))
-
-  const activePreset = PRESETS.find(nights => clampEnd(addDays(startDate, nights - 1)) === endDate)
-  const isRest = endDate === lastDate
 
   return (
     <div className="mb-6 space-y-4">
@@ -66,9 +74,9 @@ export default function SlateCalendar({ schedule }: SlateCalendarProps) {
               <button
                 key={nights}
                 type="button"
-                onClick={() => applyPreset(nights)}
+                onClick={() => chooseMode(nights)}
                 className={`rounded-md px-2.5 py-1.5 sm:px-3 sm:py-2 ${
-                  activePreset === nights && !isRest ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'
+                  mode === nights ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'
                 }`}
               >
                 {nights} days
@@ -76,35 +84,43 @@ export default function SlateCalendar({ schedule }: SlateCalendarProps) {
             ))}
             <button
               type="button"
-              onClick={() => applyPreset('rest')}
+              onClick={() => chooseMode('custom')}
               className={`rounded-md px-2.5 py-1.5 sm:px-3 sm:py-2 ${
-                isRest ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'
+                mode === 'custom' ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'
               }`}
             >
-              Rest of season
+              Pick an end date
             </button>
           </div>
-          <label className="flex items-center gap-2 rounded-lg bg-gray-100 px-2 py-1.5 text-xs font-semibold text-gray-600">
+          <label
+            className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-semibold ${
+              mode === 'custom' ? 'bg-gray-100 text-gray-600' : 'bg-gray-50 text-gray-400'
+            }`}
+          >
             through
-            {/* Uncontrolled + keyed: a controlled value snaps back on every
-                half-typed date, so typing a date was impossible. The key
-                remounts it when a preset moves the window instead. */}
+            {/* Draft state lets the field hold a half-typed date. A plain
+                controlled value snaps back on every incomplete keystroke, and
+                remounting it on each change blanked the field mid-pick. */}
             <input
-              key={endDate}
               type="date"
-              defaultValue={endDate}
-              min={addDays(startDate, 1)}
+              value={draftEnd ?? endDate}
+              min={minEnd}
               max={lastDate}
+              disabled={mode !== 'custom'}
               onChange={event => {
                 const picked = event.target.value
-                if (!picked) return
-                const bounded = picked < startDate ? addDays(startDate, 1) : clampEnd(picked)
-                setEndDate(bounded)
+                setDraftEnd(picked)
+                if (!picked || picked < minEnd || picked > lastDate) return
+                setCustomEnd(picked)
                 setSelectedDayIndex(0)
               }}
-              className="rounded-md border border-gray-200 bg-white px-1.5 py-1 text-xs font-bold text-gray-900"
+              onBlur={() => setDraftEnd(null)}
+              className="rounded-md border border-gray-200 bg-white px-1.5 py-1 text-xs font-bold text-gray-900 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
             />
           </label>
+          {mode !== 'custom' && (
+            <span className="text-xs text-gray-400">choose “Pick an end date” to set your own</span>
+          )}
         </div>
 
         {tracedTeam && (

--- a/frontend/src/components/SlateCalendar.tsx
+++ b/frontend/src/components/SlateCalendar.tsx
@@ -86,14 +86,20 @@ export default function SlateCalendar({ schedule }: SlateCalendarProps) {
           </div>
           <label className="flex items-center gap-2 rounded-lg bg-gray-100 px-2 py-1.5 text-xs font-semibold text-gray-600">
             through
+            {/* Uncontrolled + keyed: a controlled value snaps back on every
+                half-typed date, so typing a date was impossible. The key
+                remounts it when a preset moves the window instead. */}
             <input
+              key={endDate}
               type="date"
-              value={endDate}
+              defaultValue={endDate}
               min={addDays(startDate, 1)}
               max={lastDate}
               onChange={event => {
-                if (!event.target.value) return
-                setEndDate(clampEnd(event.target.value))
+                const picked = event.target.value
+                if (!picked) return
+                const bounded = picked < startDate ? addDays(startDate, 1) : clampEnd(picked)
+                setEndDate(bounded)
                 setSelectedDayIndex(0)
               }}
               className="rounded-md border border-gray-200 bg-white px-1.5 py-1 text-xs font-bold text-gray-900"
@@ -123,8 +129,10 @@ export default function SlateCalendar({ schedule }: SlateCalendarProps) {
             <InfoTip title={METRIC_GLOSSARY.slateSize.title} body={METRIC_GLOSSARY.slateSize.body} />
           </h2>
           <span className="text-xs text-gray-500">
-            {window.totalGames} games over {days.length} nights · {window.highVolumeNights} at {HIGH_VOLUME_GAMES}+
-            {window.darkNights > 0 && ` · ${window.darkNights} with no games`}
+            {window.totalGames} games over {days.length} nights · {window.highVolumeNights} night
+            {window.highVolumeNights === 1 ? '' : 's'} at {HIGH_VOLUME_GAMES}+ games
+            {window.darkNights > 0 &&
+              ` · ${window.darkNights} night${window.darkNights === 1 ? '' : 's'} with no games at all`}
           </span>
         </div>
 
@@ -258,6 +266,10 @@ export default function SlateCalendar({ schedule }: SlateCalendarProps) {
           below the count most teams have; <b className="text-gray-600">—</b> means ordinary.{' '}
           <b className="text-gray-600">B2B</b> = back-to-backs inside the window.{' '}
           <b className="text-gray-600">Next</b> = first game from today.
+        </p>
+        <p className="mt-2 text-xs text-gray-500">
+          Nights are <b className="text-gray-600">US Eastern game dates</b>, the same dates ESPN scores against — so a night
+          shown here tips overnight Israel time.
         </p>
       </div>
     </div>

--- a/frontend/src/components/SlotUsageTable.tsx
+++ b/frontend/src/components/SlotUsageTable.tsx
@@ -167,7 +167,7 @@ export default function SlotUsageTable({ slotUsage, avgPace, gameDaysLeft }: Slo
                   {visibleSegments.map((segment, index) => (
                     <span
                       key={segment.key}
-                      title={segmentTooltip(segment, values)}
+                      aria-label={segmentTooltip(segment, values)}
                       className={`group relative h-full min-w-[2px] ${segment.className} ${index === 0 ? 'rounded-l-full' : ''} ${index === visibleSegments.length - 1 ? 'rounded-r-full' : ''}`}
                       style={{ width: `${(segment.value / cap) * 100}%` }}
                     >

--- a/frontend/src/components/TeamNightGrid.tsx
+++ b/frontend/src/components/TeamNightGrid.tsx
@@ -1,0 +1,160 @@
+import { useMemo, useState } from 'react'
+import InfoTip from './InfoTip'
+import TeamTraceButton from './TeamTraceButton'
+import { METRIC_GLOSSARY } from '../constants/metricGlossary'
+import { formatSlateDate, type SlateDay, type SlateTeamRow } from '../utils/slateWindow'
+
+type SortKey = 'abbreviation' | 'games' | 'delta' | 'b2b' | 'nextIndex'
+
+interface TeamNightGridProps {
+  days: SlateDay[]
+  rows: SlateTeamRow[]
+  selectedDayIndex: number
+  tracedTeam: string | null
+  onSelectDay: (index: number) => void
+  onToggleTeam: (abbreviation: string) => void
+}
+
+const STICKY = {
+  team: 'sticky left-0 z-20 w-[50px] min-w-[50px] sm:w-[60px] sm:min-w-[60px]',
+  games: 'sticky left-[50px] sm:left-[60px] z-20 w-[26px] min-w-[26px] sm:w-[32px] sm:min-w-[32px]',
+  delta: 'sticky left-[76px] sm:left-[92px] z-20 w-[32px] min-w-[32px] sm:w-[38px] sm:min-w-[38px]',
+  b2b: 'hidden sm:table-cell sm:sticky sm:left-[130px] sm:z-20 sm:w-[38px] sm:min-w-[38px]',
+  next: 'hidden sm:table-cell sm:sticky sm:left-[168px] sm:z-20 sm:w-[58px] sm:min-w-[58px] sm:border-r-2 sm:border-gray-300',
+}
+
+function deltaLabel(delta: number): string {
+  if (delta === 0) return '—'
+  return delta > 0 ? `+${delta}` : `${delta}`
+}
+
+function deltaTone(delta: number): string {
+  if (delta === 0) return 'text-gray-400'
+  return delta > 0 ? 'text-green-700 dark:text-green-400' : 'text-red-600'
+}
+
+// bg-gray-200 is not one of the shades index.css remaps for dark mode, so the
+// "off" dot needs an explicit dark variant or it renders bright white.
+function dotTone(playing: boolean, backToBack: boolean, darkNight: boolean): string {
+  if (!playing) return darkNight ? 'border border-gray-300 bg-transparent' : 'bg-gray-200 dark:bg-gray-600'
+  return backToBack ? 'bg-amber-500' : 'bg-blue-600'
+}
+
+export default function TeamNightGrid({
+  days,
+  rows,
+  selectedDayIndex,
+  tracedTeam,
+  onSelectDay,
+  onToggleTeam,
+}: TeamNightGridProps) {
+  const [sortKey, setSortKey] = useState<SortKey>('delta')
+  const [sortDir, setSortDir] = useState<1 | -1>(-1)
+
+  const sorted = useMemo(() => {
+    const compare: Record<SortKey, (a: SlateTeamRow, b: SlateTeamRow) => number> = {
+      abbreviation: (a, b) => a.abbreviation.localeCompare(b.abbreviation),
+      games: (a, b) => a.games - b.games,
+      delta: (a, b) => a.delta - b.delta,
+      b2b: (a, b) => a.b2b - b.b2b,
+      nextIndex: (a, b) => b.nextIndex - a.nextIndex,
+    }
+    return [...rows].sort(
+      (a, b) => compare[sortKey](a, b) * sortDir || a.abbreviation.localeCompare(b.abbreviation)
+    )
+  }, [rows, sortDir, sortKey])
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir(current => (current === 1 ? -1 : 1))
+      return
+    }
+    setSortKey(key)
+    setSortDir(key === 'abbreviation' || key === 'nextIndex' ? 1 : -1)
+  }
+
+  const arrow = (key: SortKey) => (sortKey === key ? (sortDir > 0 ? ' ▲' : ' ▼') : '')
+  const headTone = (key: SortKey) => (sortKey === key ? 'text-blue-700' : 'text-gray-500')
+
+  const sortableHead = (key: SortKey, label: string, sticky: string, tip?: keyof typeof METRIC_GLOSSARY) => (
+    <th
+      scope="col"
+      className={`${sticky} cursor-pointer bg-gray-50 px-1 py-2 text-center text-[9px] uppercase tracking-wide sm:text-[10px] ${headTone(key)}`}
+      onClick={() => toggleSort(key)}
+      aria-sort={sortKey === key ? (sortDir > 0 ? 'ascending' : 'descending') : 'none'}
+    >
+      <span className="inline-flex items-center gap-0.5">
+        {label}
+        {arrow(key)}
+        {tip && <InfoTip title={METRIC_GLOSSARY[tip].title} body={METRIC_GLOSSARY[tip].body} />}
+      </span>
+    </th>
+  )
+
+  return (
+    <div className="max-h-[470px] overflow-auto rounded-lg border border-gray-200">
+      <table className="w-full border-collapse text-xs">
+        <thead className="sticky top-0 z-30 bg-gray-50">
+          <tr>
+            {sortableHead('abbreviation', 'Team', `${STICKY.team} text-left`)}
+            {sortableHead('games', 'G', STICKY.games)}
+            {sortableHead('delta', 'Δ', STICKY.delta, 'slateDelta')}
+            {sortableHead('b2b', 'B2B', STICKY.b2b, 'slateB2B')}
+            {sortableHead('nextIndex', 'Next', STICKY.next)}
+            {days.map((day, index) => (
+              <th
+                key={day.date}
+                scope="col"
+                onClick={() => onSelectDay(index)}
+                title={`${formatSlateDate(day.date, { weekday: 'long', month: 'short', day: 'numeric' })} — ${day.slateSize} games`}
+                className={`cursor-pointer px-0.5 py-2 text-center text-[9px] font-semibold leading-tight sm:text-[10px] ${
+                  index === selectedDayIndex ? 'bg-blue-100 text-blue-800' : day.slateSize === 0 ? 'bg-gray-200 text-gray-400' : 'text-gray-500'
+                }`}
+              >
+                {formatSlateDate(day.date, { weekday: 'narrow' })}
+                <br />
+                {formatSlateDate(day.date, { day: 'numeric' })}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map(row => {
+            const traced = row.abbreviation === tracedTeam
+            const dimmed = tracedTeam !== null && !traced
+            const rowTone = traced ? 'bg-blue-50' : 'bg-white'
+            return (
+              <tr key={row.abbreviation} className={`border-b border-gray-100 last:border-0 ${dimmed ? 'opacity-60' : ''}`}>
+                <th scope="row" className={`${STICKY.team} ${rowTone} px-1 py-1 text-left font-normal`}>
+                  <TeamTraceButton abbreviation={row.abbreviation} traced={traced} onToggle={onToggleTeam} />
+                </th>
+                <td className={`${STICKY.games} ${rowTone} px-1 py-1 text-center font-bold tabular-nums text-gray-800`}>{row.games}</td>
+                <td className={`${STICKY.delta} ${rowTone} px-1 py-1 text-center font-bold tabular-nums ${deltaTone(row.delta)}`}>
+                  {deltaLabel(row.delta)}
+                </td>
+                <td className={`${STICKY.b2b} ${rowTone} px-1 py-1 text-center tabular-nums text-gray-600`}>{row.b2b}</td>
+                <td className={`${STICKY.next} ${rowTone} px-1 py-1 text-center text-[10px] text-gray-500`}>
+                  {row.nextIndex < 0 ? '—' : formatSlateDate(days[row.nextIndex].date, { weekday: 'short', day: 'numeric' })}
+                </td>
+                {row.plays.map((playing, index) => (
+                  <td
+                    key={days[index].date}
+                    className={`px-0.5 py-1 text-center ${index === selectedDayIndex ? 'bg-blue-50' : ''}`}
+                  >
+                    <span
+                      className={`inline-block h-[9px] w-[9px] rounded-[2px] sm:h-[11px] sm:w-[11px] ${dotTone(
+                        playing,
+                        playing && index > 0 && row.plays[index - 1],
+                        days[index].slateSize === 0
+                      )}`}
+                    />
+                  </td>
+                ))}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/TeamNightGrid.tsx
+++ b/frontend/src/components/TeamNightGrid.tsx
@@ -16,11 +16,11 @@ interface TeamNightGridProps {
 }
 
 const STICKY = {
-  team: 'sticky left-0 z-20 w-[50px] min-w-[50px] sm:w-[60px] sm:min-w-[60px]',
-  games: 'sticky left-[50px] sm:left-[60px] z-20 w-[26px] min-w-[26px] sm:w-[32px] sm:min-w-[32px]',
-  delta: 'sticky left-[76px] sm:left-[92px] z-20 w-[32px] min-w-[32px] sm:w-[38px] sm:min-w-[38px]',
-  b2b: 'hidden sm:table-cell sm:sticky sm:left-[130px] sm:z-20 sm:w-[38px] sm:min-w-[38px]',
-  next: 'hidden sm:table-cell sm:sticky sm:left-[168px] sm:z-20 sm:w-[58px] sm:min-w-[58px] sm:border-r-2 sm:border-gray-300',
+  team: 'sticky left-0 z-20 w-[54px] min-w-[54px] sm:w-[64px] sm:min-w-[64px]',
+  games: 'sticky left-[54px] sm:left-[64px] z-20 w-[28px] min-w-[28px] sm:w-[34px] sm:min-w-[34px]',
+  delta: 'sticky left-[82px] sm:left-[98px] z-20 w-[34px] min-w-[34px] sm:w-[40px] sm:min-w-[40px]',
+  b2b: 'hidden sm:table-cell sm:sticky sm:left-[138px] sm:z-20 sm:w-[40px] sm:min-w-[40px]',
+  next: 'hidden sm:table-cell sm:sticky sm:left-[178px] sm:z-20 sm:w-[62px] sm:min-w-[62px] sm:border-r-2 sm:border-gray-300',
 }
 
 function deltaLabel(delta: number): string {
@@ -107,8 +107,8 @@ export default function TeamNightGrid({
                 scope="col"
                 onClick={() => onSelectDay(index)}
                 title={`${formatSlateDate(day.date, { weekday: 'long', month: 'short', day: 'numeric' })} — ${day.slateSize} games`}
-                className={`cursor-pointer px-0.5 py-2 text-center text-[9px] font-semibold leading-tight sm:text-[10px] ${
-                  index === selectedDayIndex ? 'bg-blue-100 text-blue-800' : day.slateSize === 0 ? 'bg-gray-200 text-gray-400' : 'text-gray-500'
+                className={`w-[24px] min-w-[24px] cursor-pointer px-1 py-2 text-center text-[10px] font-semibold leading-tight sm:w-[28px] sm:min-w-[28px] sm:text-[11px] ${
+                  index === selectedDayIndex ? 'bg-blue-100 text-blue-800' : day.slateSize === 0 ? 'bg-gray-200 text-gray-400 dark:bg-gray-700' : 'text-gray-500'
                 }`}
               >
                 {formatSlateDate(day.date, { weekday: 'narrow' })}
@@ -139,10 +139,10 @@ export default function TeamNightGrid({
                 {row.plays.map((playing, index) => (
                   <td
                     key={days[index].date}
-                    className={`px-0.5 py-1 text-center ${index === selectedDayIndex ? 'bg-blue-50' : ''}`}
+                    className={`w-[24px] min-w-[24px] px-1 py-1.5 text-center sm:w-[28px] sm:min-w-[28px] ${index === selectedDayIndex ? 'bg-blue-50' : ''}`}
                   >
                     <span
-                      className={`inline-block h-[9px] w-[9px] rounded-[2px] sm:h-[11px] sm:w-[11px] ${dotTone(
+                      className={`inline-block h-[14px] w-[14px] rounded-[3px] sm:h-[16px] sm:w-[16px] ${dotTone(
                         playing,
                         playing && index > 0 && row.plays[index - 1],
                         days[index].slateSize === 0

--- a/frontend/src/components/TeamTraceButton.tsx
+++ b/frontend/src/components/TeamTraceButton.tsx
@@ -1,0 +1,26 @@
+interface TeamTraceButtonProps {
+  abbreviation: string
+  traced: boolean
+  onToggle: (abbreviation: string) => void
+}
+
+export default function TeamTraceButton({ abbreviation, traced, onToggle }: TeamTraceButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={event => {
+        event.stopPropagation()
+        onToggle(abbreviation)
+      }}
+      aria-pressed={traced}
+      aria-label={traced ? `Stop tracing ${abbreviation}` : `Trace ${abbreviation} across the window`}
+      className={`rounded border px-1.5 py-1 text-[10px] font-extrabold tabular-nums tracking-wide transition-colors sm:text-[11px] ${
+        traced
+          ? 'border-blue-700 bg-blue-700 text-white'
+          : 'border-gray-200 bg-white text-gray-900 hover:border-blue-700 hover:bg-blue-50 hover:text-blue-700'
+      }`}
+    >
+      {abbreviation}
+    </button>
+  )
+}

--- a/frontend/src/constants/metricGlossary.ts
+++ b/frontend/src/constants/metricGlossary.ts
@@ -38,9 +38,17 @@ export const METRIC_GLOSSARY = {
     title: 'High-volume games',
     body: 'Games on nights with at least 10 NBA games league-wide. This is a sparse slate-density flag, not a recommendation.',
   },
-  scheduleRest: {
-    title: 'Average rest',
-    body: 'Average number of calendar rest days between this team’s published games. The first game has no rest value.',
+  slateSize: {
+    title: 'Games per night',
+    body: 'NBA games league-wide on that date. Fifteen is the theoretical maximum; a real night runs 2 to 13.',
+  },
+  slateDelta: {
+    title: 'Games vs typical',
+    body: 'Whole games above or below the count most teams have in this window. A dash means ordinary. Over short windows almost every team is ordinary, so this only separates the extremes.',
+  },
+  slateB2B: {
+    title: 'Back-to-backs in window',
+    body: 'Games this team plays on the night straight after another game, inside the selected window.',
   },
 } as const satisfies Record<string, MetricInfo>
 

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -14,7 +14,7 @@ type Grain = 'months' | 'weeks'
 
 function heatClass(value: number, min: number, max: number): string {
   if (value === 0) return 'bg-gray-50 text-gray-400'
-  if (max === min || value === max) return 'bg-blue-200 text-blue-950'
+  if (max === min) return 'bg-blue-50 text-blue-800'
   const ratio = (value - min) / (max - min)
   if (ratio >= 0.75) return 'bg-blue-100 text-blue-900'
   if (ratio >= 0.35) return 'bg-blue-50 text-blue-800'

--- a/frontend/src/pages/Schedule.tsx
+++ b/frontend/src/pages/Schedule.tsx
@@ -1,12 +1,16 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import InfoTip from '../components/InfoTip'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
+import SlateCalendar from '../components/SlateCalendar'
 import { useGetScheduleQuery } from '../store/api/fantasyApi'
 import { METRIC_GLOSSARY } from '../constants/metricGlossary'
 import { getErrorMessage } from '../utils/errorMessage'
+import { formatSlateDate, weekStart } from '../utils/slateWindow'
 
 const MONTHS = ['October', 'November', 'December', 'January', 'February', 'March', 'April']
+
+type Grain = 'months' | 'weeks'
 
 function heatClass(value: number, min: number, max: number): string {
   if (value === 0) return 'bg-gray-50 text-gray-400'
@@ -29,12 +33,41 @@ function MetricHeader({ label, metric }: { label: string; metric: keyof typeof M
 
 export default function Schedule() {
   const { data, isLoading, error } = useGetScheduleQuery()
-  const monthlyValues = useMemo(
-    () => data?.teams.flatMap(team => MONTHS.map(month => team.monthly_games[month] ?? 0)) ?? [],
-    [data]
-  )
-  const minMonthly = monthlyValues.length ? Math.min(...monthlyValues) : 0
-  const maxMonthly = monthlyValues.length ? Math.max(...monthlyValues) : 0
+  const [grain, setGrain] = useState<Grain>('months')
+
+  const weeks = useMemo(() => {
+    const starts = new Set<string>()
+    for (const day of data?.calendar_days ?? []) {
+      if (day.slate_size > 0) starts.add(weekStart(day.date))
+    }
+    return [...starts].sort()
+  }, [data])
+
+  const weeklyGames = useMemo(() => {
+    const byTeam = new Map<number, Record<string, number>>()
+    for (const team of data?.teams ?? []) {
+      const counts: Record<string, number> = {}
+      for (const game of team.games) {
+        const key = weekStart(game.date)
+        counts[key] = (counts[key] ?? 0) + 1
+      }
+      byTeam.set(team.team_id, counts)
+    }
+    return byTeam
+  }, [data])
+
+  const columns = grain === 'months' ? MONTHS : weeks
+  const cellValues = useMemo(() => {
+    if (!data) return []
+    return data.teams.flatMap(team =>
+      grain === 'months'
+        ? MONTHS.map(month => team.monthly_games[month] ?? 0)
+        : weeks.map(week => weeklyGames.get(team.team_id)?.[week] ?? 0)
+    )
+  }, [data, grain, weeklyGames, weeks])
+
+  const minCell = cellValues.length ? Math.min(...cellValues) : 0
+  const maxCell = cellValues.length ? Math.max(...cellValues) : 0
 
   if (isLoading) return <LoadingSpinner />
   if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load NBA schedule')} />
@@ -56,19 +89,37 @@ export default function Schedule() {
         </div>
       )}
 
+      <SlateCalendar schedule={data} />
+
       <div className="mb-4 flex flex-wrap items-center gap-3 text-xs text-gray-500">
         <span className="font-medium text-gray-700">Season {data.season}</span>
         <span>·</span>
-        <span>Blue cells show relative month density.</span>
-        <span className="inline-flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-blue-100" /> higher month count</span>
+        <span>Blue cells show relative {grain === 'months' ? 'month' : 'week'} density.</span>
+        <span className="inline-flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-blue-100" /> higher count</span>
+        <div className="ml-auto flex rounded-lg border border-gray-200 p-1">
+          {(['months', 'weeks'] as const).map(value => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setGrain(value)}
+              className={`rounded-md px-3 py-1.5 capitalize ${grain === value ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-50'}`}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className="max-h-[70vh] overflow-auto rounded-lg border border-gray-200 bg-white shadow">
-        <table className="min-w-[980px] w-full border-collapse text-sm">
+        <table className={`${grain === 'months' ? 'min-w-[980px]' : 'min-w-[1500px]'} w-full border-collapse text-sm`}>
           <thead className="sticky top-0 z-20 bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
             <tr>
               <th className="sticky left-0 z-30 border-b border-gray-200 bg-gray-50 px-3 py-3 text-left">Team</th>
-              {MONTHS.map(month => <th key={month} className="border-b border-gray-200 px-3 py-3 text-right">{month}</th>)}
+              {columns.map(column => (
+                <th key={column} className="border-b border-gray-200 px-3 py-3 text-right whitespace-nowrap">
+                  {grain === 'months' ? column : formatSlateDate(column, { month: 'short', day: 'numeric' })}
+                </th>
+              ))}
               <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="Total" metric="scheduleTotal" /></th>
               <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="B2B" metric="scheduleB2B" /></th>
               <th className="border-b border-gray-200 px-3 py-3 text-right"><MetricHeader label="High volume" metric="scheduleHighVolume" /></th>
@@ -80,9 +131,11 @@ export default function Schedule() {
                 <th className="sticky left-0 z-10 whitespace-nowrap border-r border-gray-100 bg-white px-3 py-3 text-left font-semibold text-gray-800">
                   {team.team_name}
                 </th>
-                {MONTHS.map(month => {
-                  const value = team.monthly_games[month] ?? 0
-                  return <td key={month} className={`px-3 py-3 text-right font-medium ${heatClass(value, minMonthly, maxMonthly)}`}>{value}</td>
+                {columns.map(column => {
+                  const value = grain === 'months'
+                    ? team.monthly_games[column] ?? 0
+                    : weeklyGames.get(team.team_id)?.[column] ?? 0
+                  return <td key={column} className={`px-3 py-3 text-right font-medium ${heatClass(value, minCell, maxCell)}`}>{value}</td>
                 })}
                 <td className="px-3 py-3 text-right font-semibold text-gray-800">{team.total_games}</td>
                 <td className="px-3 py-3 text-right text-gray-700">{team.b2b_count}</td>
@@ -92,7 +145,10 @@ export default function Schedule() {
           </tbody>
         </table>
       </div>
-      <p className="mt-3 text-xs text-gray-500">High-volume means {data.high_volume_threshold}+ NBA games league-wide on that date. This page reports schedule shape; it does not prescribe roster moves.</p>
+      <p className="mt-3 text-xs text-gray-500">
+        {grain === 'weeks' && 'Weeks start Monday. '}
+        High-volume means {data.high_volume_threshold}+ NBA games league-wide on that date. This page reports schedule shape; it does not prescribe roster moves.
+      </p>
     </div>
   )
 }

--- a/frontend/src/utils/slateWindow.ts
+++ b/frontend/src/utils/slateWindow.ts
@@ -1,0 +1,149 @@
+import type { ScheduleCalendarDay, ScheduleResponse } from '../types/api'
+
+export const HIGH_VOLUME_GAMES = 10
+
+export interface SlateMatchup {
+  away: string
+  home: string
+}
+
+export interface SlateDay {
+  date: string
+  slateSize: number
+  highVolume: boolean
+  matchups: SlateMatchup[]
+}
+
+export interface SlateTeamRow {
+  abbreviation: string
+  teamName: string
+  plays: boolean[]
+  games: number
+  b2b: number
+  nextIndex: number
+  delta: number
+}
+
+export interface SlateWindow {
+  days: SlateDay[]
+  rows: SlateTeamRow[]
+  modalGames: number
+  minGames: number
+  maxGames: number
+  ordinaryTeams: number
+  totalGames: number
+  highVolumeNights: number
+  darkNights: number
+}
+
+export function firstScheduleDay(days: ScheduleCalendarDay[]): string {
+  const today = new Date().toISOString().slice(0, 10)
+  return days.find(day => day.date >= today)?.date ?? days[0]?.date ?? ''
+}
+
+export function formatSlateDate(date: string, options: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('en-US', options).format(new Date(`${date}T12:00:00`))
+}
+
+export function addDays(date: string, amount: number): string {
+  const next = new Date(`${date}T12:00:00`)
+  next.setDate(next.getDate() + amount)
+  return next.toISOString().slice(0, 10)
+}
+
+/** Monday-start week key, matching how fantasy weeks are usually drawn. */
+export function weekStart(date: string): string {
+  const value = new Date(`${date}T12:00:00`)
+  const mondayOffset = (value.getDay() + 6) % 7
+  value.setDate(value.getDate() - mondayOffset)
+  return value.toISOString().slice(0, 10)
+}
+
+export function matchupsByDate(schedule: ScheduleResponse): Map<string, SlateMatchup[]> {
+  const byDate = new Map<string, SlateMatchup[]>()
+  const seen = new Set<string>()
+  for (const team of schedule.teams) {
+    for (const game of team.games) {
+      if (seen.has(game.game_id)) continue
+      seen.add(game.game_id)
+      const matchup: SlateMatchup = game.is_home
+        ? { away: game.opponent_abbreviation, home: team.abbreviation }
+        : { away: team.abbreviation, home: game.opponent_abbreviation }
+      const existing = byDate.get(game.date)
+      if (existing) existing.push(matchup)
+      else byDate.set(game.date, [matchup])
+    }
+  }
+  for (const matchups of byDate.values()) {
+    matchups.sort((a, b) => a.away.localeCompare(b.away))
+  }
+  return byDate
+}
+
+export function buildSlateWindow(
+  schedule: ScheduleResponse,
+  startDate: string,
+  endDate: string,
+  matchups: Map<string, SlateMatchup[]>
+): SlateWindow {
+  const days: SlateDay[] = schedule.calendar_days
+    .filter(day => day.date >= startDate && day.date <= endDate)
+    .map(day => ({
+      date: day.date,
+      slateSize: day.slate_size,
+      highVolume: day.high_volume,
+      matchups: matchups.get(day.date) ?? [],
+    }))
+
+  const dayIndex = new Map(days.map((day, index) => [day.date, index]))
+  const rows: SlateTeamRow[] = schedule.teams.map(team => {
+    const plays = new Array<boolean>(days.length).fill(false)
+    for (const game of team.games) {
+      const index = dayIndex.get(game.date)
+      if (index !== undefined) plays[index] = true
+    }
+    let games = 0
+    let b2b = 0
+    let nextIndex = -1
+    plays.forEach((playing, index) => {
+      if (!playing) return
+      games += 1
+      if (index > 0 && plays[index - 1]) b2b += 1
+      if (nextIndex === -1) nextIndex = index
+    })
+    return {
+      abbreviation: team.abbreviation,
+      teamName: team.team_name,
+      plays,
+      games,
+      b2b,
+      nextIndex,
+      delta: 0,
+    }
+  })
+
+  const counts = new Map<number, number>()
+  for (const row of rows) counts.set(row.games, (counts.get(row.games) ?? 0) + 1)
+  let modalGames = 0
+  let ordinaryTeams = 0
+  for (const [value, count] of counts) {
+    if (count > ordinaryTeams || (count === ordinaryTeams && value > modalGames)) {
+      modalGames = value
+      ordinaryTeams = count
+    }
+  }
+  for (const row of rows) row.delta = row.games - modalGames
+
+  const gameCounts = rows.map(row => row.games)
+  return {
+    days,
+    rows,
+    modalGames,
+    ordinaryTeams,
+    minGames: gameCounts.length ? Math.min(...gameCounts) : 0,
+    maxGames: gameCounts.length ? Math.max(...gameCounts) : 0,
+    totalGames: days.reduce((sum, day) => sum + day.slateSize, 0),
+    highVolumeNights: days.filter(day => day.slateSize >= HIGH_VOLUME_GAMES).length,
+    darkNights: days.filter(day => day.slateSize === 0).length,
+  }
+}

--- a/frontend/src/utils/slateWindow.ts
+++ b/frontend/src/utils/slateWindow.ts
@@ -36,8 +36,15 @@ export interface SlateWindow {
   darkNights: number
 }
 
+/** Today as ESPN dates games: the US Eastern calendar day, not the viewer's.
+ *  toISOString() would give the UTC day, which is already tomorrow between
+ *  7pm and midnight ET — that dropped the in-progress slate from the window. */
+export function easternToday(): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date())
+}
+
 export function firstScheduleDay(days: ScheduleCalendarDay[]): string {
-  const today = new Date().toISOString().slice(0, 10)
+  const today = easternToday()
   return days.find(day => day.date >= today)?.date ?? days[0]?.date ?? ''
 }
 


### PR DESCRIPTION
Adds a card above the season grid answering three questions the app could not: how many NBA games land on each upcoming night, who plays on a given night, and which teams have the most games coming. Also gives the existing season grid a months/weeks toggle.

Built against an approved mockup (`slate_calendar_v4.html`, repo root) after four design rounds.

## No backend changes

Every number comes from the one already-cached `/api/nba/schedule` payload. `calendar_days[]` had been shipped since the season-schedule work but was never read by the frontend; the per-team `games[]` in the same response give the dots, counts, back-to-backs and matchups. Changing the window re-slices an array in memory — no extra request.

## What's in it

- **SlateCalendar** — night strip with a 10-game threshold rule, presets plus a free end date, and a matchup row for the selected night.
- **TeamNightGrid** — 30 teams x one dot per night, sortable, with games / delta / back-to-backs / next game pinned left so they stay readable while nights scroll.
- **TeamTraceButton** — shared control, so picking a team looks and behaves identically in the matchup row and the grid.
- **Season grid months/weeks toggle** — weeks start Monday. Exposes gaps the month view hides, such as the near-empty NBA Cup knockout week (Dec 7-11 are five straight zero-game days).
- **Cap bar tooltip fix** — segments carried both a native `title=` and a styled tooltip with the same text, so both painted on hover. Swapped for `aria-label`.

## Deliberate calls

- **Delta is whole games**, never decimals, measured against the count most teams have. Over 14 days 26 of 30 teams are identical; tenths implied a precision that is not there. It is a tails signal and the copy says so.
- **One rendering at every window length.** An earlier version thinned bars past 21 days and swapped dots for weekly counts past 35. Both removed — a 14-day and a rest-of-season view should be the same chart at two lengths, and the grid already had the sticky anchor column that makes scrolling fine.
- **Window mode is explicit state**, not inferred from the end date. Presets disable the date input and show what they compute; "Pick an end date" enables it starting at the last scheduled day.
- **Dates are US Eastern game dates**, matching how ESPN scores. Fixed a bug where "today" was computed in UTC, which between 7pm and midnight ET dropped the in-progress slate from the window.

## Verification

Manual, against live 2026-27 data, both themes and both viewports:

- Window clamps to season start while in the offseason
- All 25 week columns confirmed to be Mondays in the data, not by eye
- Trace, sort, presets, date typing and clamping, All-Star break rendering
- Mobile 375px: `documentElement.scrollWidth === 375` at rest-of-season with 174 night columns in a 2428px table scrolling inside its own container — the page body never scrolls horizontally
- Three dark-mode defects found and fixed: `bg-gray-200` and `bg-blue-900` are not shades `index.css` remaps, so off-dots rendered white and high-volume bars read as *less* prominent than normal nights
- `tsc --noEmit` clean. Lint reports 14 problems, the identical count on clean `dev` — all pre-existing in `minigames/`, none in these files

No automated tests added; this is presentational and derives from an already-tested payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)