### PR TITLE
fix: correctly rank reverse-scored categories (e.g. turnovers)

### DIFF
--- a/backend/app/services/data_provider.py
+++ b/backend/app/services/data_provider.py
@@ -316,6 +316,17 @@ class DataProvider:
             return list(RANKING_CATEGORIES)
         return self.data_transformer.resolve_ranking_categories(raw)
 
+    async def get_reverse_categories(self) -> set:
+        """Get this league's reverse-scored categories (lower raw value = better,
+        e.g. turnovers), resolved from ESPN's settings via each scoringItem's
+        isReverseItem flag. Falls back to an empty set (no known reverse
+        categories) if settings are unavailable — same caching contract as
+        get_ranking_categories."""
+        raw = self.cache_manager.totals_cache.get('raw')
+        if not raw:
+            return set()
+        return self.data_transformer.resolve_reverse_categories(raw)
+
     async def get_averages_df(self) -> pd.DataFrame:
         """Get averages DataFrame with caching"""
         totals_df = await self.get_totals_df()
@@ -325,14 +336,16 @@ class DataProvider:
     async def get_rankings_df(self) -> pd.DataFrame:
         """Get rankings DataFrame with caching"""
         averages_df = await self.get_averages_df()
-        return self.data_transformer.averages_to_rankings_df(averages_df)
+        reverse_categories = await self.get_reverse_categories()
+        return self.data_transformer.averages_to_rankings_df(averages_df, reverse_categories)
 
     async def get_all_dataframes(self) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """Get all three main DataFrames at once (optimized for endpoints that need multiple)"""
         totals_df = await self.get_totals_df()
         categories = await self.get_ranking_categories()
+        reverse_categories = await self.get_reverse_categories()
         averages_df = self.data_transformer.totals_to_averages_df(totals_df, categories)
-        rankings_df = self.data_transformer.averages_to_rankings_df(averages_df)
+        rankings_df = self.data_transformer.averages_to_rankings_df(averages_df, reverse_categories)
 
         return totals_df, averages_df, rankings_df
     

--- a/backend/app/services/data_transformer.py
+++ b/backend/app/services/data_transformer.py
@@ -46,6 +46,26 @@ class DataTransformer:
             self.logger.warning(f"Error resolving ranking categories from ESPN settings, using default: {e}")
             return list(RANKING_CATEGORIES)
 
+    def resolve_reverse_categories(self, espn_data: Dict) -> set:
+        """Determine which of this league's categories are reverse-scored
+        (lower raw value = better, e.g. turnovers) from ESPN's
+        settings.scoringSettings.scoringItems[].isReverseItem flag. Falls back
+        to an empty set (no known reverse categories) on missing/unparseable
+        settings — same fixed-default posture as resolve_ranking_categories."""
+        try:
+            scoring_items = espn_data.get('settings', {}).get('scoringSettings', {}).get('scoringItems', [])
+            reverse: set = set()
+            for item in scoring_items:
+                if not item.get('isReverseItem'):
+                    continue
+                category = STAT_ID_TO_CATEGORY.get(item.get('statId'))
+                if category and category not in NON_RANKING_STAT_KEYS:
+                    reverse.add(category)
+            return reverse
+        except Exception as e:
+            self.logger.warning(f"Error resolving reverse categories from ESPN settings, using none: {e}")
+            return set()
+
     def parse_slot_usage(self, espn_data: Dict) -> Dict[int, Dict[str, int]]:
         """Parse slot usage from mMatchupScore data. Returns {team_id: {slot_name: games_used}}"""
         result: Dict[int, Dict[str, int]] = {}
@@ -251,15 +271,17 @@ class DataTransformer:
         """
         return self.stats_calculator.calculate_per_game_averages(totals_df, categories)
     
-    def averages_to_rankings_df(self, averages_df: pd.DataFrame) -> pd.DataFrame:
+    def averages_to_rankings_df(self, averages_df: pd.DataFrame, reverse_categories: set = None) -> pd.DataFrame:
         """
         Calculate rankings from averages DataFrame
         Args:
             averages_df: DataFrame with per-game averages
