### PR TITLE
feat: generic per-category data for the analytics heatmap

### DIFF
--- a/backend/app/builders/response_builder.py
+++ b/backend/app/builders/response_builder.py
@@ -132,11 +132,14 @@ class ResponseBuilder:
     def build_heatmap_response(self, teams: List[Dict], categories: List[List[float]],
                              normalized_data: List[List[float]], ranks_data: List[List[int]],
                              data_date=None, date_range_start=None, date_range_end=None,
-                             actual_start_date=None, actual_end_date=None) -> HeatmapData:
-        """Build HeatmapData response from prepared data"""
+                             actual_start_date=None, actual_end_date=None,
+                             category_labels: Optional[List[str]] = None) -> HeatmapData:
+        """Build HeatmapData response from prepared data. category_labels defaults
+        to RANKING_CATEGORIES + ['GP'] (note: the `categories` param here is the
+        data matrix, not labels — category_labels names each column/row)."""
         team_objects = [Team(team_id=team['team_id'], team_name=team['team_name'])
                        for team in teams]
-        categories_with_gp = RANKING_CATEGORIES + ['GP']
+        categories_with_gp = category_labels or (RANKING_CATEGORIES + ['GP'])
 
         return HeatmapData(
             teams=team_objects,

--- a/backend/app/services/league_service.py
+++ b/backend/app/services/league_service.py
@@ -69,10 +69,11 @@ class LeagueService:
 
         sorted_averages_df = averages_df.set_index('team_id').loc[rankings_df['team_id']].reset_index()
 
+        categories = await self.data_provider.get_ranking_categories()
         teams_data = self._extract_teams_data(sorted_averages_df)
-        categories_data = self._extract_categories_data(sorted_averages_df)
-        normalized_data = self.stats_calculator.normalize_for_heatmap(sorted_averages_df)
-        ranks_data = self._extract_ranks_data(rankings_df, sorted_averages_df)
+        categories_data = self._extract_categories_data(sorted_averages_df, categories)
+        normalized_data = self.stats_calculator.normalize_for_heatmap(sorted_averages_df, categories)
+        ranks_data = self._extract_ranks_data(rankings_df, sorted_averages_df, categories)
 
         return self.response_builder.build_heatmap_response(
             teams=teams_data,
@@ -80,6 +81,7 @@ class LeagueService:
             normalized_data=normalized_data,
             ranks_data=ranks_data,
             data_date=self.data_provider.get_data_date(),
+            category_labels=categories + ['GP'],
         )
 
     async def _get_heatmap_for_range(self, start_date: date, end_date: date) -> HeatmapData:
@@ -172,27 +174,29 @@ class LeagueService:
         return [{'team_id': int(row['team_id']), 'team_name': str(row['team_name'])} 
                 for _, row in averages_df.iterrows()]
     
-    def _extract_categories_data(self, averages_df) -> List:
-        """Extract categories data for heatmap"""
+    def _extract_categories_data(self, averages_df, categories: Optional[List[str]] = None) -> List:
+        """Extract categories data for heatmap. categories defaults to RANKING_CATEGORIES."""
         from app.utils.constants import RANKING_CATEGORIES
-        categories_with_gp = RANKING_CATEGORIES + ['GP']
+        categories_with_gp = (categories or RANKING_CATEGORIES) + ['GP']
         return averages_df[categories_with_gp].values.tolist()
 
-    def _extract_ranks_data(self, rankings_df, averages_df) -> List[List[int]]:
-        """Extract rank data for each team and category"""
+    def _extract_ranks_data(self, rankings_df, averages_df, categories: Optional[List[str]] = None) -> List[List[int]]:
+        """Extract rank data for each team and category. categories defaults to RANKING_CATEGORIES."""
         from app.utils.constants import RANKING_CATEGORIES
+        categories = categories or RANKING_CATEGORIES
 
         team_id_to_ranks = {}
         for _, row in rankings_df.iterrows():
             team_id = int(row['team_id'])
-            ranks = [int(row[cat]) for cat in RANKING_CATEGORIES]
+            ranks = [int(row[cat]) for cat in categories]
             ranks.append(0)
             team_id_to_ranks[team_id] = ranks
 
+        default_ranks = [0] * (len(categories) + 1)
         ranks_data = []
         for _, team_row in averages_df.iterrows():
             team_id = int(team_row['team_id'])
-            ranks_data.append(team_id_to_ranks.get(team_id, [0] * 9))
+            ranks_data.append(team_id_to_ranks.get(team_id, default_ranks))
 
         return ranks_data
 

--- a/backend/tests/services/test_league_service.py
+++ b/backend/tests/services/test_league_service.py
@@ -297,3 +297,67 @@ class TestDynamicCategoriesLeagueSummary:
         # pre-existing, category-agnostic behavior, not something this PR changes.
         assert summary.category_leaders['TO_leader'].team.team_name == 'Alpha'
         assert summary.league_averages.stats['TO'] == pytest.approx((120 / 82 + 90 / 82) / 2)
+
+
+@pytest.mark.real_dataprovider
+class TestDynamicCategoriesHeatmap:
+    """Full pipeline: real DataProvider + DataTransformer + StatsCalculator +
+    ResponseBuilder, only the ESPN HTTP call stubbed, for a turnovers-scoring
+    league via get_heatmap_data()."""
+
+    @staticmethod
+    def _turnovers_league_payload():
+        def team(team_id, name, pts, to):
+            return {
+                "id": team_id,
+                "name": name,
+                "valuesByStat": {
+                    "0": pts, "1": 20, "2": 50, "3": 200, "6": 400,
+                    "13": 400, "14": 850, "15": 150, "16": 200, "17": 100,
+                    "19": 47.1, "20": 75.0, "42": 82, "40": 2000, "11": to,
+                },
+            }
+        return {
+            "scoringPeriodId": 5,
+            "teams": [team(1, "Alpha", 1000, 120), team(2, "Beta", 1100, 90)],
+            "settings": {"scoringSettings": {"scoringItems": [
+                {"statId": sid} for sid in (19, 20, 17, 3, 6, 2, 1, 0, 11)
+            ]}},
+        }
+
+    @pytest_asyncio.fixture
+    async def real_league_service(self):
+        from app.services.data_provider import DataProvider
+
+        DataProvider._instance = None
+        DataProvider._initialized = False
+        service = LeagueService()
+        service.data_provider = DataProvider()
+        service.data_provider.db_service = AsyncMock()
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"ETag": "e1"}
+        resp.json.return_value = self._turnovers_league_payload()
+        resp.raise_for_status = MagicMock()
+        service.data_provider._client.get = AsyncMock(return_value=resp)
+
+        yield service
+        DataProvider._instance = None
+        DataProvider._initialized = False
+
+    @pytest.mark.asyncio
+    async def test_heatmap_includes_turnovers_column(self, real_league_service):
+        heatmap = await real_league_service.get_heatmap_data()
+
+        assert 'TO' in heatmap.categories
+        to_index = heatmap.categories.index('TO')
+        # data/normalized_data/ranks_data are positional matrices aligned to categories
+        for row in heatmap.data:
+            assert len(row) == len(heatmap.categories)
+        assert heatmap.ranks_data is not None
+        for row in heatmap.ranks_data:
+            assert len(row) == len(heatmap.categories)
+        # sanity: the TO column values are the actual per-game TO averages
+        to_values = sorted(row[to_index] for row in heatmap.data)
+        assert to_values == sorted([120 / 82, 90 / 82])


