### PR TITLE
refactor: consolidate roster slot config into one shared constant

### DIFF
--- a/backend/app/services/data_transformer.py
+++ b/backend/app/services/data_transformer.py
@@ -6,11 +6,10 @@ from app.utils.constants import (
 )
 from app.services.stats_calculator import StatsCalculator
 from app.config import settings
+from app.utils.roster_slots import SLOT_CAPS
 
 
 SLOT_MAP = {0: 'PG', 1: 'SG', 2: 'SF', 3: 'PF', 4: 'C', 5: 'G', 6: 'F', 11: 'UTIL'}
-# UTIL is three roster slots plus two spare games (3 * 82 + 2).
-SLOT_CAPS = {'PG': 82, 'SG': 82, 'SF': 82, 'PF': 82, 'C': 82, 'G': 82, 'F': 82, 'UTIL': 248}
 
 
 class DataTransformer:

--- a/backend/app/services/slot_games_estimator.py
+++ b/backend/app/services/slot_games_estimator.py
@@ -1,10 +1,6 @@
 import pandas as pd
 
-SLOT_CAPS = {
-    'PG': 82, 'SG': 82, 'SF': 82, 'PF': 82,
-    'C': 82, 'G': 82, 'F': 82, 'UTIL': 248,
-}
-SLOTS = list(SLOT_CAPS.keys())
+from app.utils.roster_slots import SLOT_CAPS, SLOT_NAMES as SLOTS
 
 
 class SlotGamesEstimator:

--- a/backend/app/services/team_slot_pace.py
+++ b/backend/app/services/team_slot_pace.py
@@ -5,12 +5,11 @@ import pandas as pd
 from app.config import settings
 from app.services.data_provider import DataProvider
 from app.services.nba_stats_service import NBAStatsService
+from app.utils.roster_slots import SLOT_NAMES as _SLOT_NAMES
 
 logger = logging.getLogger(__name__)
 
 _NBA_AVG_PACE_FALLBACK = 65.9
-
-_SLOT_NAMES = ['PG', 'SG', 'SF', 'PF', 'C', 'G', 'F', 'UTIL']
 
 
 async def get_team_slot_pace_df() -> pd.DataFrame:

--- a/backend/app/utils/roster_slots.py
+++ b/backend/app/utils/roster_slots.py
@@ -1,0 +1,10 @@
+"""Shared roster-slot configuration for this league.
+
+Mirrored in frontend/src/utils/slotProjection.ts — keep the two in sync.
+"""
+
+SLOT_CAPS = {
+    'PG': 82, 'SG': 82, 'SF': 82, 'PF': 82,
+    'C': 82, 'G': 82, 'F': 82, 'UTIL': 248,
+}
+SLOT_NAMES = list(SLOT_CAPS.keys())


### PR DESCRIPTION
## Summary
- `SLOT_CAPS`/`SLOT_NAMES` (PG/SG/SF/PF/C/G/F/UTIL, UTIL cap 248) were duplicated across `slot_games_estimator.py`, `team_slot_pace.py`, and `data_transformer.py`, with a comment noting they must be kept in sync manually.
- Consolidated into a single shared `app/utils/roster_slots.py`, imported everywhere else needs it (`response_builder.py` already gets it transitively via `data_transformer`).
- No functional change — same values, single source. First of a stacked PR series toward more generic (multi-format) league support; this part is unrelated to the category work and safe to land independently.

## Test plan
- [x] `uv run pytest -q` — 536 passed, 14 deselected (unchanged from before the refactor)
- [x] Confirmed no remaining inline copies of the slot constants (`grep -rn "SLOT_CAPS\|SLOTS\b" app`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR3E5SAZSkNfMygaeuvt9f)_