+            reverse_categories: category codes where a lower raw value is better
+                                 (e.g. turnovers) — see resolve_reverse_categories
         Returns:
             DataFrame with rankings and total points
         """
-        return self.stats_calculator.calculate_rankings(averages_df)
+        return self.stats_calculator.calculate_rankings(averages_df, reverse_categories)
     
     def _extract_player_stats(self, entry: Dict, team_id: int, stat_split_type_id: int = 0) -> Dict:
         """Extract player stats from ESPN API data"""

--- a/backend/app/services/league_service.py
+++ b/backend/app/services/league_service.py
@@ -27,7 +27,8 @@ class LeagueService:
             raise ResourceNotFoundError("Unable to fetch averages data from ESPN API")
 
         categories = await self.data_provider.get_ranking_categories()
-        category_leaders = self._calculate_category_leaders(averages_df, categories)
+        reverse_categories = await self.data_provider.get_reverse_categories()
+        category_leaders = self._calculate_category_leaders(averages_df, categories, reverse_categories)
         league_averages = self._calculate_league_averages(averages_df, categories)
 
         nba_avg_pace = None
@@ -70,9 +71,10 @@ class LeagueService:
         sorted_averages_df = averages_df.set_index('team_id').loc[rankings_df['team_id']].reset_index()
 
         categories = await self.data_provider.get_ranking_categories()
+        reverse_categories = await self.data_provider.get_reverse_categories()
         teams_data = self._extract_teams_data(sorted_averages_df)
         categories_data = self._extract_categories_data(sorted_averages_df, categories)
-        normalized_data = self.stats_calculator.normalize_for_heatmap(sorted_averages_df, categories)
+        normalized_data = self.stats_calculator.normalize_for_heatmap(sorted_averages_df, categories, reverse_categories)
         ranks_data = self._extract_ranks_data(rankings_df, sorted_averages_df, categories)
 
         return self.response_builder.build_heatmap_response(
@@ -153,9 +155,10 @@ class LeagueService:
             shots_data, data_date=self.data_provider.get_data_date()
         )
     
-    def _calculate_category_leaders(self, averages_df, categories: Optional[List[str]] = None) -> Dict[str, RankingStats]:
+    def _calculate_category_leaders(self, averages_df, categories: Optional[List[str]] = None,
+                                  reverse_categories: Optional[set] = None) -> Dict[str, RankingStats]:
         """Calculate category leaders (business logic). categories defaults to RANKING_CATEGORIES."""
-        leaders_data = self.stats_calculator.find_category_leaders(averages_df, categories)
+        leaders_data = self.stats_calculator.find_category_leaders(averages_df, categories, reverse_categories)
         category_leaders = {}
 
         for category, data in leaders_data.items():

--- a/backend/app/services/ranking_service.py
+++ b/backend/app/services/ranking_service.py
@@ -29,7 +29,8 @@ class RankingService:
             raise ResourceNotFoundError("Unable to fetch rankings data from ESPN API")
 
         categories = await self.data_provider.get_ranking_categories()
-        totals_raw_df, totals_rankings_df = self._build_totals_rankings_df(totals_df, categories)
+        reverse_categories = await self.data_provider.get_reverse_categories()
+        totals_raw_df, totals_rankings_df = self._build_totals_rankings_df(totals_df, categories, reverse_categories)
 
         if sort_by is not None and not self._is_valid_sort_column(sort_by, averages_rankings_df):
             raise InvalidParameterError(f"Invalid sort column: {sort_by}")
@@ -147,7 +148,8 @@ class RankingService:
         return df, transformer.averages_to_rankings_df(df)
 
     def _build_totals_rankings_df(self, totals_df: pd.DataFrame,
-                                   categories: Optional[list[str]] = None) -> tuple[pd.DataFrame, pd.DataFrame]:
+                                   categories: Optional[list[str]] = None,
+                                   reverse_categories: Optional[set] = None) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Build (raw totals, rankings) DataFrames from season totals (no per-game division).
         categories defaults to RANKING_CATEGORIES."""
         from app.services.data_transformer import DataTransformer
@@ -156,7 +158,7 @@ class RankingService:
         categories = categories or RANKING_CATEGORIES
         cols_to_keep = ['team_id', 'team_name', 'GP'] + [c for c in categories if c in totals_df.columns]
         df = totals_df[[c for c in cols_to_keep if c in totals_df.columns]].copy()
