### PR TITLE
Rankings page: rename view toggle, default to Rankings, format averages like heatmap

### DIFF
--- a/frontend/src/pages/Rankings.tsx
+++ b/frontend/src/pages/Rankings.tsx
@@ -22,11 +22,18 @@ const CATEGORY_KEY_MAP: Record<string, string> = {
   pts: 'PTS',
 }
 
+const PERCENTAGE_CATEGORIES = new Set(['FG%', 'FT%'])
+
+// Matches the heatmap's category-cell formatting (Analytics.tsx) so the same
+// stat reads identically in both places: 4 decimal places, percentages scaled to 0-100.
+const formatAverageValue = (categoryKey: string, val: number) =>
+  PERCENTAGE_CATEGORIES.has(categoryKey) ? (val * 100).toFixed(4) + '%' : val.toFixed(4)
+
 const Rankings = () => {
   const [sortBy, setSortBy] = useState<string>('total_points')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [mode, setMode] = useState<'averages' | 'totals'>('averages')
-  const [cellValues, setCellValues] = useState<'actual' | 'category_rank'>('actual')
+  const [viewMode, setViewMode] = useState<'standings' | 'rankings'>('rankings')
   const [startDate, setStartDate] = useState<string>('')
   const [endDate, setEndDate] = useState<string>('')
   const [dateError, setDateError] = useState<string>('')
@@ -94,7 +101,7 @@ const Rankings = () => {
 
   const getSortValue = (team: RankingStats) => {
     const categoryKey = CATEGORY_KEY_MAP[sortBy]
-    if (categoryKey && cellValues === 'category_rank') {
+    if (categoryKey && viewMode === 'rankings') {
       return team.category_ranks?.[categoryKey]
     }
     return team[sortBy as keyof RankingStats]
@@ -113,7 +120,7 @@ const Rankings = () => {
     return 0
   })
 
-  const isActualValues = cellValues === 'actual'
+  const isStandings = viewMode === 'standings'
 
   const columns = [
     { key: 'rank', label: 'Rank', sortable: true },
@@ -130,7 +137,7 @@ const Rankings = () => {
     { key: 'gp', label: 'GP', sortable: true },
   ]
 
-  const titleWord = isActualValues ? 'Standings' : 'Rankings'
+  const titleWord = isStandings ? 'Standings' : 'Rankings'
   const modeLabel = mode === 'averages' ? 'Averages' : 'Totals'
 
   const hasDateMismatch = data && isDateRangeActive && (
@@ -181,12 +188,37 @@ const Rankings = () => {
                 )}
               </h2>
               <p className="text-blue-100 mt-1">
-                {isActualValues
+                {isStandings
                   ? `${mode === 'averages' ? 'Per-game averages' : 'Season totals'}, exactly as ESPN reports them. Rank and Total still reflect roto scoring.`
                   : 'Each category cell shows the team\'s rank within that category. Click column headers to sort.'}
               </p>
             </div>
             <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
+              <div className="flex flex-col gap-1 items-start sm:items-end">
+                <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">View Mode</span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setViewMode('standings')}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      isStandings
+                        ? 'bg-white text-blue-700'
+                        : 'bg-blue-500 text-white hover:bg-blue-400'
+                    }`}
+                  >
+                    Standings
+                  </button>
+                  <button
+                    onClick={() => setViewMode('rankings')}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      !isStandings
+                        ? 'bg-white text-blue-700'
+                        : 'bg-blue-500 text-white hover:bg-blue-400'
+                    }`}
+                  >
+                    Rankings
+                  </button>
+                </div>
+              </div>
               <div className="flex flex-col gap-1 items-start sm:items-end">
                 <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">Values</span>
                 <div className="flex gap-2">
@@ -209,31 +241,6 @@ const Rankings = () => {
                     }`}
                   >
                     Totals
-                  </button>
-                </div>
-              </div>
-              <div className="flex flex-col gap-1 items-start sm:items-end">
-                <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">Category Cells</span>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => setCellValues('actual')}
-                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-                      isActualValues
-                        ? 'bg-white text-blue-700'
-                        : 'bg-blue-500 text-white hover:bg-blue-400'
-                    }`}
-                  >
-                    Actual Values
-                  </button>
-                  <button
-                    onClick={() => setCellValues('category_rank')}
-                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-                      !isActualValues
-                        ? 'bg-white text-blue-700'
-                        : 'bg-blue-500 text-white hover:bg-blue-400'
-                    }`}
-                  >
-                    Category Rank
                   </button>
                 </div>
               </div>
@@ -360,16 +367,27 @@ const Rankings = () => {
                   </td>
                   {columns.slice(2).map((column) => {
                     const categoryKey = CATEGORY_KEY_MAP[column.key]
-                    const value = (categoryKey && !isActualValues)
+                    const isCategoryColumn = !!categoryKey
+                    const value = (isCategoryColumn && !isStandings)
                       ? team.category_ranks?.[categoryKey]
                       : (team[column.key as keyof RankingStats] as number)
-                    const formatValue = (val: number) => {
-                      if (column.key === 'gp' || (categoryKey && !isActualValues)) return val
-                      return val % 1 === 0 ? val.toString() : val.toFixed(1)
+
+                    let display: string | number | undefined = value
+                    if (typeof value === 'number') {
+                      if (isCategoryColumn && !isStandings) {
+                        display = value
+                      } else if (isCategoryColumn && isStandings && mode === 'averages') {
+                        display = formatAverageValue(categoryKey, value)
+                      } else if (column.key === 'gp') {
+                        display = value
+                      } else {
+                        display = value % 1 === 0 ? value.toString() : value.toFixed(1)
+                      }
                     }
+
                     return (
                       <td key={column.key} className={`table-cell font-medium ${column.key === 'gp' ? 'border-l-2 border-gray-300' : ''}`}>
-                        {typeof value === 'number' ? formatValue(value) : value}
+                        {display}
                       </td>
                     )
                   })}

--- a/frontend/src/pages/__tests__/Rankings.test.tsx
+++ b/frontend/src/pages/__tests__/Rankings.test.tsx
@@ -8,7 +8,7 @@ import Rankings from '../Rankings';
 function team(overrides: Partial<RankingStats> = {}): RankingStats {
   return {
     team: { team_id: 1, team_name: 'Alpha Squad' },
-    fg_percentage: 0.5,
+    fg_percentage: 0.467,
     ft_percentage: 0.8,
     three_pm: 100,
     ast: 200,
@@ -51,6 +51,7 @@ describe('Rankings page', () => {
                 rank: 1,
                 total_points: 8,
                 pts: 115.3,
+                fg_percentage: 0.467,
                 category_ranks: { 'FG%': 3, 'FT%': 1, '3PM': 2, AST: 2, REB: 2, STL: 2, BLK: 2, PTS: 2 },
               }),
               team({
@@ -58,6 +59,7 @@ describe('Rankings page', () => {
                 rank: 2,
                 total_points: 4,
                 pts: 121.0,
+                fg_percentage: 0.444,
                 category_ranks: { 'FG%': 1, 'FT%': 3, '3PM': 3, AST: 1, REB: 1, STL: 1, BLK: 3, PTS: 3 },
               }),
             ],
@@ -93,40 +95,50 @@ describe('Rankings page', () => {
     vi.unstubAllGlobals();
   });
 
-  it('defaults to Rankings (Averages) with actual values, rank and total always visible', async () => {
+  it('defaults to Rankings (Averages) with category-rank cells, Rank and Total always visible', async () => {
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
-    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /^total/i })).toBeInTheDocument();
-
-    const table = screen.getByRole('table');
-    const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
-    expect(within(alphaRow).getByText('115.3')).toBeInTheDocument();
-  });
-
-  it('switching to Category Rank shows rank-in-category cells and retitles to Rankings, keeping Rank/Total columns', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Rankings />);
-    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
-
-    await user.click(screen.getByRole('button', { name: /^category rank$/i }));
-
     expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /^total/i })).toBeInTheDocument();
 
     const table = screen.getByRole('table');
     const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
-    // FG% category rank for Alpha is 3, not the actual .5 value
-    expect(within(alphaRow).queryByText('115.3')).not.toBeInTheDocument();
+    // Category rank (3), not the actual pts/fg% value, in the default Rankings view
+    expect(within(alphaRow).queryByText('115.3000')).not.toBeInTheDocument();
   });
 
-  it('Totals x Actual Values shows Team Standings (Totals) using raw totals values', async () => {
+  it('the "View Mode" group offers Standings/Rankings and "Values" offers Averages/Totals', async () => {
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+    expect(screen.getByText('View Mode')).toBeInTheDocument();
+    expect(screen.getByText('Values')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^standings$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^rankings$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^averages$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^totals$/i })).toBeInTheDocument();
+  });
+
+  it('switching to Standings x Averages shows actual values rounded to 4 decimals, like the heatmap', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
 
+    await user.click(screen.getByRole('button', { name: /^standings$/i }));
+
+    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
+    const table = screen.getByRole('table');
+    const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
+    expect(within(alphaRow).getByText('115.3000')).toBeInTheDocument();
+    expect(within(alphaRow).getByText('46.7000%')).toBeInTheDocument();
+  });
+
+  it('Standings x Totals shows raw totals values without the 4-decimal average formatting', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /^standings$/i }));
     await user.click(screen.getByRole('button', { name: /^totals$/i }));
 
     expect(screen.getByText('Team Standings (Totals)')).toBeInTheDocument();
@@ -135,17 +147,17 @@ describe('Rankings page', () => {
     expect(within(alphaRow).getByText('4000')).toBeInTheDocument();
   });
 
-  it('switching back to Actual Values restores real values', async () => {
+  it('switching back to Rankings restores category-rank cells', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
 
-    await user.click(screen.getByRole('button', { name: /^category rank$/i }));
-    await user.click(screen.getByRole('button', { name: /^actual values$/i }));
+    await user.click(screen.getByRole('button', { name: /^standings$/i }));
+    await user.click(screen.getByRole('button', { name: /^rankings$/i }));
 
-    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
+    expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
     const table = screen.getByRole('table');
     const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
-    expect(within(alphaRow).getByText('115.3')).toBeInTheDocument();
+    expect(within(alphaRow).queryByText('115.3000')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up polish for the Standings/Rankings view on the League Rankings page (#199), based on feedback after merge:

- Averages "Standings" cells now round to 4 decimal places, matching the heatmap's category-cell formatting (percentages scaled to 0-100 with a `%` suffix) instead of the previous 1-decimal display.
- Renamed the cell-content toggle group to **View Mode** (Standings / Rankings) and reordered it before the **Values** (Averages / Totals) toggle.
- Default view is now **Rankings × Averages** instead of Standings × Averages.

## Test plan

- [x] `npx vitest run` — 183 passed, 3 skipped
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx eslint src/pages/Rankings.tsx src/pages/__tests__/Rankings.test.tsx` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AczKHYLw3oFudjFtvxWPUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AczKHYLw3oFudjFtvxWPUw)_