### PR TITLE
feat(teams): rebuild Slot Usage as a row-per-slot table

### DIFF
--- a/frontend/src/components/SlotUsageTable.tsx
+++ b/frontend/src/components/SlotUsageTable.tsx
@@ -1,13 +1,13 @@
 import type { SlotUsage } from '../types/api'
 import {
   SLOT_NAMES,
-  SLOT_MULTIPLICITY,
   SLOT_CAPS,
   formatCap,
-  formatRateDelta,
   formatSlotNumber,
   projectSlot,
+  slotStatus,
   type PaceContext,
+  type SlotName,
 } from '../utils/slotProjection'
 
 interface SlotUsageTableProps {
@@ -16,190 +16,142 @@ interface SlotUsageTableProps {
   gameDaysLeft?: number | null
 }
 
-interface Segment {
-  key: 'played' | 'onTrack' | 'possible' | 'gone'
-  value: number
-  className: string
+type GapTone = 'neutral' | 'short' | 'lost'
+
+const TRACK_TONE: Record<GapTone, string> = {
+  neutral: 'bg-slate-100 dark:bg-slate-700',
+  short: 'bg-orange-100 dark:bg-orange-950',
+  lost: 'bg-rose-100 dark:bg-rose-950',
 }
 
-const SEGMENT_STYLES = {
-  played: 'bg-blue-700',
-  onTrack: 'bg-blue-300',
-  possible: 'bg-slate-200',
-  gone: 'bg-red-500',
-} as const
-
-function segmentTooltip(segment: Segment, values: { played: number; estimated: number; max: number; cap: number; gameDaysLeft: number | null }) {
-  if (segment.key === 'played') return `Played ${formatSlotNumber(values.played)} of ${formatSlotNumber(values.cap)}`
-  if (segment.key === 'onTrack') return `On track to add ${formatSlotNumber(segment.value)} → est ${formatSlotNumber(values.estimated)}`
-  if (segment.key === 'possible') return `Still possible +${formatSlotNumber(segment.value)} → max reachable ${formatSlotNumber(values.max)}`
-  const days = values.gameDaysLeft === null ? 'the remaining game days' : `${values.gameDaysLeft} game days remain`
-  return `Gone — ${formatSlotNumber(segment.value)}. Only ${days}, so the cap can no longer be reached.`
+const NOTE_TONE: Record<GapTone, string> = {
+  neutral: 'text-orange-700 dark:text-orange-300',
+  short: 'text-orange-700 dark:text-orange-300',
+  lost: 'text-rose-600 dark:text-rose-400',
 }
 
-function Legend({ className, label }: { className: string; label: string }) {
+const VALUE_TONE: Record<GapTone, string> = {
+  neutral: 'text-gray-900 dark:text-gray-50',
+  short: 'text-gray-900 dark:text-gray-50',
+  lost: 'text-rose-600 dark:text-rose-400',
+}
+
+interface ValueCellProps {
+  value: number | null
+  cap: number
+  tone: GapTone
+  note: string | null
+}
+
+/**
+ * The track is the cap and the fill is the value, so the empty part of the track is
+ * the gap — tinted by what kind of gap it is. The number sits at the end of the track
+ * rather than beside it, which is what keeps the two reading as one object.
+ */
+function ValueCell({ value, cap, tone, note }: ValueCellProps) {
+  const width = value === null ? 0 : Math.max(0, Math.min(100, (value / cap) * 100))
   return (
-    <span className="inline-flex items-center gap-1 text-[11px] text-gray-500">
-      <span className={`h-2.5 w-2.5 rounded-sm ${className}`} />
+    <td className="relative px-1.5 py-1.5 text-right align-middle sm:px-2 sm:py-2">
+      <span className={`absolute inset-y-1 left-1 right-1 overflow-hidden rounded ${TRACK_TONE[tone]}`}>
+        <span className="absolute inset-y-0 left-0 rounded-l bg-blue-200 dark:bg-blue-800" style={{ width: `${width}%` }} />
+      </span>
+      <span className={`relative block text-[13px] font-extrabold tabular-nums sm:text-[14.5px] ${VALUE_TONE[tone]}`}>
+        {formatSlotNumber(value)}
+      </span>
+      <span className={`relative block text-[9px] font-semibold leading-tight sm:text-[9.5px] ${note ? NOTE_TONE[tone] : 'text-transparent'}`}>
+        {note ?? ' '}
+      </span>
+    </td>
+  )
+}
+
+function HeadCell({ label, gloss }: { label: string; gloss: string }) {
+  return (
+    <th scope="col" className="px-1.5 pb-1.5 text-right text-[9.5px] font-bold uppercase tracking-wider text-gray-400 sm:px-2 dark:text-gray-500">
       {label}
-    </span>
+      <span className="block text-[9px] font-semibold normal-case tracking-normal text-gray-400 dark:text-gray-500">
+        {gloss}
+      </span>
+    </th>
   )
-}
-
-function ValueChip({ label, value, dotClass, className = 'bg-gray-100 text-gray-600' }: {
-  label: string
-  value: string | number
-  dotClass?: string
-  className?: string
-}) {
-  return (
-    <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold ${className}`}>
-      {dotClass && <span className={`h-2 w-2 rounded-sm ${dotClass}`} />}
-      <span>{label}</span>
-      <b className="tabular-nums">{value}</b>
-    </span>
-  )
-}
-
-function formatVsPace(used: number, avgPace: number | null | undefined): string {
-  if (typeof avgPace !== 'number' || !Number.isFinite(avgPace) || avgPace <= 0) {
-    return used === 0 ? '— 0' : '—'
-  }
-  const delta = formatRateDelta(used, avgPace)
-  return delta === 'on pace' ? '0.0' : delta
 }
 
 export default function SlotUsageTable({ slotUsage, avgPace, gameDaysLeft }: SlotUsageTableProps) {
   const pace: PaceContext = { avgPace, gameDaysLeft }
-  const columns = SLOT_NAMES.map(slot => {
+  const rows = SLOT_NAMES.map(slot => {
     const usage = slotUsage[slot]
-    return { slot, projection: usage ? projectSlot(usage.games_used, slot, pace) : null }
+    const projection = usage ? projectSlot(usage.games_used, slot, pace) : null
+    return { slot, projection, status: projection ? slotStatus(projection, slot, pace) : null }
   })
   const numericPace = typeof avgPace === 'number' && avgPace > 0 ? avgPace : null
-  const pacePercent = numericPace === null ? null : Math.min(100, (numericPace / 82) * 100)
 
   return (
-    <div className="bg-white rounded-lg shadow p-4 sm:p-6">
-      <div className="flex flex-col gap-3 border-b border-gray-100 pb-4 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="text-xl sm:text-2xl font-bold text-gray-900">Slot pace</h2>
-          <p className="mt-1 max-w-2xl text-xs text-gray-500">
-            A report of games already used, the NBA-pace projection, and the remaining ceiling. The cap is a limit, not a target.
-          </p>
-        </div>
-        <div className="text-xs text-gray-500 sm:text-right">
-          NBA pace{' '}
-          {numericPace === null ? (
-            <span className="font-semibold text-gray-600">not available yet</span>
-          ) : (
+    <div className="rounded-lg bg-white p-4 shadow sm:p-6 dark:bg-gray-800">
+      <div className="flex flex-col gap-1 pb-3 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
+        <h2 className="text-lg font-bold text-gray-900 sm:text-xl dark:text-gray-50">Slot usage</h2>
+        <p className="text-[11.5px] tabular-nums text-gray-400 dark:text-gray-500">
+          {typeof gameDaysLeft === 'number' && (
             <>
-              <span className="font-semibold text-gray-700">{numericPace.toFixed(1)}</span> GP/team
+              <span className="font-bold text-gray-600 dark:text-gray-300">{gameDaysLeft}</span> game days left
             </>
           )}
-          {typeof gameDaysLeft === 'number' && <span> · {gameDaysLeft} days left</span>}
-        </div>
+          {typeof gameDaysLeft === 'number' && numericPace !== null && ' · '}
+          {numericPace !== null && (
+            <>
+              NBA pace <span className="font-bold text-gray-600 dark:text-gray-300">{numericPace.toFixed(1)}</span>
+            </>
+          )}
+        </p>
       </div>
 
-      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
-        <Legend className="bg-blue-700" label="Played" />
-        <Legend className="bg-blue-300" label="On track to add" />
-        <Legend className="bg-gray-200" label="Still possible" />
-        <Legend className="bg-red-500" label="Gone" />
-        {pacePercent !== null && (
-          <span className="inline-flex items-center gap-1 text-[11px] text-gray-500">
-            <span className="h-3 w-0.5 bg-blue-900" /> NBA pace marker
-          </span>
-        )}
-      </div>
-
-      <div className="mt-5 space-y-4">
-        <div className="hidden items-center gap-3 sm:flex">
-          <div className="w-16 shrink-0" />
-          <div className="relative h-4 flex-1">
-            {pacePercent !== null && (
-              <span
-                className="absolute -top-2 whitespace-nowrap rounded bg-slate-900 px-1.5 py-0.5 text-[10px] font-extrabold tracking-wide text-white shadow-sm"
-                style={{ left: `${pacePercent}%`, transform: pacePercent > 88 ? 'translateX(-100%)' : 'translateX(-50%)' }}
-              >
-                NBA pace {numericPace?.toFixed(1)}
-              </span>
-            )}
-          </div>
-          <div className="w-16 shrink-0" />
-        </div>
-
-        {columns.map(({ slot, projection }) => {
-          if (!projection) return null
-          const cap = SLOT_CAPS[slot]
-          const played = Math.min(projection.usedTotal, cap)
-          const estimated = projection.estimatedRounded ?? played
-          const max = projection.maxGamesTotal ?? (typeof gameDaysLeft === 'number'
-            ? Math.min(played + gameDaysLeft * SLOT_MULTIPLICITY[slot], cap)
-            : cap)
-          const onTrack = Math.max(0, estimated - played)
-          const possible = Math.max(0, max - Math.max(played, estimated))
-          const gone = Math.max(0, cap - max)
-          const segments: Segment[] = [
-            { key: 'played', value: played, className: SEGMENT_STYLES.played },
-            { key: 'onTrack', value: onTrack, className: SEGMENT_STYLES.onTrack },
-            { key: 'possible', value: possible, className: SEGMENT_STYLES.possible },
-            { key: 'gone', value: gone, className: SEGMENT_STYLES.gone },
-          ]
-          const visibleSegments = segments.filter(segment => segment.value > 0)
-          const values = { played, estimated, max, cap, gameDaysLeft: typeof gameDaysLeft === 'number' ? gameDaysLeft : null }
-          const paceMarkerPercent = pacePercent === null
-            ? null
-            : Math.min(100, (numericPace! * SLOT_MULTIPLICITY[slot] / cap) * 100)
-          const paceTooltip = numericPace === null
-            ? `NBA pace is not available yet${projection.used === 0 ? ' · 0 games used.' : '.'}`
-            : slot === 'UTIL'
-              ? `${numericPace.toFixed(1)} × 3 = ${(numericPace * SLOT_MULTIPLICITY[slot]).toFixed(1)} · ${projection.usedTotal >= numericPace * 3 ? 'ahead' : 'behind'} by ${Math.abs(projection.usedTotal - numericPace * 3).toFixed(1)}.`
-              : `NBA pace ${numericPace.toFixed(1)} · ${projection.used >= numericPace ? 'ahead' : 'behind'} by ${Math.abs(projection.used - numericPace).toFixed(1)}.`
-          const paceChip = formatVsPace(projection.used, avgPace)
-          return (
-            <div key={slot} className="grid grid-cols-1 gap-1 sm:grid-cols-[4rem_minmax(0,1fr)_4rem] sm:items-center sm:gap-3">
-              <div className="flex items-center justify-between sm:block">
-                <div className="text-xs font-bold uppercase tracking-wide text-gray-700">{slot}</div>
-                {slot === 'UTIL' && <div className="text-[10px] text-gray-400">× 3 slots</div>}
-              </div>
-              <div className="relative">
-                <div className="relative flex h-[18px] overflow-visible rounded-full border border-slate-600 bg-gray-50">
-                  {visibleSegments.map((segment, index) => (
-                    <span
-                      key={segment.key}
-                      aria-label={segmentTooltip(segment, values)}
-                      className={`group relative h-full min-w-[2px] ${segment.className} ${index === 0 ? 'rounded-l-full' : ''} ${index === visibleSegments.length - 1 ? 'rounded-r-full' : ''}`}
-                      style={{ width: `${(segment.value / cap) * 100}%` }}
-                    >
-                      <span className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden w-max max-w-[16rem] -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-[10px] font-normal text-white shadow-lg group-hover:block group-focus:block">
-                        {segmentTooltip(segment, values)}
-                      </span>
-                    </span>
-                  ))}
-                  {paceMarkerPercent !== null && (
-                    <span
-                      aria-label={`NBA pace ${numericPace?.toFixed(1)}`}
-                      title={paceTooltip}
-                      className="pointer-events-auto absolute bottom-[-6px] top-[-6px] z-20 w-0.5 -translate-x-px rounded-sm bg-slate-900 shadow-[0_0_0_1.5px_white] after:absolute after:-left-[3px] after:-top-1 after:h-[7px] after:w-[7px] after:rounded-full after:bg-slate-900 after:shadow-[0_0_0_1.5px_white]"
-                      style={{ left: `${paceMarkerPercent}%` }}
-                    />
-                  )}
-                </div>
-              </div>
-              <div className="hidden text-right text-xs text-gray-500 sm:block">cap {formatCap(slot)}</div>
-              <div className="flex flex-wrap gap-1.5 py-0.5 sm:col-start-2">
-                <ValueChip label="played" value={formatSlotNumber(played)} dotClass="bg-blue-700" className="bg-blue-50 text-blue-800" />
-                <ValueChip label="estimated" value={formatSlotNumber(estimated)} dotClass="bg-blue-300" className="bg-blue-100 text-blue-800" />
-                <ValueChip label="max reachable" value={formatSlotNumber(max)} dotClass="bg-slate-300" className="bg-slate-100 text-slate-700" />
-                {gone > 0 && <ValueChip label="gone" value={formatSlotNumber(gone)} dotClass="bg-red-700" className="bg-red-500 text-white" />}
-                <span className={`inline-flex items-center rounded bg-slate-900 px-1.5 py-0.5 text-[10px] font-bold text-white ${numericPace === null ? 'opacity-75' : ''}`}>
-                  vs pace <b className="ml-1 tabular-nums">{paceChip}</b>
-                </span>
-              </div>
-            </div>
-          )
-        })}
-      </div>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="border-b border-gray-200 dark:border-gray-600">
+            <th scope="col" className="pb-1.5 text-left text-[9.5px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+              Slot
+            </th>
+            <HeadCell label="Used" gloss="games played" />
+            <HeadCell label="Projected" gloss="season finish" />
+            <HeadCell label="Max" gloss="most still possible" />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(({ slot, projection, status }) => {
+            const cap = SLOT_CAPS[slot as SlotName]
+            const lost = status?.lost ?? null
+            const short = status?.short ?? null
+            const behind = status?.behindPace ?? null
+            return (
+              <tr key={slot} className="border-b border-gray-100 last:border-0 dark:border-gray-700/70">
+                <th scope="row" className="py-1.5 pr-1 text-left align-middle sm:py-2">
+                  <span className="block text-[12.5px] font-extrabold tracking-wide text-gray-600 dark:text-gray-300">{slot}</span>
+                  <span className="block text-[9.5px] font-semibold tabular-nums text-gray-400 dark:text-gray-500">
+                    /{formatCap(slot)}
+                  </span>
+                </th>
+                <ValueCell
+                  value={projection?.usedTotal ?? null}
+                  cap={cap}
+                  tone="neutral"
+                  note={behind === null ? null : `${formatSlotNumber(behind)} behind pace`}
+                />
+                <ValueCell
+                  value={projection?.estimatedRounded ?? null}
+                  cap={cap}
+                  tone={short === null ? 'neutral' : 'short'}
+                  note={short === null ? null : `${formatSlotNumber(short)} short`}
+                />
+                <ValueCell
+                  value={projection?.maxGamesTotal ?? null}
+                  cap={cap}
+                  tone={lost === null ? 'neutral' : 'lost'}
+                  note={lost === null ? null : `${formatSlotNumber(lost)} lost`}
+                />
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
     </div>
   )
 }

--- a/frontend/src/utils/__tests__/slotProjection.test.ts
+++ b/frontend/src/utils/__tests__/slotProjection.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   projectSlot,
-  rateTone,
-  formatRateDelta,
-  maxTone,
-  estimatedTone,
+  slotStatus,
   canColor,
   formatCap,
   formatSlotNumber,
@@ -99,18 +96,6 @@ describe('projectSlot', () => {
     expect(estimatedRounded).toBe(81)
   })
 
-  it('grades the rounded estimate, so 81.7 counts as a full season', () => {
-    const ctx = { avgPace: 41.3, gameDaysLeft: 82 }
-    const { estimatedRounded } = projectSlot(41, 'PG', ctx)
-    expect(estimatedTone(estimatedRounded, 'PG', ctx)).toBe('green')
-  })
-
-  it('still grades 81.1 as short of a full season', () => {
-    const ctx = { avgPace: 60.4, gameDaysLeft: 44 }
-    const { estimatedRounded } = projectSlot(58, 'PG', ctx)
-    expect(estimatedTone(estimatedRounded, 'PG', ctx)).toBe('yellow')
-  })
-
   it('projects UTIL as a whole column, capped at 248', () => {
     const { estimated, estimatedPerSlot } = projectSlot(248, 'UTIL', { avgPace: 80, gameDaysLeft: 20 })
     expect(estimated).toBeCloseTo(248, 6)
@@ -131,11 +116,12 @@ describe('projectSlot', () => {
     expect(estimated).toBeCloseTo(expected, 6)
   })
 
-  it('returns nulls when pace is unavailable', () => {
+  it('returns nulls when pace is unavailable, but still knows the ceiling', () => {
     const p = projectSlot(40, 'PG', { avgPace: null, gameDaysLeft: 40 })
     expect(p.rate).toBeNull()
-    expect(p.maxGames).toBeNull()
     expect(p.estimated).toBeNull()
+    expect(p.maxGames).toBe(80)
+    expect(p.maxGamesTotal).toBe(80)
   })
 
   it('returns nulls when pace is zero', () => {
@@ -144,9 +130,58 @@ describe('projectSlot', () => {
   })
 
   it('falls back to pace extrapolation when game days are unknown', () => {
-    const { estimated, maxGames } = projectSlot(40, 'PG', { avgPace: 41, gameDaysLeft: null })
-    expect(maxGames).toBeNull()
+    const { estimated } = projectSlot(40, 'PG', { avgPace: 41, gameDaysLeft: null })
     expect(estimated).toBeCloseTo(80, 6)
+  })
+
+  it('treats the whole cap as reachable while the remaining game days are unknown', () => {
+    const p = projectSlot(40, 'PG', { avgPace: 41, gameDaysLeft: null })
+    expect(p.maxGames).toBe(82)
+    expect(p.maxGamesTotal).toBe(82)
+    expect(projectSlot(120, 'UTIL', { avgPace: 41, gameDaysLeft: null }).maxGamesTotal).toBe(248)
+  })
+})
+
+describe('slotStatus', () => {
+  const status = (used: number, slot: Parameters<typeof projectSlot>[1], ctx: typeof midSeason) =>
+    slotStatus(projectSlot(used, slot, ctx), slot, ctx)
+
+  it('says nothing at all for a slot on pace with a full season reachable', () => {
+    const ctx = { avgPace: 60, gameDaysLeft: 22 }
+    expect(status(60, 'PG', ctx)).toEqual({ behindPace: null, short: null, lost: null })
+  })
+
+  it('reports games behind pace once the gap reaches 3', () => {
+    const ctx = { avgPace: 60, gameDaysLeft: 22 }
+    expect(status(58, 'PG', ctx).behindPace).toBeNull()
+    expect(status(57, 'PG', ctx).behindPace).toBe(3)
+    expect(status(48, 'PG', ctx).behindPace).toBe(12)
+  })
+
+  it('never reports being ahead of pace', () => {
+    expect(status(70, 'PG', { avgPace: 60, gameDaysLeft: 22 }).behindPace).toBeNull()
+  })
+
+  it('measures behindPace per slot, so UTIL is comparable with the rest', () => {
+    const ctx = { avgPace: 60, gameDaysLeft: 22 }
+    expect(status(175, 'UTIL', ctx).behindPace).toBeNull()
+    expect(status(150, 'UTIL', ctx).behindPace).toBe(10)
+  })
+
+  it('counts lost games against the whole column cap', () => {
+    const ctx = { avgPace: 60, gameDaysLeft: 12 }
+    expect(status(48, 'PG', ctx).lost).toBe(22)
+    expect(status(82, 'PG', ctx).lost).toBeNull()
+  })
+
+  it('rounds the projection before calling it short, so 81.7 is a full season', () => {
+    expect(status(41, 'PG', { avgPace: 41.3, gameDaysLeft: 82 }).short).toBeNull()
+    expect(status(58, 'PG', { avgPace: 60.4, gameDaysLeft: 44 }).short).toBe(1)
+  })
+
+  it('stays silent while the season is too young to judge', () => {
+    expect(status(2, 'PG', { avgPace: 6, gameDaysLeft: 140 }))
+      .toEqual({ behindPace: null, short: null, lost: null })
   })
 })
 
@@ -165,122 +200,13 @@ describe('canColor', () => {
   })
 })
 
-describe('rateTone', () => {
-  it('is green inside the 5% band, either way', () => {
-    expect(rateTone(1.02, midSeason)).toBe('green')
-    expect(rateTone(0.98, midSeason)).toBe('green')
-  })
-
-  it('grades a slot burning games too fast by how far off it is', () => {
-    expect(rateTone(1.06, midSeason)).toBe('yellow')
-    expect(rateTone(1.12, midSeason)).toBe('orange')
-    expect(rateTone(1.2, midSeason)).toBe('red')
-  })
-
-  it('grades a slot falling behind the same way', () => {
-    expect(rateTone(0.94, midSeason)).toBe('yellow')
-    expect(rateTone(0.88, midSeason)).toBe('orange')
-    expect(rateTone(0.8, midSeason)).toBe('red')
-  })
-
-  it('stays neutral early in the season', () => {
-    expect(rateTone(1.5, { avgPace: 6, gameDaysLeft: 140 })).toBe('neutral')
-    expect(rateTone(0.2, { avgPace: 6, gameDaysLeft: 140 })).toBe('neutral')
-  })
-})
-
-describe('formatRateDelta', () => {
-  it('counts the games behind the NBA rate', () => {
-    expect(formatRateDelta(69, 69.3)).toBe('−0.3')
-  })
-
-  it('counts the games ahead of it', () => {
-    expect(formatRateDelta(74, 69.6)).toBe('+4.4')
-  })
-
-  it('says so when the slot sits on the rate', () => {
-    expect(formatRateDelta(69.3, 69.3)).toBe('on pace')
-  })
-
-  it('renders a dash without a rate', () => {
-    expect(formatRateDelta(40, null)).toBe('-')
-  })
-
-  it('leaves the colour to rateTone, which still grades in percent', () => {
-    // 69 against 69.3 is only 0.4% off, so it stays green despite the visible −0.3.
-    expect(rateTone(69 / 69.3, { avgPace: 69.3, gameDaysLeft: 25 })).toBe('green')
-  })
-})
-
-describe('maxTone', () => {
-  it('is green while the full column is still reachable', () => {
-    expect(maxTone(82, 'PG', midSeason)).toBe('green')
-  })
-
-  it('is red once the column can no longer be filled', () => {
-    expect(maxTone(81.5, 'PG', midSeason)).toBe('red')
-  })
-
-  it('judges UTIL against 248, not 82', () => {
-    expect(maxTone(248, 'UTIL', midSeason)).toBe('green')
-    expect(maxTone(247, 'UTIL', midSeason)).toBe('red')
-    expect(maxTone(90, 'UTIL', midSeason)).toBe('red')
-  })
-
-  it('only ever returns green or red', () => {
-    for (const value of [0, 40, 82, 200]) {
-      expect(['green', 'red']).toContain(maxTone(value, 'PG', midSeason))
-    }
-  })
-
-  it('stays neutral early in the season', () => {
-    expect(maxTone(40, 'PG', { avgPace: 6, gameDaysLeft: 140 })).toBe('neutral')
-  })
-})
-
-describe('estimatedTone', () => {
-  it('is green at 82 and above', () => {
-    expect(estimatedTone(82, 'PG', midSeason)).toBe('green')
-    expect(estimatedTone(82.6, 'PG', midSeason)).toBe('green')
-  })
-
-  it('is yellow between 80 and 82', () => {
-    expect(estimatedTone(81.9, 'PG', midSeason)).toBe('yellow')
-    expect(estimatedTone(80, 'PG', midSeason)).toBe('yellow')
-  })
-
-  it('is orange between 78 and 80', () => {
-    expect(estimatedTone(79.9, 'PG', midSeason)).toBe('orange')
-    expect(estimatedTone(78, 'PG', midSeason)).toBe('orange')
-  })
-
-  it('is red under 78', () => {
-    expect(estimatedTone(77.9, 'PG', midSeason)).toBe('red')
-  })
-
-  it('scales every band by three for UTIL', () => {
-    expect(estimatedTone(246, 'UTIL', midSeason)).toBe('green')
-    expect(estimatedTone(245, 'UTIL', midSeason)).toBe('yellow')
-    expect(estimatedTone(239, 'UTIL', midSeason)).toBe('orange')
-    expect(estimatedTone(233, 'UTIL', midSeason)).toBe('red')
-  })
-
-  it('does not read a full UTIL column as a failing single slot', () => {
-    expect(estimatedTone(248, 'UTIL', midSeason)).toBe('green')
-  })
-
-  it('stays neutral early in the season', () => {
-    expect(estimatedTone(20, 'PG', { avgPace: 6, gameDaysLeft: 140 })).toBe('neutral')
-  })
-})
-
 describe('formatCap', () => {
   it('is a plain 82 for single slots', () => {
     expect(formatCap('PG')).toBe('82')
   })
 
-  it('splits the UTIL cap so the two spare ESPN games stay visible', () => {
-    expect(formatCap('UTIL')).toBe('(246+2)')
+  it('keeps the two spare ESPN games visible on the UTIL cap', () => {
+    expect(formatCap('UTIL')).toBe('246+2')
   })
 })
 

--- a/frontend/src/utils/slotProjection.ts
+++ b/frontend/src/utils/slotProjection.ts
@@ -17,6 +17,9 @@ export const SLOT_MULTIPLICITY: Record<SlotName, number> = {
   PG: 1, SG: 1, SF: 1, PF: 1, C: 1, G: 1, F: 1, UTIL: 3,
 }
 
+/** A single slot can be filled on at most 82 NBA game days. */
+export const GAMES_PER_SLOT = 82
+
 /**
  * Season allowance per column. UTIL is three slots plus two spare games (3 * 82 + 2):
  * an ESPN quirk lets you leave one UTIL open on the last game week and still play all
@@ -26,9 +29,6 @@ export const SLOT_CAPS: Record<SlotName, number> = {
   PG: 82, SG: 82, SF: 82, PF: 82, C: 82, G: 82, F: 82, UTIL: 248,
 }
 
-/** A single slot can be filled on at most 82 NBA game days. */
-export const GAMES_PER_SLOT = 82
-
 /** The cap a single slot of this column may reach — 82 everywhere, 82.67 for UTIL. */
 export function slotCeiling(slot: SlotName): number {
   return SLOT_CAPS[slot] / SLOT_MULTIPLICITY[slot]
@@ -37,20 +37,8 @@ export function slotCeiling(slot: SlotName): number {
 /** Below this NBA pace the season is too young for any of these signals to mean anything. */
 export const MIN_PACE_FOR_COLOR = 10
 
-/**
- * Estimate bands, per slot: at 82 you finish the season, under 78 you have lost real games.
- * Scaled by the column's slot count before comparing, so UTIL is judged against 3 × these.
- */
-export const EST_GREEN = 82
-export const EST_YELLOW = 80
-export const EST_ORANGE = 78
-
-/** Rate bands, as absolute drift away from 1.0 — in either direction. */
-export const RATE_GREEN = 0.05
-export const RATE_YELLOW = 0.1
-export const RATE_ORANGE = 0.15
-
-export type SlotTone = 'neutral' | 'green' | 'yellow' | 'orange' | 'red'
+/** Below this the slot is close enough to the NBA rate that saying so is noise. */
+export const BEHIND_PACE_GAMES = 3
 
 export interface SlotProjection {
   /** Games used, normalised to a single slot (UTIL divided by 3). */
@@ -98,13 +86,21 @@ export function projectSlot(
   const used = gamesUsed / multiplicity
   const ceiling = slotCeiling(slot)
 
+  // The ceiling needs no pace: it is games already banked plus one per remaining game day.
+  // With the remaining days still unknown, the whole cap is in principle reachable.
+  const daysLeft = typeof gameDaysLeft === 'number' ? gameDaysLeft : null
+  const maxGames = daysLeft === null ? ceiling : Math.min(used + daysLeft, ceiling)
+  // Every remaining game day can fill each slot in the column, so UTIL gains three a day.
+  const maxGamesTotal =
+    daysLeft === null ? cap : Math.min(gamesUsed + daysLeft * multiplicity, cap)
+
   if (typeof avgPace !== 'number' || avgPace <= 0) {
     return {
       used,
       usedTotal: gamesUsed,
       rate: null,
-      maxGames: null,
-      maxGamesTotal: null,
+      maxGames,
+      maxGamesTotal,
       estimated: null,
       estimatedRounded: null,
       estimatedPerSlot: null,
@@ -112,12 +108,6 @@ export function projectSlot(
   }
 
   const rate = used / avgPace
-
-  const daysLeft = typeof gameDaysLeft === 'number' ? gameDaysLeft : null
-  const maxGames = daysLeft === null ? null : Math.min(used + daysLeft, ceiling)
-  // Every remaining game day can fill each slot in the column, so UTIL gains three a day.
-  const maxGamesTotal =
-    daysLeft === null ? null : Math.min(gamesUsed + daysLeft * multiplicity, SLOT_CAPS[slot])
 
   // Worked on the column total against the column cap, exactly as the backend estimator does.
   // Method 1 — extrapolate the current rate over a full 82-game season.
@@ -142,67 +132,52 @@ export function projectSlot(
 }
 
 /**
- * Rate is graded on how far off pace the slot is, in either direction — burning games
- * too fast is as much of a problem as falling behind. The arrow carries the direction.
+ * What the row has to say, if anything. A slot on pace, projecting a full season and
+ * with nothing lost produces three nulls, and the table prints nothing for it — colour
+ * and words only ever appear together, on the exceptions.
+ *
+ * `behindPace` is per slot so UTIL is comparable with the rest; `short` and `lost` are
+ * whole-column counts, because a lost game is a lost game whichever slot it belonged to.
  */
-export function rateTone(rate: number | null, ctx: PaceContext): SlotTone {
-  if (rate === null || !canColor(ctx)) return 'neutral'
-  const drift = Math.abs(rate - 1)
-  if (drift < RATE_GREEN) return 'green'
-  if (drift < RATE_YELLOW) return 'yellow'
-  if (drift < RATE_ORANGE) return 'orange'
-  return 'red'
+export interface SlotStatus {
+  /** Games this slot is behind the NBA rate, per slot. Null when ahead or close enough. */
+  behindPace: number | null
+  /** Games the projection falls short of the column cap. Null when it reaches it. */
+  short: number | null
+  /** Games the column can no longer play, whatever happens now. Null when none. */
+  lost: number | null
+}
+
+export function slotStatus(
+  projection: SlotProjection,
+  slot: SlotName,
+  ctx: PaceContext,
+): SlotStatus {
+  if (!canColor(ctx)) return { behindPace: null, short: null, lost: null }
+
+  const { avgPace } = ctx
+  const cap = SLOT_CAPS[slot]
+  const behind = typeof avgPace === 'number' ? avgPace - projection.used : 0
+  const short = projection.estimatedRounded === null ? 0 : cap - projection.estimatedRounded
+  const lost = projection.maxGamesTotal === null ? 0 : cap - projection.maxGamesTotal
+
+  return {
+    behindPace: behind >= BEHIND_PACE_GAMES ? behind : null,
+    short: short > 0 ? short : null,
+    lost: lost > 0 ? lost : null,
+  }
 }
 
 /**
- * How many games the slot is off the NBA rate, signed: 69 used against a rate of 69.3
- * reads −0.3. The colour still comes from rateTone, which grades the gap in percent.
- */
-export function formatRateDelta(used: number, avgPace: number | null | undefined): string {
-  if (typeof avgPace !== 'number' || !Number.isFinite(avgPace)) return '-'
-  const delta = used - avgPace
-  if (Math.abs(delta) < 0.05) return 'on pace'
-  return `${delta > 0 ? '+' : '−'}${Math.abs(delta).toFixed(1)}`
-}
-
-/**
- * Binary: either the column can still be filled out completely, or it cannot.
- * Compared against the whole column's cap, so UTIL is judged against 248 rather than 82.
- */
-export function maxTone(maxGamesTotal: number | null, slot: SlotName, ctx: PaceContext): SlotTone {
-  if (maxGamesTotal === null || !canColor(ctx)) return 'neutral'
-  return maxGamesTotal < SLOT_CAPS[slot] ? 'red' : 'green'
-}
-
-/** Takes the column total, so UTIL is graded against 3 × each band. */
-export function estimatedTone(estimated: number | null, slot: SlotName, ctx: PaceContext): SlotTone {
-  if (estimated === null || !canColor(ctx)) return 'neutral'
-  const slots = SLOT_MULTIPLICITY[slot]
-  if (estimated >= EST_GREEN * slots) return 'green'
-  if (estimated >= EST_YELLOW * slots) return 'yellow'
-  if (estimated >= EST_ORANGE * slots) return 'orange'
-  return 'red'
-}
-
-export const TONE_CLASS: Record<SlotTone, string> = {
-  neutral: 'bg-gray-100 text-gray-600',
-  green: 'bg-green-100 text-green-800',
-  yellow: 'bg-yellow-100 text-yellow-800',
-  orange: 'bg-orange-100 text-orange-800',
-  red: 'bg-red-100 text-red-800',
-}
-
-
-/**
- * The cap as a denominator. UTIL is written (246+2) rather than 248 so the two spare
- * games stay visible as the oddity they are, instead of hiding inside a round total.
+ * The cap as a denominator. UTIL is written 246+2 rather than 248 so the two spare
+ * games stay visible as the ESPN quirk they are, instead of hiding inside a round total.
  */
 export function formatCap(slot: SlotName): string {
   const slots = SLOT_MULTIPLICITY[slot]
   if (slots === 1) return String(SLOT_CAPS[slot])
   const base = GAMES_PER_SLOT * slots
   const spare = SLOT_CAPS[slot] - base
-  return spare === 0 ? String(base) : `(${base}+${spare})`
+  return spare === 0 ? String(base) : `${base}+${spare}`
 }
 
 /** Trims a trailing `.0` so whole numbers stay readable in a dense table. */


### PR DESCRIPTION
## What

Slot Usage becomes a table: one row per slot, three labelled columns — **Used**, **Projected**, **Max** — and no legend.

The horizontal bars encoded values as lengths, which meant decoding them against a four-colour legend at the top of the card. A table states the value instead.

## How a cell works

The track is the cap, the fill is the value, so **the empty part of the track is the gap** — tinted by what kind of gap it is:

| tint | meaning |
|---|---|
| neutral | games still playable |
| orange | projection falls short of the cap |
| rose | schedule ran out; can never be played |

**Colour never travels alone.** A tinted cell always carries the words explaining it — `12 behind pace`, `18 short`, `14 lost`. A slot that is on pace, projecting a full season and has lost nothing prints nothing, so all remaining text marks a real problem.

## Logic

`slotStatus()` replaces `rateTone` / `maxTone` / `estimatedTone`:

- `behindPace` is **per slot**, so UTIL is comparable with single slots instead of looking three times worse. Reported once the gap reaches 3 games.
- `short` and `lost` stay whole-column counts — a lost game is lost whichever slot it belonged to.
- Below 10 GP/team all three are null and the card stays silent, as the old `canColor` gate did.

`projectSlot` now computes the ceiling without a pace (games banked + one per remaining game day), so **Max** reads `82` / `248` rather than a dash before the season has a pace.

UTIL keeps its 248 cap and reads `246+2`, preserving the ESPN spare-games quirk.

Removed with the old design: `rateTone`, `maxTone`, `estimatedTone`, `TONE_CLASS`, `formatRateDelta`, and the `EST_*` / `RATE_*` bands.

## Mobile

Same layout at both widths; only padding and type size change. Fits 390px with no horizontal scroll — the previous grid used `overflow-x-auto` and hid G and UTIL behind a sideways drag.

## Verification

- `tsc --noEmit` clean (also passed the pre-push hook)
- `eslint` clean on all three files
- `vitest run` — 20 files, 178 passed, 3 skipped
- 8 new `slotStatus` tests: pace threshold, per-slot UTIL, rounding before "short", silence below the colour threshold, ceiling without a pace
- Rendered in the running app at desktop and 390px, light and dark. Fixed a dark-mode bug found there: the translucent fill blended with the rose/orange track and rendered purple; the fill is now opaque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)