-        return df, transformer.averages_to_rankings_df(df)
+        return df, transformer.averages_to_rankings_df(df, reverse_categories)
 
     def _is_valid_sort_column(self, sort_by: str, rankings_df) -> bool:
         return sort_by.upper() in rankings_df.columns

--- a/backend/app/services/stats_calculator.py
+++ b/backend/app/services/stats_calculator.py
@@ -6,26 +6,37 @@ from app.utils.constants import RANKING_CATEGORIES, PERCENTAGE_CATEGORIES
 class StatsCalculator:
     """Pure statistical calculations and derived metrics"""
     
-    def calculate_rankings(self, averages_df: pd.DataFrame) -> pd.DataFrame:
+    def calculate_rankings(self, averages_df: pd.DataFrame, reverse_categories: Optional[set] = None) -> pd.DataFrame:
         """
         Calculate rankings from averages DataFrame
         Args:
             averages_df: DataFrame with per-game averages
+            reverse_categories: category codes where a lower raw value scores
+                                 better (e.g. turnovers) — that column is ranked
+                                 with the worst raw value getting the lowest score,
+                                 instead of the default "higher raw value wins"
         Returns:
             DataFrame with rankings and total points
         """
         if averages_df.empty:
             raise ValueError("Cannot calculate rankings for empty DataFrame")
-        
+
         ranked = averages_df.copy()
+        reverse_categories = reverse_categories or set()
 
         # Keep team_id, team_name, and GP for reference
         ranking_cols = [col for col in ranked.columns if col not in ['team_id', 'team_name', 'GP']]
         team_info = ranked[['team_id', 'team_name', 'GP']].copy()
 
-        # Calculate rankings only for statistical categories
-        ranked_stats = ranked[ranking_cols].rank()
-        
+        # Calculate rankings only for statistical categories. Each column's
+        # score increases with "better" performance in that category: for a
+        # normal category that means the highest raw value scores highest
+        # (ascending=True); for a reverse category (e.g. turnovers) the lowest
+        # raw value should score highest, so that column ranks ascending=False.
+        ranked_stats = pd.DataFrame(index=ranked.index)
+        for col in ranking_cols:
+            ranked_stats[col] = ranked[col].rank(ascending=col not in reverse_categories)
+
         # Add total points
         ranked_stats['TOTAL_POINTS'] = ranked_stats.sum(axis=1)
         
@@ -46,12 +57,15 @@ class StatsCalculator:
 
         return final_ranked
     
-    def find_category_leaders(self, averages_df: pd.DataFrame, categories: Optional[List[str]] = None) -> Dict:
+    def find_category_leaders(self, averages_df: pd.DataFrame, categories: Optional[List[str]] = None,
+                            reverse_categories: Optional[set] = None) -> Dict:
         """
         Find the leader in each statistical category
         Args:
             averages_df: DataFrame with per-game averages
             categories: category codes to report leaders for (defaults to RANKING_CATEGORIES)
+            reverse_categories: category codes where the lowest raw value is the
+                                 leader (e.g. turnovers), instead of the highest
         Returns:
             Dictionary with category leaders
         """
@@ -59,14 +73,20 @@ class StatsCalculator:
             return {}
 
         leaders = {}
+        reverse_categories = reverse_categories or set()
 
         for category in (categories or RANKING_CATEGORIES):
             if category in averages_df.columns:
                 if averages_df[category].isnull().all():
                     continue
 
-                # Find team with highest value in this category
-                best_team_idx = averages_df[category].idxmax()
+                # Find the best-performing team in this category: highest raw
+                # value, unless it's a reverse category (e.g. turnovers) where
+                # the lowest raw value is the leader.
+                best_team_idx = (
+                    averages_df[category].idxmin() if category in reverse_categories
+                    else averages_df[category].idxmax()
+                )
                 best_team_row = averages_df.iloc[best_team_idx]
                 best_value = best_team_row[category]
                 
@@ -98,13 +118,17 @@ class StatsCalculator:
 
         return league_stats
 
