### PR TITLE
feat: render Rankings table columns from the API's category list

### DIFF
--- a/frontend/src/pages/Rankings.tsx
+++ b/frontend/src/pages/Rankings.tsx
@@ -11,17 +11,6 @@ import { todayIso, getDateNDaysAgo } from '../utils/dateRange'
 const formatDate = (d: string) =>
   new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 
-const CATEGORY_KEY_MAP: Record<string, string> = {
-  fg_percentage: 'FG%',
-  ft_percentage: 'FT%',
-  three_pm: '3PM',
-  ast: 'AST',
-  reb: 'REB',
-  stl: 'STL',
-  blk: 'BLK',
-  pts: 'PTS',
-}
-
 const PERCENTAGE_CATEGORIES = new Set(['FG%', 'FT%'])
 
 // Matches the heatmap's category-cell formatting (Analytics.tsx) so the same
@@ -99,10 +88,15 @@ const Rankings = () => {
     ? (data?.averages_rankings || [])
     : (data?.totals_rankings || [])
 
+  // This league's actual scoring categories (e.g. FG%, FT%, 3PM, ... or
+  // whatever ESPN's league settings resolve to — see backend
+  // resolve_ranking_categories), in display order. TOTAL_POINTS is handled
+  // separately as the fixed "Total" column.
+  const categoryKeys = (data?.categories || []).filter(c => c !== 'TOTAL_POINTS')
+
   const getSortValue = (team: RankingStats) => {
-    const categoryKey = CATEGORY_KEY_MAP[sortBy]
-    if (categoryKey && viewMode === 'rankings') {
-      return team.category_ranks?.[categoryKey]
+    if (categoryKeys.includes(sortBy)) {
+      return viewMode === 'rankings' ? team.category_ranks?.[sortBy] : team.stats?.[sortBy]
     }
     return team[sortBy as keyof RankingStats]
   }
@@ -125,14 +119,7 @@ const Rankings = () => {
   const columns = [
     { key: 'rank', label: 'Rank', sortable: true },
     { key: 'team', label: 'Team', sortable: true },
-    { key: 'fg_percentage', label: 'FG%', sortable: true },
-    { key: 'ft_percentage', label: 'FT%', sortable: true },
-    { key: 'three_pm', label: '3PM', sortable: true },
-    { key: 'ast', label: 'AST', sortable: true },
-    { key: 'reb', label: 'REB', sortable: true },
-    { key: 'stl', label: 'STL', sortable: true },
-    { key: 'blk', label: 'BLK', sortable: true },
-    { key: 'pts', label: 'PTS', sortable: true },
+    ...categoryKeys.map(key => ({ key, label: key, sortable: true })),
     { key: 'total_points', label: 'Total', sortable: true },
     { key: 'gp', label: 'GP', sortable: true },
   ]
@@ -368,10 +355,9 @@ const Rankings = () => {
                     </Link>
                   </td>
                   {columns.slice(2).map((column) => {
-                    const categoryKey = CATEGORY_KEY_MAP[column.key]
-                    const isCategoryColumn = !!categoryKey
-                    const value = (isCategoryColumn && !isStandings)
-                      ? team.category_ranks?.[categoryKey]
+                    const isCategoryColumn = categoryKeys.includes(column.key)
+                    const value = isCategoryColumn
+                      ? (isStandings ? team.stats?.[column.key] : team.category_ranks?.[column.key])
                       : (team[column.key as keyof RankingStats] as number)
 
                     let display: string | number | undefined = value
@@ -379,7 +365,7 @@ const Rankings = () => {
                       if (isCategoryColumn && !isStandings) {
                         display = value
                       } else if (isCategoryColumn && isStandings && mode === 'averages') {
-                        display = formatAverageValue(categoryKey, value)
+                        display = formatAverageValue(column.key, value)
                       } else if (column.key === 'gp') {
                         display = value
                       } else {

--- a/frontend/src/pages/__tests__/Rankings.test.tsx
+++ b/frontend/src/pages/__tests__/Rankings.test.tsx
@@ -5,8 +5,10 @@ import type { RankingStats } from '../../types/api';
 import { renderWithProviders } from '../../test/helpers';
 import Rankings from '../Rankings';
 
+const ALL_CATEGORIES = ['FG%', 'FT%', '3PM', 'AST', 'REB', 'STL', 'BLK', 'PTS'];
+
 function team(overrides: Partial<RankingStats> = {}): RankingStats {
-  return {
+  const base = {
     team: { team_id: 1, team_name: 'Alpha Squad' },
     fg_percentage: 0.467,
     ft_percentage: 0.8,
@@ -22,6 +24,19 @@ function team(overrides: Partial<RankingStats> = {}): RankingStats {
     category_ranks: { 'FG%': 2, 'FT%': 2, '3PM': 2, AST: 2, REB: 2, STL: 2, BLK: 2, PTS: 2 },
     ...overrides,
   };
+  // `stats` mirrors the fixed fields above by default (as the real API does),
+  // unless the caller supplies its own `stats` override.
+  const stats = overrides.stats ?? {
+    'FG%': base.fg_percentage,
+    'FT%': base.ft_percentage,
+    '3PM': base.three_pm,
+    AST: base.ast,
+    REB: base.reb,
+    STL: base.stl,
+    BLK: base.blk,
+    PTS: base.pts,
+  };
+  return { ...base, stats };
 }
 
 function jsonResponse(body: unknown, status = 200) {
@@ -79,7 +94,7 @@ describe('Rankings page', () => {
                 category_ranks: { 'FG%': 1, 'FT%': 1, '3PM': 1, AST: 1, REB: 1, STL: 1, BLK: 1, PTS: 2 },
               }),
             ],
-            categories: ['pts', 'reb', 'ast'],
+            categories: [...ALL_CATEGORIES, 'TOTAL_POINTS'],
             last_updated: '2026-08-19',
           });
         }
@@ -159,5 +174,54 @@ describe('Rankings page', () => {
     const table = screen.getByRole('table');
     const alphaRow = within(table).getByText('Alpha Squad').closest('tr')!;
     expect(within(alphaRow).queryByText('115.3000')).not.toBeInTheDocument();
+  });
+});
+
+describe('Rankings page — dynamic categories', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = requestUrl(input);
+        if (url.includes('/rankings')) {
+          return jsonResponse({
+            averages_rankings: [
+              team({
+                team: { team_id: 1, team_name: 'Turnover Titans' },
+                rank: 1,
+                total_points: 9,
+                category_ranks: { ...team().category_ranks, TO: 1 },
+                stats: { ...team().stats, TO: 12.5 },
+              }),
+            ],
+            totals_rankings: [],
+            categories: [...ALL_CATEGORIES, 'TO', 'TOTAL_POINTS'],
+            last_updated: '2026-08-19',
+          });
+        }
+        if (url.includes('/league/summary')) {
+          return jsonResponse({ nba_avg_pace: 100, nba_game_days_left: 30, season_start: '2025-10-01' });
+        }
+        return new Response('not found', { status: 404 });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders an extra league category (TO) as its own column, driven by the API categories list', async () => {
+    renderWithProviders(<Rankings />);
+    await waitFor(() => expect(screen.getByText('Turnover Titans')).toBeInTheDocument());
+
+    expect(screen.getByRole('columnheader', { name: 'TO' })).toBeInTheDocument();
+
+    const table = screen.getByRole('table');
+    const row = within(table).getByText('Turnover Titans').closest('tr')!;
+    // Rankings view shows the category *rank* (1), not the raw stat value
+    const toIndex = within(table).getAllByRole('columnheader').findIndex(h => h.textContent?.includes('TO'));
+    const cells = within(row).getAllByRole('cell');
+    expect(cells[toIndex].textContent).toBe('1');
   });
 });

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -17,6 +17,10 @@ export interface RankingStats {
   total_points: number;
   rank?: number;
   category_ranks?: Record<string, number>;
+  /** Generic per-category values keyed by category code (e.g. "PTS", "TO") for
+   * this league's actual scoring categories. Superset of the fixed fields above
+   * for leagues scoring beyond the historical default 8. */
+  stats?: Record<string, number>;
 }
 
 export interface LeagueRankings {
@@ -52,6 +56,8 @@ export interface AverageStats {
   blk: number;
   pts: number;
   gp: number;
+  /** See RankingStats.stats */
+  stats?: Record<string, number>;
 }
 
 export interface TeamAverageStats extends AverageStats {


### PR DESCRIPTION
## Summary
Stacked on #206. Fourth in the series: the Rankings page consumes the generic `categories`/`stats` shape added on the backend, instead of hardcoding the 8-category column set.

- `Rankings.tsx` — `columns` built from `data.categories` (already generic on `LeagueRankings`) instead of a hardcoded array; cell values read from `team.stats`/`team.category_ranks` (both keyed by category code) instead of fixed named fields. Removed the now-unnecessary `CATEGORY_KEY_MAP` indirection.
- `api.ts` — added optional `stats?: Record<string, number>` to `RankingStats`/`AverageStats`, matching the backend's additive change. Existing fixed fields untouched, so nothing else consuming these types needs to change (TeamDetail, league summary widgets, shots — all deferred, as noted in #206).

## Test plan
- [x] Updated `Rankings.test.tsx` fixtures to include `stats` (mirroring the fixed fields, as the real API does) and a correct `categories` list
- [x] New test: an extra league category (TO) renders as its own column, sourced entirely from API data
- [x] Full frontend suite: **184 passed**, 0 failures
- [x] `tsc -b` clean
- [x] **Manually verified with a real browser** (Playwright/Chromium) against the actual running backend (FastAPI, mocked ESPN response for a turnovers-scoring league) and Vite dev server — confirmed the TO column renders correctly in both Rankings and Standings view, in the right position, with zero console/page errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR3E5SAZSkNfMygaeuvt9f)_