### PR TITLE
feat: render TeamDetail's Per-Game Averages and Trade's category bar dynamically

### DIFF
--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -18,6 +18,20 @@ import PlayerNameLink from '../components/PlayerNameLink'
 import RosterCoverage from '../components/RosterCoverage'
 import { FF_MATCHUP_QUALITY, FF_PROJECTIONS, FF_SCHEDULE } from '../config/featureFlags'
 
+// FG%/FT% are shown in the Shot Chart Stats block instead (fixed shooting
+// stats, unrelated to the league's configured scoring categories).
+const PERCENTAGE_CATEGORIES = new Set(['FG%', 'FT%'])
+
+const CATEGORY_DISPLAY_NAMES: Record<string, string> = {
+  PTS: 'Points',
+  REB: 'Rebounds',
+  AST: 'Assists',
+  STL: 'Steals',
+  BLK: 'Blocks',
+  '3PM': '3-Pointers',
+  TO: 'Turnovers',
+}
+
 const TeamDetail = () => {
   const { teamId } = useParams<{ teamId: string }>()
   const navigate = useNavigate()
@@ -111,6 +125,12 @@ const TeamDetail = () => {
   if (isLoading) return <LoadingSpinner />
   if (error) return <ErrorMessage message={getErrorMessage(error, 'Failed to load team details')} />
   if (!team_detail) return <ErrorMessage message="Team not found" />
+
+  // This league's actual scoring categories, in order, excluding percentages
+  // (shown separately in Shot Chart Stats) — sourced from the API response
+  // rather than a hardcoded list.
+  const perGameCategories = Object.keys(team_detail.category_ranks)
+    .filter(key => !PERCENTAGE_CATEGORIES.has(key))
 
   const columns = [
     { key: 'include', label: 'Include', align: 'center', sortable: false },
@@ -329,30 +349,12 @@ const TeamDetail = () => {
           <div>
             <h2 className="text-xl font-semibold mb-4">Per-Game Averages</h2>
             <div className="space-y-3">
-              <div className="flex justify-between">
-                <span>Points:</span>
-                <span>{team_detail.raw_averages.pts.toFixed(2)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Rebounds:</span>
-                <span>{team_detail.raw_averages.reb.toFixed(2)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Assists:</span>
-                <span>{team_detail.raw_averages.ast.toFixed(2)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Steals:</span>
-                <span>{team_detail.raw_averages.stl.toFixed(2)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Blocks:</span>
-                <span>{team_detail.raw_averages.blk.toFixed(2)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span>3-Pointers:</span>
-                <span>{team_detail.raw_averages.three_pm.toFixed(2)}</span>
-              </div>
+              {perGameCategories.map(key => (
+                <div className="flex justify-between" key={key}>
+                  <span>{CATEGORY_DISPLAY_NAMES[key] ?? key}:</span>
+                  <span>{(team_detail.raw_averages.stats?.[key] ?? 0).toFixed(2)}</span>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Trade/components/TeamRankingsBar.tsx
+++ b/frontend/src/pages/Trade/components/TeamRankingsBar.tsx
@@ -5,20 +5,16 @@ interface TeamRankingsBarProps {
   categoryRanks: Record<string, number>;
 }
 
-const CATEGORIES = [
-  { key: 'FG%', label: 'FG%' },
-  { key: 'FT%', label: 'FT%' },
-  { key: '3PM', label: '3PM' },
-  { key: 'AST', label: 'AST' },
-  { key: 'REB', label: 'REB' },
-  { key: 'STL', label: 'STL' },
-  { key: 'BLK', label: 'BLK' },
-  { key: 'PTS', label: 'PTS' },
-];
-
 export const TeamRankingsBar: React.FC<TeamRankingsBarProps> = ({ categoryRanks }) => {
+  // Column order/set comes straight from the API response (this league's
+  // actual scoring categories), not a hardcoded 8-category list.
+  const categoryKeys = Object.keys(categoryRanks)
+  const teamCount = Object.keys(categoryRanks).length > 0
+    ? Math.max(...Object.values(categoryRanks))
+    : 1
+
   const normalizeRank = (rank: number): number => {
-    return (rank - 1) / 11;
+    return teamCount > 1 ? (rank - 1) / (teamCount - 1) : 0.5;
   };
 
   return (
@@ -26,27 +22,27 @@ export const TeamRankingsBar: React.FC<TeamRankingsBarProps> = ({ categoryRanks 
       <table className="w-full text-xs">
         <thead>
           <tr className="bg-gray-50">
-            {CATEGORIES.map((category) => (
+            {categoryKeys.map((key) => (
               <th
-                key={category.key}
+                key={key}
                 className="px-2 py-1 text-center font-semibold text-gray-700 border-r border-gray-200 last:border-r-0"
               >
-                {category.label}
+                {key}
               </th>
             ))}
           </tr>
         </thead>
         <tbody>
           <tr>
-            {CATEGORIES.map((category) => {
-              const rank = categoryRanks[category.key] || 0;
+            {categoryKeys.map((key) => {
+              const rank = categoryRanks[key] || 0;
               const normalizedValue = normalizeRank(rank);
               const backgroundColor = getHeatmapColor(normalizedValue);
               const textColor = getTextColor(normalizedValue);
 
               return (
                 <td
-                  key={category.key}
+                  key={key}
                   className="px-2 py-1.5 text-center font-bold border-r border-gray-200 last:border-r-0"
                   style={{
                     backgroundColor,

--- a/frontend/src/pages/Trade/components/__tests__/TeamRankingsBar.test.tsx
+++ b/frontend/src/pages/Trade/components/__tests__/TeamRankingsBar.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TeamRankingsBar } from '../TeamRankingsBar';
+
+describe('TeamRankingsBar', () => {
+  it('renders exactly the categories present in categoryRanks, in order', () => {
+    render(<TeamRankingsBar categoryRanks={{ 'FG%': 2, PTS: 1, TO: 3 }} />);
+
+    const headers = screen.getAllByRole('columnheader').map(h => h.textContent);
+    expect(headers).toEqual(['FG%', 'PTS', 'TO']);
+  });
+
+  it('renders each category rank value as a cell', () => {
+    render(<TeamRankingsBar categoryRanks={{ PTS: 2, TO: 1 }} />);
+
+    const cells = screen.getAllByRole('cell').map(c => c.textContent);
+    expect(cells).toEqual(['2', '1']);
+  });
+
+  it('handles an empty categoryRanks without crashing', () => {
+    render(<TeamRankingsBar categoryRanks={{}} />);
+    expect(screen.queryAllByRole('columnheader')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on #210. Closes out the two frontend spots deliberately deferred in #208: `TeamDetail.tsx`'s own averages table and `Trade`'s category comparison bar both hardcoded the 8-category set, so a league scoring beyond it (e.g. turnovers) would have that category silently missing from these views even though the API has carried it since #208/#210.

- `TeamDetail.tsx` — "Per-Game Averages" now iterates `Object.keys(team_detail.category_ranks)` (already ordered to match the league's resolved categories) instead of 6 hardcoded rows, with a display-name map (falls back to the raw category code for unknown categories). FG%/FT% stay excluded here since they're shown in the adjacent Shot Chart Stats block.
- `Trade/components/TeamRankingsBar.tsx` — columns now come from `Object.keys(categoryRanks)` instead of a hardcoded 8-category array. Also fixed an adjacent hardcoded assumption found in the same component: rank-to-color normalization assumed exactly a 12-team league (`(rank-1)/11`); now derives team count from the actual rank values present.

## Test plan
- [x] 3 new `TeamRankingsBar` tests (dynamic column set/order, cell values, empty-input safety)
- [x] Full frontend suite: **187 passed** (3 new), 0 failures
- [x] `tsc -b` clean
- [x] Manually verified with a **real browser** (Playwright/Chromium) against a real running backend (mocked ESPN, turnovers-scoring league) and Vite dev server: TeamDetail's Per-Game Averages correctly shows "Turnovers: 1.10" with zero console/page errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR3E5SAZSkNfMygaeuvt9f)_