-    def normalize_for_heatmap(self, averages_df: pd.DataFrame, categories: Optional[List[str]] = None) -> List[List[float]]:
+    def normalize_for_heatmap(self, averages_df: pd.DataFrame, categories: Optional[List[str]] = None,
+                            reverse_categories: Optional[set] = None) -> List[List[float]]:
         """
         Normalize data for heatmap visualization using diverging scale
         centered on the league average (average = 0.5 = white)
         Args:
             averages_df: DataFrame with per-game averages
             categories: category codes to include (defaults to RANKING_CATEGORIES)
+            reverse_categories: category codes where a lower raw value is better
+                                 (e.g. turnovers) — colored inverted so "better"
+                                 always reads as the same end of the scale
         Returns:
             Normalized data matrix for heatmap
         """
@@ -113,6 +137,7 @@ class StatsCalculator:
 
         normalized_data = []
         categories_with_gp = (categories or RANKING_CATEGORIES) + ['GP']
+        reverse_categories = reverse_categories or set()
 
         for category in categories_with_gp:
             if category in averages_df.columns:
@@ -133,6 +158,8 @@ class StatsCalculator:
                                 norm_val = 0.5 + 0.5 * (val - mean_val) / (max_val - mean_val)
                             else:
                                 norm_val = 0.5
+                        if category in reverse_categories:
+                            norm_val = 1.0 - norm_val
                         normalized_col.append(norm_val)
                 else:
                     normalized_col = [0.5] * len(col_data)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -140,6 +140,9 @@ class MockDataProvider:
         from app.utils.constants import RANKING_CATEGORIES
         return list(RANKING_CATEGORIES)
 
+    async def get_reverse_categories(self):
+        return set()
+
     async def get_slot_usage(self):
         return {}
 

--- a/backend/tests/services/test_data_transformer.py
+++ b/backend/tests/services/test_data_transformer.py
@@ -333,3 +333,37 @@ class TestRawStandingsToTotalsDynamicCategories:
         }]}
         df = transformer.raw_standings_to_totals_df(payload)
         assert "TO" not in df.columns
+
+
+class TestResolveReverseCategories:
+    def test_no_settings_returns_empty_set(self, transformer):
+        assert transformer.resolve_reverse_categories({}) == set()
+
+    def test_reverse_item_flagged_true_included(self, transformer):
+        payload = {"settings": {"scoringSettings": {"scoringItems": [
+            {"statId": 0, "isReverseItem": False},
+            {"statId": 11, "isReverseItem": True},
+        ]}}}
+        assert transformer.resolve_reverse_categories(payload) == {"TO"}
+
+    def test_no_reverse_items_returns_empty_set(self, transformer):
+        payload = {"settings": {"scoringSettings": {"scoringItems": [
+            {"statId": 0, "isReverseItem": False},
+            {"statId": 6, "isReverseItem": False},
+        ]}}}
+        assert transformer.resolve_reverse_categories(payload) == set()
+
+    def test_missing_is_reverse_item_key_treated_as_false(self, transformer):
+        payload = {"settings": {"scoringSettings": {"scoringItems": [
+            {"statId": 0},
+        ]}}}
+        assert transformer.resolve_reverse_categories(payload) == set()
+
+    def test_reverse_non_ranking_stat_excluded(self, transformer):
+        payload = {"settings": {"scoringSettings": {"scoringItems": [
+            {"statId": 42, "isReverseItem": True},
+        ]}}}
+        assert transformer.resolve_reverse_categories(payload) == set()
+
+    def test_malformed_settings_returns_empty_set(self, transformer):
+        assert transformer.resolve_reverse_categories({"settings": "not-a-dict"}) == set()

--- a/backend/tests/services/test_league_service.py
+++ b/backend/tests/services/test_league_service.py
@@ -291,12 +291,78 @@ class TestDynamicCategoriesLeagueSummary:
         summary = await real_league_service.get_league_summary()
 
         assert 'TO_leader' in summary.category_leaders
-        # find_category_leaders always takes the highest value in a category
-        # (no "lower is better" handling for reverse-scored stats like TO) —
-        # Alpha has more turnovers, so Alpha is the (raw) "leader" here. That's
-        # pre-existing, category-agnostic behavior, not something this PR changes.
+        # This payload's scoringItems don't set isReverseItem, so TO is treated
+        # as a normal (higher-is-better) category here: Alpha has more
+        # turnovers, so Alpha is the (raw) "leader". See
+        # TestReverseScoredCategories below for the isReverseItem=True case,
+        # where the lowest-TO team correctly leads instead.
         assert summary.category_leaders['TO_leader'].team.team_name == 'Alpha'
         assert summary.league_averages.stats['TO'] == pytest.approx((120 / 82 + 90 / 82) / 2)
