### PR TITLE
fix(teams): flag any behind-pace gap, not just 3+ games

### DIFF
--- a/frontend/src/utils/__tests__/slotProjection.test.ts
+++ b/frontend/src/utils/__tests__/slotProjection.test.ts
@@ -151,10 +151,11 @@ describe('slotStatus', () => {
     expect(status(60, 'PG', ctx)).toEqual({ behindPace: null, short: null, lost: null })
   })
 
-  it('reports games behind pace once the gap reaches 3', () => {
+  it('reports any gap that rounds to a whole game behind pace', () => {
     const ctx = { avgPace: 60, gameDaysLeft: 22 }
-    expect(status(58, 'PG', ctx).behindPace).toBeNull()
-    expect(status(57, 'PG', ctx).behindPace).toBe(3)
+    expect(status(60, 'PG', ctx).behindPace).toBeNull()
+    expect(status(59.6, 'PG', ctx).behindPace).toBeNull()
+    expect(status(59, 'PG', ctx).behindPace).toBe(1)
     expect(status(48, 'PG', ctx).behindPace).toBe(12)
   })
 
@@ -164,7 +165,7 @@ describe('slotStatus', () => {
 
   it('measures behindPace per slot, so UTIL is comparable with the rest', () => {
     const ctx = { avgPace: 60, gameDaysLeft: 22 }
-    expect(status(175, 'UTIL', ctx).behindPace).toBeNull()
+    expect(status(180, 'UTIL', ctx).behindPace).toBeNull()
     expect(status(150, 'UTIL', ctx).behindPace).toBe(10)
   })
 

--- a/frontend/src/utils/slotProjection.ts
+++ b/frontend/src/utils/slotProjection.ts
@@ -37,9 +37,6 @@ export function slotCeiling(slot: SlotName): number {
 /** Below this NBA pace the season is too young for any of these signals to mean anything. */
 export const MIN_PACE_FOR_COLOR = 10
 
-/** Below this the slot is close enough to the NBA rate that saying so is noise. */
-export const BEHIND_PACE_GAMES = 3
-
 export interface SlotProjection {
   /** Games used, normalised to a single slot (UTIL divided by 3). */
   used: number
@@ -136,11 +133,12 @@ export function projectSlot(
  * with nothing lost produces three nulls, and the table prints nothing for it — colour
  * and words only ever appear together, on the exceptions.
  *
- * `behindPace` is per slot so UTIL is comparable with the rest; `short` and `lost` are
- * whole-column counts, because a lost game is a lost game whichever slot it belonged to.
+ * `behindPace` is per slot so UTIL is comparable with the rest, and flags any gap once it
+ * rounds to a whole game; `short` and `lost` are whole-column counts, because a lost game
+ * is a lost game whichever slot it belonged to.
  */
 export interface SlotStatus {
-  /** Games this slot is behind the NBA rate, per slot. Null when ahead or close enough. */
+  /** Games this slot is behind the NBA rate, per slot. Null when at or ahead of pace. */
   behindPace: number | null
   /** Games the projection falls short of the column cap. Null when it reaches it. */
   short: number | null
@@ -162,7 +160,8 @@ export function slotStatus(
   const lost = projection.maxGamesTotal === null ? 0 : cap - projection.maxGamesTotal
 
   return {
-    behindPace: behind >= BEHIND_PACE_GAMES ? behind : null,
+    // A fractional game (69.3 vs 69) is not a real gap — round before flagging it.
+    behindPace: Math.round(behind) > 0 ? behind : null,
     short: short > 0 ? short : null,
     lost: lost > 0 ? lost : null,
   }


### PR DESCRIPTION
## Why

#196 merged before a follow-up fix landed — this PR carries that fix, which never made it into `dev`.

`BEHIND_PACE_GAMES` silently swallowed any slot up to 2.9 games behind pace. Removed: `behindPace` now flags as soon as the gap rounds to a whole game, matching `short` and `lost`, which already flag on any positive value.

## Verification

- `tsc --noEmit` clean (pre-push hook confirmed)
- `vitest run` on `slotProjection.test.ts` — 35 passed, including updated threshold cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)