### PR TITLE
Rankings page: real ESPN standings view alongside roto rankings

### DIFF
--- a/backend/app/builders/response_builder.py
+++ b/backend/app/builders/response_builder.py
@@ -14,7 +14,9 @@ from app.config import settings
 class ResponseBuilder:
     """Transforms data into API response objects (pure data transformation)"""
     
-    def build_rankings_response(self, averages_rankings_df: pd.DataFrame,
+    def build_rankings_response(self, averages_df: pd.DataFrame,
+                              totals_df: pd.DataFrame,
+                              averages_rankings_df: pd.DataFrame,
                               totals_rankings_df: pd.DataFrame,
                               sort_by: Optional[str] = None,
                               order: str = "asc",
@@ -23,15 +25,25 @@ class ResponseBuilder:
                               date_range_end=None,
                               actual_start_date=None,
                               actual_end_date=None) -> LeagueRankings:
-        """Build LeagueRankings response from averages and totals rankings DataFrames"""
+        """Build LeagueRankings response from averages/totals rankings DataFrames (rank + total
+        points per team) paired with their raw counterparts (actual per-category stat values)"""
         sort_col = "RANK" if sort_by is None else sort_by.upper()
         ascending = order == "asc"
 
         averages_rankings_df = averages_rankings_df.sort_values(sort_col, ascending=ascending)
         totals_rankings_df = totals_rankings_df.sort_values(sort_col, ascending=ascending)
 
-        averages_rankings = [self._create_ranking_stats(row) for _, row in averages_rankings_df.iterrows()]
-        totals_rankings = [self._create_ranking_stats(row) for _, row in totals_rankings_df.iterrows()]
+        averages_by_team = averages_df.set_index('team_id')
+        totals_by_team = totals_df.set_index('team_id')
+
+        averages_rankings = [
+            self._create_ranking_stats(row, averages_by_team.loc[int(row['team_id'])])
+            for _, row in averages_rankings_df.iterrows()
+        ]
+        totals_rankings = [
+            self._create_ranking_stats(row, totals_by_team.loc[int(row['team_id'])])
+            for _, row in totals_rankings_df.iterrows()
+        ]
 
         return LeagueRankings(
             averages_rankings=averages_rankings,
@@ -66,7 +78,7 @@ class ResponseBuilder:
         team = Team(team_id=team_id, team_name=totals_data['team_name'])
         shot_chart = self._create_shot_chart_stats(totals_data)
         raw_averages = self._create_raw_average_stats(avg_data)
-        ranking_stats = self._create_ranking_stats(rank_data)
+        ranking_stats = self._create_ranking_stats(rank_data, avg_data)
 
         slot_usage: Dict[str, SlotUsage] = {}
         for slot_name, cap in SLOT_CAPS.items():
@@ -234,21 +246,24 @@ class ResponseBuilder:
             gp=float(league_avg_data['GP'])
         )
     
-    def _create_ranking_stats(self, row: pd.Series) -> RankingStats:
-        """Create RankingStats object from dataframe row"""
+    def _create_ranking_stats(self, ranked_row: pd.Series, raw_row: pd.Series) -> RankingStats:
+        """Create RankingStats object from a ranked dataframe row (rank + total points, plus each
+        category's rank-in-category via RANKING_CATEGORIES) paired with the raw row holding the
+        team's actual per-category stat values"""
         return RankingStats(
-            team=Team(team_id=int(row['team_id']), team_name=str(row['team_name'])),
-            fg_percentage=float(row['FG%']),
-            ft_percentage=float(row['FT%']),
-            three_pm=float(row['3PM']),
-            ast=float(row['AST']),
-            reb=float(row['REB']),
-            stl=float(row['STL']),
-            blk=float(row['BLK']),
-            pts=float(row['PTS']),
-            gp=int(row['GP']),
-            total_points=float(row['TOTAL_POINTS']),
-            rank=int(row['RANK'])
+            team=Team(team_id=int(ranked_row['team_id']), team_name=str(ranked_row['team_name'])),
+            fg_percentage=float(raw_row['FG%']),
+            ft_percentage=float(raw_row['FT%']),
+            three_pm=float(raw_row['3PM']),
+            ast=float(raw_row['AST']),
+            reb=float(raw_row['REB']),
+            stl=float(raw_row['STL']),
+            blk=float(raw_row['BLK']),
+            pts=float(raw_row['PTS']),
+            gp=int(ranked_row['GP']),
+            total_points=float(ranked_row['TOTAL_POINTS']),
+            rank=int(ranked_row['RANK']),
+            category_ranks={col: int(ranked_row[col]) for col in RANKING_CATEGORIES},
         )
     
     def _create_shot_chart_stats(self, totals_data: pd.Series) -> ShotChartStats:

--- a/backend/app/models/stats.py
+++ b/backend/app/models/stats.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Dict, Optional
 from .base import Team
 
 
@@ -45,6 +45,7 @@ class RankingStats(BaseModel):
     gp: int
     total_points: float
     rank: Optional[int] = None
+    category_ranks: Optional[Dict[str, int]] = None
 
 class TeamShotStats(BaseModel):
     team: Team

--- a/backend/app/services/ranking_service.py
+++ b/backend/app/services/ranking_service.py
@@ -24,11 +24,11 @@ class RankingService:
         if start_date is not None and end_date is not None:
             return await self._get_rankings_for_range(start_date, end_date, sort_by, order)
 
-        totals_df, _, averages_rankings_df = await self.data_provider.get_all_dataframes()
+        totals_df, averages_df, averages_rankings_df = await self.data_provider.get_all_dataframes()
         if totals_df is None:
             raise ResourceNotFoundError("Unable to fetch rankings data from ESPN API")
 
-        totals_rankings_df = self._build_totals_rankings_df(totals_df)
+        totals_raw_df, totals_rankings_df = self._build_totals_rankings_df(totals_df)
 
         if sort_by is not None and not self._is_valid_sort_column(sort_by, averages_rankings_df):
             raise InvalidParameterError(f"Invalid sort column: {sort_by}")
@@ -36,6 +36,8 @@ class RankingService:
             raise InvalidParameterError("Order must be 'asc' or 'desc'")
 
         return self.response_builder.build_rankings_response(
+            averages_df=averages_df,
+            totals_df=totals_raw_df,
             averages_rankings_df=averages_rankings_df,
             totals_rankings_df=totals_rankings_df,
             sort_by=sort_by,
@@ -58,8 +60,8 @@ class RankingService:
 
         delta_df = self._compute_delta(end_df, start_df)
 
-        averages_rankings_df = self._build_averages_rankings_df(delta_df)
-        totals_rankings_df = self._build_totals_rankings_df_from_delta(delta_df)
+        averages_df, averages_rankings_df = self._build_averages_rankings_df(delta_df)
+        totals_raw_df, totals_rankings_df = self._build_totals_rankings_df_from_delta(delta_df)
 
         if sort_by is not None and not self._is_valid_sort_column(sort_by, averages_rankings_df):
             raise InvalidParameterError(f"Invalid sort column: {sort_by}")
@@ -67,6 +69,8 @@ class RankingService:
             raise InvalidParameterError("Order must be 'asc' or 'desc'")
 
         return self.response_builder.build_rankings_response(
+            averages_df=averages_df,
+            totals_df=totals_raw_df,
             averages_rankings_df=averages_rankings_df,
             totals_rankings_df=totals_rankings_df,
             sort_by=sort_by,
@@ -95,8 +99,8 @@ class RankingService:
         delta['ft_pct'] = (delta['ftm'] / delta['fta'].replace(0, float('nan'))).fillna(0)
         return delta
 
-    def _build_averages_rankings_df(self, delta_df: pd.DataFrame) -> pd.DataFrame:
-        """Build averages rankings DataFrame from delta (divide counting stats by GP)."""
+    def _build_averages_rankings_df(self, delta_df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Build (raw averages, rankings) DataFrames from delta (divide counting stats by GP)."""
         from app.services.data_transformer import DataTransformer
         transformer = DataTransformer()
 
@@ -118,10 +122,10 @@ class RankingService:
         df['PTS'] = delta_df['pts']
 
         averages_df = transformer.totals_to_averages_df(df)
-        return transformer.averages_to_rankings_df(averages_df)
+        return averages_df, transformer.averages_to_rankings_df(averages_df)
 
-    def _build_totals_rankings_df_from_delta(self, delta_df: pd.DataFrame) -> pd.DataFrame:
-        """Build totals rankings DataFrame directly from delta counting stats."""
+    def _build_totals_rankings_df_from_delta(self, delta_df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Build (raw totals, rankings) DataFrames directly from delta counting stats."""
         from app.services.data_transformer import DataTransformer
         transformer = DataTransformer()
 
@@ -138,16 +142,16 @@ class RankingService:
         df['BLK'] = delta_df['blk']
         df['PTS'] = delta_df['pts']
 
-        return transformer.averages_to_rankings_df(df)
+        return df, transformer.averages_to_rankings_df(df)
 
-    def _build_totals_rankings_df(self, totals_df: pd.DataFrame) -> pd.DataFrame:
-        """Build totals rankings DataFrame from season totals (no per-game division)."""
+    def _build_totals_rankings_df(self, totals_df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Build (raw totals, rankings) DataFrames from season totals (no per-game division)."""
         from app.services.data_transformer import DataTransformer
         transformer = DataTransformer()
 
         cols_to_keep = ['team_id', 'team_name', 'GP'] + [c for c in RANKING_CATEGORIES if c in totals_df.columns]
         df = totals_df[[c for c in cols_to_keep if c in totals_df.columns]].copy()
-        return transformer.averages_to_rankings_df(df)
+        return df, transformer.averages_to_rankings_df(df)
 
     def _is_valid_sort_column(self, sort_by: str, rankings_df) -> bool:
         return sort_by.upper() in rankings_df.columns

--- a/backend/tests/builders/test_response_builder.py
+++ b/backend/tests/builders/test_response_builder.py
@@ -40,9 +40,9 @@ def response_builder_players_df():
 class TestResponseBuilder:
     """Test suite for ResponseBuilder class"""
     
-    def test_build_rankings_response_default_sorting(self, response_builder, sample_rankings_df):
+    def test_build_rankings_response_default_sorting(self, response_builder, sample_averages_df, sample_rankings_df):
         """Test build_rankings_response with default sorting (by RANK, asc)"""
-        result = response_builder.build_rankings_response(sample_rankings_df, sample_rankings_df)
+        result = response_builder.build_rankings_response(sample_averages_df, sample_averages_df, sample_rankings_df, sample_rankings_df)
 
         assert isinstance(result, LeagueRankings), "Should return LeagueRankings object"
         assert len(result.averages_rankings) == 3, "Should have 3 rankings"
@@ -57,30 +57,32 @@ class TestResponseBuilder:
         assert first_ranking.team.team_id == 1, "First ranking should be Team Alpha"
         assert first_ranking.team.team_name == 'Team Alpha', "First ranking should be Team Alpha"
         assert first_ranking.rank == 1, "First ranking should have rank 1"
+        assert first_ranking.pts == 115.3, "Cell values should be the actual stat, not the category rank"
+        assert first_ranking.category_ranks['FG%'] == 2, "category_ranks should carry the rank-in-category"
 
-    def test_build_rankings_response_custom_sorting(self, response_builder, sample_rankings_df):
+    def test_build_rankings_response_custom_sorting(self, response_builder, sample_averages_df, sample_rankings_df):
         """Test build_rankings_response with custom sorting by PTS descending"""
-        result = response_builder.build_rankings_response(sample_rankings_df, sample_rankings_df, sort_by='PTS', order='desc')
+        result = response_builder.build_rankings_response(sample_averages_df, sample_averages_df, sample_rankings_df, sample_rankings_df, sort_by='PTS', order='desc')
 
-        pts_values = [ranking.pts for ranking in result.averages_rankings]
+        pts_ranks = [ranking.category_ranks['PTS'] for ranking in result.averages_rankings]
         team_names = [ranking.team.team_name for ranking in result.averages_rankings]
 
-        assert pts_values == [3, 2, 1], "Should be sorted by PTS descending"
+        assert pts_ranks == [3, 2, 1], "Should be sorted by PTS rank descending"
         assert team_names == ['Team Gamma', 'Team Alpha', 'Team Beta'], "Should be in correct PTS order"
 
-    def test_build_rankings_response_ascending_order(self, response_builder, sample_rankings_df):
+    def test_build_rankings_response_ascending_order(self, response_builder, sample_averages_df, sample_rankings_df):
         """Test build_rankings_response with FG% ascending order"""
-        result = response_builder.build_rankings_response(sample_rankings_df, sample_rankings_df, sort_by='FG%', order='asc')
+        result = response_builder.build_rankings_response(sample_averages_df, sample_averages_df, sample_rankings_df, sample_rankings_df, sort_by='FG%', order='asc')
 
-        fg_values = [ranking.fg_percentage for ranking in result.averages_rankings]
+        fg_ranks = [ranking.category_ranks['FG%'] for ranking in result.averages_rankings]
         team_names = [ranking.team.team_name for ranking in result.averages_rankings]
 
-        assert fg_values == [1, 2, 3], "Should be sorted by FG% ascending"
+        assert fg_ranks == [1, 2, 3], "Should be sorted by FG% rank ascending"
         assert team_names == ['Team Gamma', 'Team Alpha', 'Team Beta'], "Should be in correct FG% order"
 
-    def test_build_rankings_response_total_points_sorting(self, response_builder, sample_rankings_df):
+    def test_build_rankings_response_total_points_sorting(self, response_builder, sample_averages_df, sample_rankings_df):
         """Test build_rankings_response with TOTAL_POINTS sorting"""
-        result = response_builder.build_rankings_response(sample_rankings_df, sample_rankings_df, sort_by='TOTAL_POINTS', order='desc')
+        result = response_builder.build_rankings_response(sample_averages_df, sample_averages_df, sample_rankings_df, sample_rankings_df, sort_by='TOTAL_POINTS', order='desc')
 
         total_points = [ranking.total_points for ranking in result.averages_rankings]
         team_names = [ranking.team.team_name for ranking in result.averages_rankings]

--- a/backend/tests/routes/test_rankings.py
+++ b/backend/tests/routes/test_rankings.py
@@ -6,18 +6,16 @@ import pytest
 client = TestClient(app)
 
 
-sort_by_to_attribute = {
-    "PTS": "pts",
-    "REB": "reb",
-    "AST": "ast",
-    "FG%": "fg_percentage",
-    "FT%": "ft_percentage",
-    "3PM": "three_pm",
-    "STL": "stl",
-    "BLK": "blk",
-    "TOTAL_POINTS": "total_points",
-    "RANK": "rank",
-}   
+CATEGORY_SORT_KEYS = {"PTS", "REB", "AST", "FG%", "FT%", "3PM", "STL", "BLK"}
+
+
+def _sort_key(ranking, sort_by: str):
+    """Server sorts category columns by rank-in-category, not the raw stat value
+    (which is what ranking.pts/fg_percentage/etc. now hold), so mirror that here."""
+    upper = sort_by.upper()
+    if upper in CATEGORY_SORT_KEYS:
+        return ranking.category_ranks[upper]
+    return getattr(ranking, "total_points" if upper == "TOTAL_POINTS" else "rank")
 
 def _build_rankings_url(sort_by=None, order=None):
     """Build rankings URL with query parameters"""
@@ -56,7 +54,7 @@ def test_get_rankings_default():
 def test_get_rankings_with_sort_by(sort_by):
     """Test that the rankings are sorted by the sort_by column, order default is asc"""
     league_rankings = _get_valid_rankings(sort_by=sort_by)
-    expected_sorted = sorted(league_rankings.averages_rankings, key=lambda x: getattr(x, sort_by_to_attribute[sort_by.upper()]), reverse=False)
+    expected_sorted = sorted(league_rankings.averages_rankings, key=lambda x: _sort_key(x, sort_by), reverse=False)
     assert league_rankings.averages_rankings == expected_sorted
 
 @pytest.mark.parametrize("order", ["asc", "desc"])
@@ -71,7 +69,7 @@ def test_get_rankings_with_order_without_sort_by(order):
 def test_get_rankings_with_order_and_sort_by(sort_by, order):
     """Test that the rankings are sorted by the sort_by column, order default is asc"""
     league_rankings = _get_valid_rankings(sort_by=sort_by, order=order)
-    expected_sorted = sorted(league_rankings.averages_rankings, key=lambda x: getattr(x, sort_by_to_attribute[sort_by.upper()]), reverse=order == "desc")
+    expected_sorted = sorted(league_rankings.averages_rankings, key=lambda x: _sort_key(x, sort_by), reverse=order == "desc")
     assert league_rankings.averages_rankings == expected_sorted
 
 def test_get_rankings_with_invalid_sort_by():

--- a/backend/tests/services/test_ranking_service.py
+++ b/backend/tests/services/test_ranking_service.py
@@ -111,12 +111,12 @@ class TestRankingServiceResponseBuilding:
     """Response building tests for RankingService with mocked data provider but real response building"""
 
     @pytest.fixture
-    def response_building_ranking_service(self, sample_rankings_df, sample_totals_df):
+    def response_building_ranking_service(self, sample_rankings_df, sample_totals_df, sample_averages_df):
         """Create RankingService with mocked DataProvider but real ResponseBuilder"""
         with patch('app.services.ranking_service.DataProvider') as mock_data_provider:
             service = RankingService()
             service.data_provider = AsyncMock()
-            service.data_provider.get_all_dataframes.return_value = (sample_totals_df, None, sample_rankings_df)
+            service.data_provider.get_all_dataframes.return_value = (sample_totals_df, sample_averages_df, sample_rankings_df)
             service.data_provider.get_data_date = MagicMock(return_value=None)
             return service
 
@@ -146,9 +146,9 @@ class TestRankingServiceResponseBuilding:
         """Integration test: Verify sorting by specific category works correctly"""
         league_rankings = await response_building_ranking_service.get_league_rankings(sort_by='FG%', order='desc')
 
-        expected_fg_values = [3, 2, 1]
-        actual_fg_values = [ranking.fg_percentage for ranking in league_rankings.averages_rankings]
-        assert actual_fg_values == expected_fg_values, f"Expected {expected_fg_values}, got {actual_fg_values}"
+        expected_fg_ranks = [3, 2, 1]
+        actual_fg_ranks = [ranking.category_ranks['FG%'] for ranking in league_rankings.averages_rankings]
+        assert actual_fg_ranks == expected_fg_ranks, f"Expected {expected_fg_ranks}, got {actual_fg_ranks}"
 
         expected_team_names = ['Team Beta', 'Team Alpha', 'Team Gamma']
         actual_team_names = [ranking.team.team_name for ranking in league_rankings.averages_rankings]
@@ -227,16 +227,16 @@ class TestRankingServiceIntegration:
         assert isinstance(league_rankings, LeagueRankings)
         rankings = league_rankings.averages_rankings
 
-        pts_values = [ranking.pts for ranking in rankings]
-        assert pts_values == sorted(pts_values, reverse=True), "PTS should be in descending order"
+        pts_ranks = [ranking.category_ranks['PTS'] for ranking in rankings]
+        assert pts_ranks == sorted(pts_ranks, reverse=True), "PTS rank-in-category should be in descending order"
 
         league_rankings_asc = await integration_ranking_service.get_league_rankings(
             sort_by='AST', order='asc'
         )
 
         rankings_asc = league_rankings_asc.averages_rankings
-        ast_values = [ranking.ast for ranking in rankings_asc]
-        assert ast_values == sorted(ast_values), "AST should be in ascending order"
+        ast_ranks = [ranking.category_ranks['AST'] for ranking in rankings_asc]
+        assert ast_ranks == sorted(ast_ranks), "AST rank-in-category should be in ascending order"
 
     @pytest.mark.asyncio
     async def test_integration_error_handling(self, integration_ranking_service):

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -100,7 +100,7 @@ const Layout = () => {
   const navItems = [
     { path: '/', label: 'Dashboard', icon: '📊' },
     { path: '/teams', label: 'Teams', icon: '👥' },
-    { path: '/rankings', label: 'Rankings', icon: '🏆' },
+    { path: '/rankings', label: 'Standings & Rankings', icon: '🏆' },
     { path: '/shots', label: 'Shots', icon: '🎯' },
     { path: '/analytics', label: 'Analytics', icon: '📈' },
     { path: '/estimator', label: 'Estimator', icon: '🔮' },
@@ -490,7 +490,7 @@ const ReorgLayout = ({ darkMode, setDarkMode, setSearchOpen }: ReorgLayoutProps)
       label: 'League',
       icon: '👥',
       items: [
-        { path: '/rankings', label: 'League Rankings', icon: '🏆' },
+        { path: '/rankings', label: 'Standings & Rankings', icon: '🏆' },
         { path: '/teams', label: 'Teams', icon: '👥' },
         ...(FF_DRAFT_REPORT ? [{ path: '/draft-report', label: 'Draft Report', icon: '📝' }] : []),
       ],

--- a/frontend/src/constants/searchablePages.ts
+++ b/frontend/src/constants/searchablePages.ts
@@ -21,7 +21,7 @@ export interface SearchablePage {
  */
 export const SEARCHABLE_PAGES: SearchablePage[] = [
   { label: 'Dashboard', path: '/', icon: '📊', group: 'League' },
-  { label: 'League Rankings', path: '/rankings', icon: '🏆', group: 'League' },
+  { label: 'Standings & Rankings', path: '/rankings', icon: '🏆', group: 'League' },
   { label: 'Teams', path: '/teams', icon: '👥', group: 'League' },
   ...(FF_DRAFT_REPORT ? [{ label: 'Draft Report', path: '/draft-report', icon: '📝', group: 'League' }] : []),
   { label: 'Players', path: '/players', icon: '⛹️', group: 'Players' },

--- a/frontend/src/pages/Rankings.tsx
+++ b/frontend/src/pages/Rankings.tsx
@@ -336,7 +336,9 @@ const Rankings = () => {
                     key={column.key}
                     className={`table-header ${
                       column.sortable ? 'cursor-pointer hover:bg-gray-100 transition-colors duration-150' : ''
-                    } ${column.key === 'gp' ? 'border-l-2 border-gray-300' : ''}`}
+                    } ${column.key === 'gp' ? 'border-l-2 border-gray-300' : ''} ${
+                      column.key === 'team' ? 'sticky left-0 z-20 bg-gray-50 shadow-[2px_0_4px_-2px_rgba(0,0,0,0.15)]' : ''
+                    }`}
                     onClick={() => column.sortable && handleSort(column.key)}
                   >
                     <div className="flex items-center">
@@ -353,11 +355,11 @@ const Rankings = () => {
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
               {rankings.map((team: RankingStats, index: number) => (
-                <tr key={team.team.team_id} className="hover:bg-blue-50 transition-colors duration-150 border-b border-gray-100">
+                <tr key={team.team.team_id} className="group hover:bg-blue-50 transition-colors duration-150 border-b border-gray-100">
                   <td className="table-cell font-bold text-blue-600">
                     #{team.rank || index + 1}
                   </td>
-                  <td className="table-cell">
+                  <td className="table-cell sticky left-0 z-10 bg-white group-hover:bg-blue-50 shadow-[2px_0_4px_-2px_rgba(0,0,0,0.15)]">
                     <Link
                       to={`/team/${team.team.team_id}`}
                       className="text-blue-600 hover:text-blue-800 font-semibold transition-colors duration-150 hover:underline"

--- a/frontend/src/pages/Rankings.tsx
+++ b/frontend/src/pages/Rankings.tsx
@@ -11,11 +11,22 @@ import { todayIso, getDateNDaysAgo } from '../utils/dateRange'
 const formatDate = (d: string) =>
   new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 
+const CATEGORY_KEY_MAP: Record<string, string> = {
+  fg_percentage: 'FG%',
+  ft_percentage: 'FT%',
+  three_pm: '3PM',
+  ast: 'AST',
+  reb: 'REB',
+  stl: 'STL',
+  blk: 'BLK',
+  pts: 'PTS',
+}
+
 const Rankings = () => {
   const [sortBy, setSortBy] = useState<string>('total_points')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [mode, setMode] = useState<'averages' | 'totals'>('averages')
-  const [display, setDisplay] = useState<'ranked' | 'raw'>('ranked')
+  const [cellValues, setCellValues] = useState<'actual' | 'category_rank'>('actual')
   const [startDate, setStartDate] = useState<string>('')
   const [endDate, setEndDate] = useState<string>('')
   const [dateError, setDateError] = useState<string>('')
@@ -60,17 +71,6 @@ const Rankings = () => {
     setAppliedDates({})
   }
 
-  const handleDisplayChange = (next: 'ranked' | 'raw') => {
-    setDisplay(next)
-    if (next === 'raw' && (sortBy === 'rank' || sortBy === 'total_points')) {
-      setSortBy('team')
-      setSortOrder('asc')
-    } else if (next === 'ranked' && sortBy === 'team') {
-      setSortBy('total_points')
-      setSortOrder('desc')
-    }
-  }
-
   const handleSort = (column: string) => {
     if (sortBy === column) {
       setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
@@ -92,9 +92,17 @@ const Rankings = () => {
     ? (data?.averages_rankings || [])
     : (data?.totals_rankings || [])
 
+  const getSortValue = (team: RankingStats) => {
+    const categoryKey = CATEGORY_KEY_MAP[sortBy]
+    if (categoryKey && cellValues === 'category_rank') {
+      return team.category_ranks?.[categoryKey]
+    }
+    return team[sortBy as keyof RankingStats]
+  }
+
   const rankings = [...rawRankings].sort((a, b) => {
-    const aValue = a[sortBy as keyof RankingStats]
-    const bValue = b[sortBy as keyof RankingStats]
+    const aValue = getSortValue(a)
+    const bValue = getSortValue(b)
     if (typeof aValue === 'number' && typeof bValue === 'number') {
       return sortOrder === 'asc' ? aValue - bValue : bValue - aValue
     }
@@ -105,10 +113,10 @@ const Rankings = () => {
     return 0
   })
 
-  const isRanked = display === 'ranked'
+  const isActualValues = cellValues === 'actual'
 
   const columns = [
-    ...(isRanked ? [{ key: 'rank', label: 'Rank', sortable: true }] : []),
+    { key: 'rank', label: 'Rank', sortable: true },
     { key: 'team', label: 'Team', sortable: true },
     { key: 'fg_percentage', label: 'FG%', sortable: true },
     { key: 'ft_percentage', label: 'FT%', sortable: true },
@@ -118,11 +126,11 @@ const Rankings = () => {
     { key: 'stl', label: 'STL', sortable: true },
     { key: 'blk', label: 'BLK', sortable: true },
     { key: 'pts', label: 'PTS', sortable: true },
-    ...(isRanked ? [{ key: 'total_points', label: 'Total', sortable: true }] : []),
+    { key: 'total_points', label: 'Total', sortable: true },
     { key: 'gp', label: 'GP', sortable: true },
   ]
 
-  const titleWord = isRanked ? 'Rankings' : 'Standings'
+  const titleWord = isActualValues ? 'Standings' : 'Rankings'
   const modeLabel = mode === 'averages' ? 'Averages' : 'Totals'
 
   const hasDateMismatch = data && isDateRangeActive && (
@@ -173,13 +181,9 @@ const Rankings = () => {
                 )}
               </h2>
               <p className="text-blue-100 mt-1">
-                {isRanked
-                  ? (mode === 'averages'
-                      ? 'Click column headers to sort. Total points calculated from category rankings.'
-                      : 'Totals mode: raw accumulated stats, ranked by total roto score.')
-                  : (mode === 'averages'
-                      ? 'Per-game averages, exactly as tracked — no roto scoring applied.'
-                      : 'Season-to-date category totals, exactly as ESPN reports them — no roto scoring, no computed rank.')}
+                {isActualValues
+                  ? `${mode === 'averages' ? 'Per-game averages' : 'Season totals'}, exactly as ESPN reports them. Rank and Total still reflect roto scoring.`
+                  : 'Each category cell shows the team\'s rank within that category. Click column headers to sort.'}
               </p>
             </div>
             <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
@@ -209,27 +213,27 @@ const Rankings = () => {
                 </div>
               </div>
               <div className="flex flex-col gap-1 items-start sm:items-end">
-                <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">Display</span>
+                <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">Category Cells</span>
                 <div className="flex gap-2">
                   <button
-                    onClick={() => handleDisplayChange('ranked')}
+                    onClick={() => setCellValues('actual')}
                     className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-                      isRanked
+                      isActualValues
                         ? 'bg-white text-blue-700'
                         : 'bg-blue-500 text-white hover:bg-blue-400'
                     }`}
                   >
-                    Ranked
+                    Actual Values
                   </button>
                   <button
-                    onClick={() => handleDisplayChange('raw')}
+                    onClick={() => setCellValues('category_rank')}
                     className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-                      !isRanked
+                      !isActualValues
                         ? 'bg-white text-blue-700'
                         : 'bg-blue-500 text-white hover:bg-blue-400'
                     }`}
                   >
-                    Raw
+                    Category Rank
                   </button>
                 </div>
               </div>
@@ -343,11 +347,9 @@ const Rankings = () => {
             <tbody className="bg-white divide-y divide-gray-200">
               {rankings.map((team: RankingStats, index: number) => (
                 <tr key={team.team.team_id} className="hover:bg-blue-50 transition-colors duration-150 border-b border-gray-100">
-                  {isRanked && (
-                    <td className="table-cell font-bold text-blue-600">
-                      #{team.rank || index + 1}
-                    </td>
-                  )}
+                  <td className="table-cell font-bold text-blue-600">
+                    #{team.rank || index + 1}
+                  </td>
                   <td className="table-cell">
                     <Link
                       to={`/team/${team.team.team_id}`}
@@ -356,10 +358,13 @@ const Rankings = () => {
                       {team.team.team_name}
                     </Link>
                   </td>
-                  {columns.slice(isRanked ? 2 : 1).map((column) => {
-                    const value = team[column.key as keyof RankingStats] as number
+                  {columns.slice(2).map((column) => {
+                    const categoryKey = CATEGORY_KEY_MAP[column.key]
+                    const value = (categoryKey && !isActualValues)
+                      ? team.category_ranks?.[categoryKey]
+                      : (team[column.key as keyof RankingStats] as number)
                     const formatValue = (val: number) => {
-                      if (column.key === 'gp') return val
+                      if (column.key === 'gp' || (categoryKey && !isActualValues)) return val
                       return val % 1 === 0 ? val.toString() : val.toFixed(1)
                     }
                     return (

--- a/frontend/src/pages/Rankings.tsx
+++ b/frontend/src/pages/Rankings.tsx
@@ -15,6 +15,7 @@ const Rankings = () => {
   const [sortBy, setSortBy] = useState<string>('total_points')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [mode, setMode] = useState<'averages' | 'totals'>('averages')
+  const [display, setDisplay] = useState<'ranked' | 'raw'>('ranked')
   const [startDate, setStartDate] = useState<string>('')
   const [endDate, setEndDate] = useState<string>('')
   const [dateError, setDateError] = useState<string>('')
@@ -59,6 +60,17 @@ const Rankings = () => {
     setAppliedDates({})
   }
 
+  const handleDisplayChange = (next: 'ranked' | 'raw') => {
+    setDisplay(next)
+    if (next === 'raw' && (sortBy === 'rank' || sortBy === 'total_points')) {
+      setSortBy('team')
+      setSortOrder('asc')
+    } else if (next === 'ranked' && sortBy === 'team') {
+      setSortBy('total_points')
+      setSortOrder('desc')
+    }
+  }
+
   const handleSort = (column: string) => {
     if (sortBy === column) {
       setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
@@ -93,8 +105,10 @@ const Rankings = () => {
     return 0
   })
 
+  const isRanked = display === 'ranked'
+
   const columns = [
-    { key: 'rank', label: 'Rank', sortable: true },
+    ...(isRanked ? [{ key: 'rank', label: 'Rank', sortable: true }] : []),
     { key: 'team', label: 'Team', sortable: true },
     { key: 'fg_percentage', label: 'FG%', sortable: true },
     { key: 'ft_percentage', label: 'FT%', sortable: true },
@@ -104,9 +118,12 @@ const Rankings = () => {
     { key: 'stl', label: 'STL', sortable: true },
     { key: 'blk', label: 'BLK', sortable: true },
     { key: 'pts', label: 'PTS', sortable: true },
-    { key: 'total_points', label: 'Total', sortable: true },
+    ...(isRanked ? [{ key: 'total_points', label: 'Total', sortable: true }] : []),
     { key: 'gp', label: 'GP', sortable: true },
   ]
+
+  const titleWord = isRanked ? 'Rankings' : 'Standings'
+  const modeLabel = mode === 'averages' ? 'Averages' : 'Totals'
 
   const hasDateMismatch = data && isDateRangeActive && (
     (data.actual_start_date && data.actual_start_date !== data.date_range_start) ||
@@ -148,7 +165,7 @@ const Rankings = () => {
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <div>
               <h2 className="text-2xl font-bold text-white">
-                Team Rankings ({mode === 'averages' ? 'Averages' : 'Totals'})
+                Team {titleWord} ({modeLabel})
                 {isDateRangeActive && (
                   <span className="ml-2 text-lg font-normal text-blue-100">
                     – {formatDate(appliedDates.startDate!)} - {formatDate(appliedDates.endDate!)}
@@ -156,32 +173,66 @@ const Rankings = () => {
                 )}
               </h2>
               <p className="text-blue-100 mt-1">
-                {mode === 'averages'
-                  ? 'Click column headers to sort. Total points calculated from category rankings.'
-                  : 'Totals mode: raw accumulated stats for the period.'}
+                {isRanked
+                  ? (mode === 'averages'
+                      ? 'Click column headers to sort. Total points calculated from category rankings.'
+                      : 'Totals mode: raw accumulated stats, ranked by total roto score.')
+                  : (mode === 'averages'
+                      ? 'Per-game averages, exactly as tracked — no roto scoring applied.'
+                      : 'Season-to-date category totals, exactly as ESPN reports them — no roto scoring, no computed rank.')}
               </p>
             </div>
-            <div className="flex gap-2 shrink-0">
-              <button
-                onClick={() => setMode('averages')}
-                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-                  mode === 'averages'
-                    ? 'bg-white text-blue-700'
-                    : 'bg-blue-500 text-white hover:bg-blue-400'
-                }`}
-              >
-                Averages
-              </button>
-              <button
-                onClick={() => setMode('totals')}
-                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-                  mode === 'totals'
-                    ? 'bg-white text-blue-700'
-                    : 'bg-blue-500 text-white hover:bg-blue-400'
-                }`}
-              >
-                Totals
-              </button>
+            <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
+              <div className="flex flex-col gap-1 items-start sm:items-end">
+                <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">Values</span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setMode('averages')}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      mode === 'averages'
+                        ? 'bg-white text-blue-700'
+                        : 'bg-blue-500 text-white hover:bg-blue-400'
+                    }`}
+                  >
+                    Averages
+                  </button>
+                  <button
+                    onClick={() => setMode('totals')}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      mode === 'totals'
+                        ? 'bg-white text-blue-700'
+                        : 'bg-blue-500 text-white hover:bg-blue-400'
+                    }`}
+                  >
+                    Totals
+                  </button>
+                </div>
+              </div>
+              <div className="flex flex-col gap-1 items-start sm:items-end">
+                <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">Display</span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleDisplayChange('ranked')}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      isRanked
+                        ? 'bg-white text-blue-700'
+                        : 'bg-blue-500 text-white hover:bg-blue-400'
+                    }`}
+                  >
+                    Ranked
+                  </button>
+                  <button
+                    onClick={() => handleDisplayChange('raw')}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      !isRanked
+                        ? 'bg-white text-blue-700'
+                        : 'bg-blue-500 text-white hover:bg-blue-400'
+                    }`}
+                  >
+                    Raw
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
 
@@ -292,9 +343,11 @@ const Rankings = () => {
             <tbody className="bg-white divide-y divide-gray-200">
               {rankings.map((team: RankingStats, index: number) => (
                 <tr key={team.team.team_id} className="hover:bg-blue-50 transition-colors duration-150 border-b border-gray-100">
-                  <td className="table-cell font-bold text-blue-600">
-                    #{team.rank || index + 1}
-                  </td>
+                  {isRanked && (
+                    <td className="table-cell font-bold text-blue-600">
+                      #{team.rank || index + 1}
+                    </td>
+                  )}
                   <td className="table-cell">
                     <Link
                       to={`/team/${team.team.team_id}`}
@@ -303,7 +356,7 @@ const Rankings = () => {
                       {team.team.team_name}
                     </Link>
                   </td>
-                  {columns.slice(2).map((column) => {
+                  {columns.slice(isRanked ? 2 : 1).map((column) => {
                     const value = team[column.key as keyof RankingStats] as number
                     const formatValue = (val: number) => {
                       if (column.key === 'gp') return val

--- a/frontend/src/pages/Rankings.tsx
+++ b/frontend/src/pages/Rankings.tsx
@@ -22,11 +22,18 @@ const CATEGORY_KEY_MAP: Record<string, string> = {
   pts: 'PTS',
 }
 
+const PERCENTAGE_CATEGORIES = new Set(['FG%', 'FT%'])
+
+// Matches the heatmap's category-cell formatting (Analytics.tsx) so the same
+// stat reads identically in both places: 4 decimal places, percentages scaled to 0-100.
+const formatAverageValue = (categoryKey: string, val: number) =>
+  PERCENTAGE_CATEGORIES.has(categoryKey) ? (val * 100).toFixed(4) + '%' : val.toFixed(4)
+
 const Rankings = () => {
   const [sortBy, setSortBy] = useState<string>('total_points')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
   const [mode, setMode] = useState<'averages' | 'totals'>('averages')
-  const [cellValues, setCellValues] = useState<'actual' | 'category_rank'>('actual')
+  const [viewMode, setViewMode] = useState<'standings' | 'rankings'>('rankings')
   const [startDate, setStartDate] = useState<string>('')
   const [endDate, setEndDate] = useState<string>('')
   const [dateError, setDateError] = useState<string>('')
@@ -94,7 +101,7 @@ const Rankings = () => {
 
   const getSortValue = (team: RankingStats) => {
     const categoryKey = CATEGORY_KEY_MAP[sortBy]
-    if (categoryKey && cellValues === 'category_rank') {
+    if (categoryKey && viewMode === 'rankings') {
       return team.category_ranks?.[categoryKey]
     }
     return team[sortBy as keyof RankingStats]
@@ -113,7 +120,7 @@ const Rankings = () => {
     return 0
   })
 
-  const isActualValues = cellValues === 'actual'
+  const isStandings = viewMode === 'standings'
 
   const columns = [
     { key: 'rank', label: 'Rank', sortable: true },
@@ -130,7 +137,7 @@ const Rankings = () => {
     { key: 'gp', label: 'GP', sortable: true },
   ]
 
-  const titleWord = isActualValues ? 'Standings' : 'Rankings'
+  const titleWord = isStandings ? 'Standings' : 'Rankings'
   const modeLabel = mode === 'averages' ? 'Averages' : 'Totals'
 
   const hasDateMismatch = data && isDateRangeActive && (
@@ -181,12 +188,37 @@ const Rankings = () => {
                 )}
               </h2>
               <p className="text-blue-100 mt-1">
-                {isActualValues
+                {isStandings
                   ? `${mode === 'averages' ? 'Per-game averages' : 'Season totals'}, exactly as ESPN reports them. Rank and Total still reflect roto scoring.`
                   : 'Each category cell shows the team\'s rank within that category. Click column headers to sort.'}
               </p>
             </div>
             <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
+              <div className="flex flex-col gap-1 items-start sm:items-end">
+                <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">View Mode</span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setViewMode('standings')}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      isStandings
+                        ? 'bg-white text-blue-700'
+                        : 'bg-blue-500 text-white hover:bg-blue-400'
+                    }`}
+                  >
+                    Standings
+                  </button>
+                  <button
+                    onClick={() => setViewMode('rankings')}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      !isStandings
+                        ? 'bg-white text-blue-700'
+                        : 'bg-blue-500 text-white hover:bg-blue-400'
+                    }`}
+                  >
+                    Rankings
+                  </button>
+                </div>
+              </div>
               <div className="flex flex-col gap-1 items-start sm:items-end">
                 <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">Values</span>
                 <div className="flex gap-2">
@@ -209,31 +241,6 @@ const Rankings = () => {
                     }`}
                   >
                     Totals
-                  </button>
-                </div>
-              </div>
-              <div className="flex flex-col gap-1 items-start sm:items-end">
-                <span className="text-xs font-semibold uppercase tracking-wide text-blue-100">Category Cells</span>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => setCellValues('actual')}
-                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-                      isActualValues
-                        ? 'bg-white text-blue-700'
-                        : 'bg-blue-500 text-white hover:bg-blue-400'
-                    }`}
-                  >
-                    Actual Values
-                  </button>
-                  <button
-                    onClick={() => setCellValues('category_rank')}
-                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-                      !isActualValues
-                        ? 'bg-white text-blue-700'
-                        : 'bg-blue-500 text-white hover:bg-blue-400'
-                    }`}
-                  >
-                    Category Rank
                   </button>
                 </div>
               </div>
@@ -360,16 +367,27 @@ const Rankings = () => {
                   </td>
                   {columns.slice(2).map((column) => {
                     const categoryKey = CATEGORY_KEY_MAP[column.key]
-                    const value = (categoryKey && !isActualValues)
+                    const isCategoryColumn = !!categoryKey
+                    const value = (isCategoryColumn && !isStandings)
                       ? team.category_ranks?.[categoryKey]
                       : (team[column.key as keyof RankingStats] as number)
-                    const formatValue = (val: number) => {
-                      if (column.key === 'gp' || (categoryKey && !isActualValues)) return val
-                      return val % 1 === 0 ? val.toString() : val.toFixed(1)
+
+                    let display: string | number | undefined = value
+                    if (typeof value === 'number') {
+                      if (isCategoryColumn && !isStandings) {
+                        display = value
+                      } else if (isCategoryColumn && isStandings && mode === 'averages') {
+                        display = formatAverageValue(categoryKey, value)
+                      } else if (column.key === 'gp') {
+                        display = value
+                      } else {
+                        display = value % 1 === 0 ? value.toString() : value.toFixed(1)
+                      }
                     }
+
                     return (
                       <td key={column.key} className={`table-cell font-medium ${column.key === 'gp' ? 'border-l-2 border-gray-300' : ''}`}>
-                        {typeof value === 'number' ? formatValue(value) : value}
+                        {display}
                       </td>
                     )
                   })}

--- a/frontend/src/pages/__tests__/Rankings.test.tsx
+++ b/frontend/src/pages/__tests__/Rankings.test.tsx
@@ -1,0 +1,131 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RankingStats } from '../../types/api';
+import { renderWithProviders } from '../../test/helpers';
+import Rankings from '../Rankings';
+
+function team(overrides: Partial<RankingStats> = {}): RankingStats {
+  return {
+    team: { team_id: 1, team_name: 'Alpha Squad' },
+    fg_percentage: 0.5,
+    ft_percentage: 0.8,
+    three_pm: 100,
+    ast: 200,
+    reb: 300,
+    stl: 40,
+    blk: 20,
+    pts: 1000,
+    gp: 50,
+    total_points: 8,
+    rank: 1,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return (input as Request).url;
+}
+
+describe('Rankings page', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = requestUrl(input);
+        if (url.includes('/rankings')) {
+          return jsonResponse({
+            averages_rankings: [
+              team({ team: { team_id: 1, team_name: 'Alpha Squad' }, rank: 1, total_points: 8 }),
+              team({ team: { team_id: 2, team_name: 'Beta Ballers' }, rank: 2, total_points: 4, pts: 500 }),
+            ],
+            totals_rankings: [
+              team({ team: { team_id: 1, team_name: 'Alpha Squad' }, rank: 2, total_points: 4, pts: 4000 }),
+              team({ team: { team_id: 2, team_name: 'Beta Ballers' }, rank: 1, total_points: 8, pts: 9000 }),
+            ],
+            categories: ['pts', 'reb', 'ast'],
+            last_updated: '2026-08-19',
+          });
+        }
+        if (url.includes('/league/summary')) {
+          return jsonResponse({ nba_avg_pace: 100, nba_game_days_left: 30, season_start: '2025-10-01' });
+        }
+        return new Response('not found', { status: 404 });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to Rankings (Averages) with rank and total columns', async () => {
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+    expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /^total/i })).toBeInTheDocument();
+  });
+
+  it('switching Display to Raw drops rank/total columns and retitles to Standings', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /^raw$/i }));
+
+    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: /rank/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: /^total$/i })).not.toBeInTheDocument();
+    const table = screen.getByRole('table');
+    const dataRows = within(table).getAllByRole('row').slice(1);
+    expect(dataRows[0]).toHaveTextContent('Alpha Squad');
+    expect(within(dataRows[0]).queryByText(/^#/)).not.toBeInTheDocument();
+  });
+
+  it('Totals x Raw shows Team Standings (Totals) using raw totals values', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /^totals$/i }));
+    await user.click(screen.getByRole('button', { name: /^raw$/i }));
+
+    expect(screen.getByText('Team Standings (Totals)')).toBeInTheDocument();
+    const table = screen.getByRole('table');
+    const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
+    expect(within(alphaRow).getByText('4000')).toBeInTheDocument();
+  });
+
+  it('Ranked x Totals shows Team Rankings (Totals)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /^totals$/i }));
+
+    expect(screen.getByText('Team Rankings (Totals)')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
+  });
+
+  it('switching back to Ranked restores rank and total columns', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /^raw$/i }));
+    await user.click(screen.getByRole('button', { name: /^ranked$/i }));
+
+    expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/Rankings.test.tsx
+++ b/frontend/src/pages/__tests__/Rankings.test.tsx
@@ -8,7 +8,7 @@ import Rankings from '../Rankings';
 function team(overrides: Partial<RankingStats> = {}): RankingStats {
   return {
     team: { team_id: 1, team_name: 'Alpha Squad' },
-    fg_percentage: 0.5,
+    fg_percentage: 0.467,
     ft_percentage: 0.8,
     three_pm: 100,
     ast: 200,
@@ -51,6 +51,7 @@ describe('Rankings page', () => {
                 rank: 1,
                 total_points: 8,
                 pts: 115.3,
+                fg_percentage: 0.467,
                 category_ranks: { 'FG%': 3, 'FT%': 1, '3PM': 2, AST: 2, REB: 2, STL: 2, BLK: 2, PTS: 2 },
               }),
               team({
@@ -58,6 +59,7 @@ describe('Rankings page', () => {
                 rank: 2,
                 total_points: 4,
                 pts: 121.0,
+                fg_percentage: 0.444,
                 category_ranks: { 'FG%': 1, 'FT%': 3, '3PM': 3, AST: 1, REB: 1, STL: 1, BLK: 3, PTS: 3 },
               }),
             ],
@@ -93,40 +95,50 @@ describe('Rankings page', () => {
     vi.unstubAllGlobals();
   });
 
-  it('defaults to Rankings (Averages) with actual values, rank and total always visible', async () => {
+  it('defaults to Rankings (Averages) with category-rank cells, Rank and Total always visible', async () => {
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
-    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /^total/i })).toBeInTheDocument();
-
-    const table = screen.getByRole('table');
-    const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
-    expect(within(alphaRow).getByText('115.3')).toBeInTheDocument();
-  });
-
-  it('switching to Category Rank shows rank-in-category cells and retitles to Rankings, keeping Rank/Total columns', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Rankings />);
-    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
-
-    await user.click(screen.getByRole('button', { name: /^category rank$/i }));
-
     expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /^total/i })).toBeInTheDocument();
 
     const table = screen.getByRole('table');
     const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
-    // FG% category rank for Alpha is 3, not the actual .5 value
-    expect(within(alphaRow).queryByText('115.3')).not.toBeInTheDocument();
+    // Category rank (3), not the actual pts/fg% value, in the default Rankings view
+    expect(within(alphaRow).queryByText('115.3000')).not.toBeInTheDocument();
   });
 
-  it('Totals x Actual Values shows Team Standings (Totals) using raw totals values', async () => {
+  it('the "View Mode" group offers Standings/Rankings and "Values" offers Averages/Totals', async () => {
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+    expect(screen.getByText('View Mode')).toBeInTheDocument();
+    expect(screen.getByText('Values')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^standings$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^rankings$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^averages$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^totals$/i })).toBeInTheDocument();
+  });
+
+  it('switching to Standings x Averages shows actual values rounded to 4 decimals, like the heatmap', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
 
+    await user.click(screen.getByRole('button', { name: /^standings$/i }));
+
+    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
+    const table = screen.getByRole('table');
+    const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
+    expect(within(alphaRow).getByText('115.3000')).toBeInTheDocument();
+    expect(within(alphaRow).getByText('46.7000%')).toBeInTheDocument();
+  });
+
+  it('Standings x Totals shows raw totals values without the 4-decimal average formatting', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /^standings$/i }));
     await user.click(screen.getByRole('button', { name: /^totals$/i }));
 
     expect(screen.getByText('Team Standings (Totals)')).toBeInTheDocument();
@@ -135,17 +147,17 @@ describe('Rankings page', () => {
     expect(within(alphaRow).getByText('4000')).toBeInTheDocument();
   });
 
-  it('switching back to Actual Values restores real values', async () => {
+  it('switching back to Rankings restores category-rank cells', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
 
-    await user.click(screen.getByRole('button', { name: /^category rank$/i }));
-    await user.click(screen.getByRole('button', { name: /^actual values$/i }));
+    await user.click(screen.getByRole('button', { name: /^standings$/i }));
+    await user.click(screen.getByRole('button', { name: /^rankings$/i }));
 
-    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
+    expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
     const table = screen.getByRole('table');
     const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
-    expect(within(alphaRow).getByText('115.3')).toBeInTheDocument();
+    expect(within(alphaRow).queryByText('115.3000')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/__tests__/Rankings.test.tsx
+++ b/frontend/src/pages/__tests__/Rankings.test.tsx
@@ -19,6 +19,7 @@ function team(overrides: Partial<RankingStats> = {}): RankingStats {
     gp: 50,
     total_points: 8,
     rank: 1,
+    category_ranks: { 'FG%': 2, 'FT%': 2, '3PM': 2, AST: 2, REB: 2, STL: 2, BLK: 2, PTS: 2 },
     ...overrides,
   };
 }
@@ -45,12 +46,36 @@ describe('Rankings page', () => {
         if (url.includes('/rankings')) {
           return jsonResponse({
             averages_rankings: [
-              team({ team: { team_id: 1, team_name: 'Alpha Squad' }, rank: 1, total_points: 8 }),
-              team({ team: { team_id: 2, team_name: 'Beta Ballers' }, rank: 2, total_points: 4, pts: 500 }),
+              team({
+                team: { team_id: 1, team_name: 'Alpha Squad' },
+                rank: 1,
+                total_points: 8,
+                pts: 115.3,
+                category_ranks: { 'FG%': 3, 'FT%': 1, '3PM': 2, AST: 2, REB: 2, STL: 2, BLK: 2, PTS: 2 },
+              }),
+              team({
+                team: { team_id: 2, team_name: 'Beta Ballers' },
+                rank: 2,
+                total_points: 4,
+                pts: 121.0,
+                category_ranks: { 'FG%': 1, 'FT%': 3, '3PM': 3, AST: 1, REB: 1, STL: 1, BLK: 3, PTS: 3 },
+              }),
             ],
             totals_rankings: [
-              team({ team: { team_id: 1, team_name: 'Alpha Squad' }, rank: 2, total_points: 4, pts: 4000 }),
-              team({ team: { team_id: 2, team_name: 'Beta Ballers' }, rank: 1, total_points: 8, pts: 9000 }),
+              team({
+                team: { team_id: 1, team_name: 'Alpha Squad' },
+                rank: 2,
+                total_points: 4,
+                pts: 4000,
+                category_ranks: { 'FG%': 2, 'FT%': 2, '3PM': 2, AST: 2, REB: 2, STL: 2, BLK: 2, PTS: 1 },
+              }),
+              team({
+                team: { team_id: 2, team_name: 'Beta Ballers' },
+                rank: 1,
+                total_points: 8,
+                pts: 9000,
+                category_ranks: { 'FG%': 1, 'FT%': 1, '3PM': 1, AST: 1, REB: 1, STL: 1, BLK: 1, PTS: 2 },
+              }),
             ],
             categories: ['pts', 'reb', 'ast'],
             last_updated: '2026-08-19',
@@ -68,37 +93,41 @@ describe('Rankings page', () => {
     vi.unstubAllGlobals();
   });
 
-  it('defaults to Rankings (Averages) with rank and total columns', async () => {
+  it('defaults to Rankings (Averages) with actual values, rank and total always visible', async () => {
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
-    expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
+    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /^total/i })).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
+    expect(within(alphaRow).getByText('115.3')).toBeInTheDocument();
   });
 
-  it('switching Display to Raw drops rank/total columns and retitles to Standings', async () => {
+  it('switching to Category Rank shows rank-in-category cells and retitles to Rankings, keeping Rank/Total columns', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
 
-    await user.click(screen.getByRole('button', { name: /^raw$/i }));
+    await user.click(screen.getByRole('button', { name: /^category rank$/i }));
 
-    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
-    expect(screen.queryByRole('columnheader', { name: /rank/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('columnheader', { name: /^total$/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /^total/i })).toBeInTheDocument();
+
     const table = screen.getByRole('table');
-    const dataRows = within(table).getAllByRole('row').slice(1);
-    expect(dataRows[0]).toHaveTextContent('Alpha Squad');
-    expect(within(dataRows[0]).queryByText(/^#/)).not.toBeInTheDocument();
+    const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
+    // FG% category rank for Alpha is 3, not the actual .5 value
+    expect(within(alphaRow).queryByText('115.3')).not.toBeInTheDocument();
   });
 
-  it('Totals x Raw shows Team Standings (Totals) using raw totals values', async () => {
+  it('Totals x Actual Values shows Team Standings (Totals) using raw totals values', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
 
     await user.click(screen.getByRole('button', { name: /^totals$/i }));
-    await user.click(screen.getByRole('button', { name: /^raw$/i }));
 
     expect(screen.getByText('Team Standings (Totals)')).toBeInTheDocument();
     const table = screen.getByRole('table');
@@ -106,26 +135,17 @@ describe('Rankings page', () => {
     expect(within(alphaRow).getByText('4000')).toBeInTheDocument();
   });
 
-  it('Ranked x Totals shows Team Rankings (Totals)', async () => {
+  it('switching back to Actual Values restores real values', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Rankings />);
     await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
 
-    await user.click(screen.getByRole('button', { name: /^totals$/i }));
+    await user.click(screen.getByRole('button', { name: /^category rank$/i }));
+    await user.click(screen.getByRole('button', { name: /^actual values$/i }));
 
-    expect(screen.getByText('Team Rankings (Totals)')).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
-  });
-
-  it('switching back to Ranked restores rank and total columns', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Rankings />);
-    await waitFor(() => expect(screen.getByText('Alpha Squad')).toBeInTheDocument());
-
-    await user.click(screen.getByRole('button', { name: /^raw$/i }));
-    await user.click(screen.getByRole('button', { name: /^ranked$/i }));
-
-    expect(screen.getByText('Team Rankings (Averages)')).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: /rank/i })).toBeInTheDocument();
+    expect(screen.getByText('Team Standings (Averages)')).toBeInTheDocument();
+    const table = screen.getByRole('table');
+    const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
+    expect(within(alphaRow).getByText('115.3')).toBeInTheDocument();
   });
 });

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -16,6 +16,7 @@ export interface RankingStats {
   gp: number;
   total_points: number;
   rank?: number;
+  category_ranks?: Record<string, number>;
 }
 
 export interface LeagueRankings {

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.11","results":[[":frontend/src/pages/__tests__/Rankings.test.tsx",{"duration":16.30400499999996,"failed":true}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.11","results":[[":frontend/src/pages/__tests__/Rankings.test.tsx",{"duration":16.30400499999996,"failed":true}]]}


### PR DESCRIPTION
## Summary

Promotes the League Rankings page work from `dev` to `master`: adds a real ESPN-standings view alongside the existing roto rankings, on the same page.

- **View Mode** toggle (Standings / Rankings): "Standings" shows each team's actual per-category stat value; "Rankings" shows the team's rank within that category (previous/only behavior). Rank and Total Points columns are always visible in both modes. Default is Rankings × Averages.
- **Values** toggle (Averages / Totals) is unchanged, now paired with View Mode.
- Backend `/rankings` now returns each team's real per-category value (previously it only returned the rank-substituted value) plus a new `category_ranks` field carrying the rank-in-category.
- Averages "Standings" cells are formatted to 4 decimal places (percentages ×100 with a `%` suffix), matching the heatmap's category-cell formatting.
- Nav entry renamed from "Rankings" / "League Rankings" to "Standings & Rankings" to reflect the page covering both.
- The Team column is now sticky when scrolling the table horizontally, so it stays visible alongside the wide set of category columns.

Squashes PRs #199, #200, #201 (already merged into `dev`) into this promotion to `master`.

## Test plan

- [x] Backend: `uv run pytest` — 536 passed
- [x] Frontend: `npx vitest run` — 183 passed, 3 skipped
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx eslint` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AczKHYLw3oFudjFtvxWPUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AczKHYLw3oFudjFtvxWPUw)_