+
+
+@pytest.mark.real_dataprovider
+class TestReverseScoredCategories:
+    """Full pipeline test for a league where ESPN flags TO as isReverseItem —
+    the lowest raw value should be the category leader and score highest,
+    not the highest raw value."""
+
+    @staticmethod
+    def _reverse_turnovers_league_payload():
+        def team(team_id, name, pts, to):
+            return {
+                "id": team_id,
+                "name": name,
+                "valuesByStat": {
+                    "0": pts, "1": 20, "2": 50, "3": 200, "6": 400,
+                    "13": 400, "14": 850, "15": 150, "16": 200, "17": 100,
+                    "19": 47.1, "20": 75.0, "42": 82, "40": 2000, "11": to,
+                },
+            }
+        return {
+            "scoringPeriodId": 5,
+            "teams": [team(1, "Alpha", 1000, 120), team(2, "Beta", 1100, 90)],
+            "settings": {"scoringSettings": {"scoringItems": [
+                {"statId": sid, "isReverseItem": sid == 11}
+                for sid in (19, 20, 17, 3, 6, 2, 1, 0, 11)
+            ]}},
+        }
+
+    @pytest_asyncio.fixture
+    async def real_league_service(self):
+        from app.services.data_provider import DataProvider
+
+        DataProvider._instance = None
+        DataProvider._initialized = False
+        service = LeagueService()
+        service.data_provider = DataProvider()
+        service.data_provider.db_service = AsyncMock()
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"ETag": "e1"}
+        resp.json.return_value = self._reverse_turnovers_league_payload()
+        resp.raise_for_status = MagicMock()
+        service.data_provider._client.get = AsyncMock(return_value=resp)
+
+        yield service
+        DataProvider._instance = None
+        DataProvider._initialized = False
+
+    @pytest.mark.asyncio
+    async def test_league_summary_leader_is_lowest_turnovers_team(self, real_league_service):
+        summary = await real_league_service.get_league_summary()
+        # Beta has fewer turnovers (90 vs 120) -> Beta correctly leads TO
+        assert summary.category_leaders['TO_leader'].team.team_name == 'Beta'
+
+    @pytest.mark.asyncio
+    async def test_heatmap_color_favors_lowest_turnovers_team(self, real_league_service):
+        heatmap = await real_league_service.get_heatmap_data()
+        to_index = heatmap.categories.index('TO')
+        team_order = [t.team_name for t in heatmap.teams]
+        alpha_color = heatmap.normalized_data[team_order.index('Alpha')][to_index]
+        beta_color = heatmap.normalized_data[team_order.index('Beta')][to_index]
+        # Beta (fewer TO, better) should read as the "good" end of the scale
+        assert beta_color > alpha_color
 
 
 @pytest.mark.real_dataprovider

--- a/backend/tests/services/test_ranking_service.py
+++ b/backend/tests/services/test_ranking_service.py
@@ -120,6 +120,7 @@ class TestRankingServiceResponseBuilding:
             service.data_provider.get_data_date = MagicMock(return_value=None)
             from app.utils.constants import RANKING_CATEGORIES
             service.data_provider.get_ranking_categories.return_value = list(RANKING_CATEGORIES)
+            service.data_provider.get_reverse_categories.return_value = set()
             return service
 
     @pytest.mark.asyncio
@@ -309,5 +310,73 @@ class TestDynamicCategoriesEndToEnd:
         beta = next(r for r in result.averages_rankings if r.team.team_name == 'Beta')
         assert beta.stats['TO'] == pytest.approx(90 / 82)
         assert 'TO' in beta.category_ranks
-        # Beta has fewer turnovers (better) than Alpha -> should rank 1st in TO
+        # This payload's scoringItems don't set isReverseItem, so TO is scored
+        # as a normal (higher-is-better) category: Beta has fewer turnovers,
+        # so it scores lowest (1) here. See TestReverseScoredRankings below
+        # for the isReverseItem=True case.
         assert beta.category_ranks['TO'] == 1