### PR DESCRIPTION
## Summary
Stacked on #208. Sixth in the series: extends generic categories to the analytics heatmap (current-standings path only; the date-range/DB path stays on the fixed default, same policy as the rest of this series).

- `league_service.py` — `_extract_categories_data`, `_extract_ranks_data`, and the `normalize_for_heatmap` call take/receive resolved categories instead of the hardcoded constant.
- `response_builder.py` — `build_heatmap_response` takes an optional `category_labels` param (default `RANKING_CATEGORIES + ['GP']`).

**No frontend changes needed** — `Analytics.tsx`'s heatmap already renders columns generically from `heatmapData.categories` (positional `data`/`normalized_data`/`ranks_data` arrays indexed against it), not hardcoded. It was already fully dynamic on the frontend side; it was just being fed a fixed category list from the backend until now.

## Test plan
- [x] New end-to-end test through the **real (unmocked)** `DataProvider → DataTransformer → StatsCalculator → ResponseBuilder` pipeline for a turnovers-scoring league via `get_heatmap_data()`
- [x] Manually verified via **FastAPI `TestClient`** hitting the real `/api/analytics/heatmap` route: `TO` appears correctly in `categories`, with `data`/`ranks_data` rows of matching length
- [x] Full backend suite: **572 passed**, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR3E5SAZSkNfMygaeuvt9f)_