+
+
+@pytest.mark.real_dataprovider
+class TestReverseScoredRankings:
+    """Full pipeline test for a league where ESPN flags TO as isReverseItem —
+    the team with fewer turnovers should score highest, not lowest."""
+
+    @staticmethod
+    def _reverse_turnovers_league_payload():
+        def team(team_id, name, pts, to):
+            return {
+                "id": team_id,
+                "name": name,
+                "valuesByStat": {
+                    "0": pts, "1": 20, "2": 50, "3": 200, "6": 400,
+                    "13": 400, "14": 850, "15": 150, "16": 200, "17": 100,
+                    "19": 47.1, "20": 75.0, "42": 82, "40": 2000, "11": to,
+                },
+            }
+        return {
+            "scoringPeriodId": 5,
+            "teams": [team(1, "Alpha", 1000, 120), team(2, "Beta", 1100, 90)],
+            "settings": {"scoringSettings": {"scoringItems": [
+                {"statId": sid, "isReverseItem": sid == 11}
+                for sid in (19, 20, 17, 3, 6, 2, 1, 0, 11)
+            ]}},
+        }
+
+    @pytest_asyncio.fixture
+    async def real_ranking_service(self):
+        from app.services.data_provider import DataProvider
+
+        DataProvider._instance = None
+        DataProvider._initialized = False
+        service = RankingService()
+        service.data_provider = DataProvider()
+        service.data_provider.db_service = AsyncMock()
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"ETag": "e1"}
+        resp.json.return_value = self._reverse_turnovers_league_payload()
+        resp.raise_for_status = MagicMock()
+        service.data_provider._client.get = AsyncMock(return_value=resp)
+
+        yield service
+        DataProvider._instance = None
+        DataProvider._initialized = False
+
+    @pytest.mark.asyncio
+    async def test_fewer_turnovers_scores_higher_in_averages_view(self, real_ranking_service):
+        result = await real_ranking_service.get_league_rankings()
+        beta = next(r for r in result.averages_rankings if r.team.team_name == 'Beta')
+        alpha = next(r for r in result.averages_rankings if r.team.team_name == 'Alpha')
+        # Beta has fewer turnovers (90 vs 120) -> should score highest (2)
+        assert beta.category_ranks['TO'] == 2
+        assert alpha.category_ranks['TO'] == 1
+
+    @pytest.mark.asyncio
+    async def test_fewer_turnovers_scores_higher_in_totals_view(self, real_ranking_service):
+        result = await real_ranking_service.get_league_rankings()
+        beta = next(r for r in result.totals_rankings if r.team.team_name == 'Beta')
+        alpha = next(r for r in result.totals_rankings if r.team.team_name == 'Alpha')
+        assert beta.category_ranks['TO'] == 2
+        assert alpha.category_ranks['TO'] == 1

--- a/backend/tests/services/test_stats_calculator.py
+++ b/backend/tests/services/test_stats_calculator.py
@@ -240,3 +240,65 @@ class TestDynamicCategories:
         result = stats_calculator.normalize_for_heatmap(averages, ["TO"])
         assert len(result) == 2
         assert len(result[0]) == 2  # TO + GP columns
+
+
+class TestReverseCategories:
+    """Reverse-scored categories (e.g. turnovers): lower raw value = better."""
+
+    def test_calculate_rankings_reverse_category_lowest_value_scores_highest(self, stats_calculator):
+        averages = pd.DataFrame({
+            "team_id": [1, 2, 3], "team_name": ["A", "B", "C"], "GP": [82, 82, 82],
+            "TO": [10.0, 5.0, 15.0],
+        })
+        result = stats_calculator.calculate_rankings(averages, reverse_categories={"TO"})
+        by_team = result.set_index("team_id")
+        # Team B has fewest TO (best) -> should score highest (3), Team C worst -> lowest (1)
+        assert by_team.loc[2, "TO"] == 3
+        assert by_team.loc[1, "TO"] == 2
+        assert by_team.loc[3, "TO"] == 1
+
+    def test_calculate_rankings_normal_category_unaffected_by_reverse_set(self, stats_calculator):
+        averages = pd.DataFrame({
+            "team_id": [1, 2], "team_name": ["A", "B"], "GP": [82, 82],
+            "PTS": [100.0, 90.0], "TO": [10.0, 5.0],
+        })
+        result = stats_calculator.calculate_rankings(averages, reverse_categories={"TO"})
+        by_team = result.set_index("team_id")
+        # PTS is not reverse: higher value (team 1) scores highest
+        assert by_team.loc[1, "PTS"] == 2
+        assert by_team.loc[2, "PTS"] == 1
+
+    def test_find_category_leaders_reverse_category_picks_lowest(self, stats_calculator):
+        averages = pd.DataFrame({
+            "team_id": [1, 2], "team_name": ["A", "B"],
+            "TO": [12.0, 8.0],
+        })
+        leaders = stats_calculator.find_category_leaders(averages, ["TO"], reverse_categories={"TO"})
+        assert leaders["TO_leader"]["team_id"] == 2
+        assert leaders["TO_leader"]["value"] == 8.0
+
+    def test_find_category_leaders_non_reverse_still_picks_highest(self, stats_calculator):
+        averages = pd.DataFrame({
+            "team_id": [1, 2], "team_name": ["A", "B"],
+            "PTS": [90.0, 110.0],
+        })
+        leaders = stats_calculator.find_category_leaders(averages, ["PTS"], reverse_categories={"TO"})
+        assert leaders["PTS_leader"]["team_id"] == 2
+
+    def test_normalize_for_heatmap_reverse_category_inverts_color_direction(self, stats_calculator):
+        averages = pd.DataFrame({
+            "team_id": [1, 2], "team_name": ["A", "B"], "GP": [82, 82],
+            "TO": [5.0, 15.0],
+        })
+        result = stats_calculator.normalize_for_heatmap(averages, ["TO"], reverse_categories={"TO"})
+        # Team 1 has fewer TO (better) -> should get the "green" (high) end after inversion
+        assert result[0][0] > result[1][0]
+
+    def test_normalize_for_heatmap_non_reverse_unaffected(self, stats_calculator):
+        averages = pd.DataFrame({
+            "team_id": [1, 2], "team_name": ["A", "B"], "GP": [82, 82],
+            "PTS": [120.0, 100.0],
+        })
+        with_reverse = stats_calculator.normalize_for_heatmap(averages, ["PTS"], reverse_categories={"TO"})
+        without_reverse = stats_calculator.normalize_for_heatmap(averages, ["PTS"])
+        assert with_reverse == without_reverse


### PR DESCRIPTION
## Summary
Stacked on #209. Fixes a real correctness bug in the category pipeline: reverse-scored categories (lower raw value = better, e.g. turnovers) were always treated as higher-is-better — the team with the *most* turnovers was picked as category leader and scored highest, exactly backwards.

Resolves which categories are reverse-scored from ESPN's own `settings.scoringSettings.scoringItems[].isReverseItem` flag (same pattern as how categories themselves are resolved), rather than hardcoding a guess — covers whatever a league actually configures as reverse-scored, not just turnovers.

- `data_transformer.py` — new `resolve_reverse_categories()`, threaded through `averages_to_rankings_df`.
- `data_provider.py` — new `get_reverse_categories()`, wired into `get_rankings_df`/`get_all_dataframes` (same cache-reuse contract as `get_ranking_categories` — no extra ESPN request).
- `stats_calculator.py` — `calculate_rankings` ranks each reverse category `ascending=False`; `find_category_leaders` uses `idxmin` for reverse categories; `normalize_for_heatmap` inverts the color scale so "better" always reads as the same end.
- `ranking_service.py` / `league_service.py` — thread `reverse_categories` through the live rankings, league summary, and heatmap paths (same scope as the categories work — DB/date-range path unaffected).

## Test plan
- [x] 11 new unit tests: `calculate_rankings`, `find_category_leaders`, `normalize_for_heatmap`, `resolve_reverse_categories`
- [x] 4 new end-to-end tests through the **real (unmocked)** pipeline proving a team with fewer turnovers correctly leads/scores highest when ESPN flags TO as `isReverseItem`, across rankings (averages + totals) and league summary
- [x] Manually verified via **FastAPI `TestClient`** hitting the real `/api/rankings` and `/api/league/summary` routes
- [x] Full backend suite: **588 passed**, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR3E5SAZSkNfMygaeuvt9f)_