### PR TITLE
feat: generic per-category stats for individual player rows

### DIFF
--- a/backend/app/builders/response_builder.py
+++ b/backend/app/builders/response_builder.py
@@ -185,30 +185,38 @@ class ResponseBuilder:
             return None
         return value if value > 0 else None
 
-    def build_players_list(self, team_players: pd.DataFrame) -> List[Player]:
-        """Build list of Player objects from players DataFrame"""
+    def _build_player_stats(self, row: pd.Series, categories: Optional[List[str]] = None) -> PlayerStats:
+        """Create PlayerStats from a player row, with the generic `stats` dict
+        populated for the league's actual scoring categories (e.g. TO) on top
+        of the fixed default fields. categories defaults to RANKING_CATEGORIES."""
+        categories = categories or RANKING_CATEGORIES
+        return PlayerStats(
+            pts=float(row['PTS']),
+            reb=float(row['REB']),
+            ast=float(row['AST']),
+            stl=float(row['STL']),
+            blk=float(row['BLK']),
+            fgm=float(row['FGM']),
+            fga=float(row['FGA']),
+            ftm=float(row['FTM']),
+            fta=float(row['FTA']),
+            fg_percentage=float(row['FG%']),
+            ft_percentage=float(row['FT%']),
+            three_pm=float(row['3PM']),
+            minutes=float(row['MIN']),
+            gp=int(row['GP']),
+            stats={col: float(row[col]) for col in categories if col in row},
+        )
+
+    def build_players_list(self, team_players: pd.DataFrame, categories: Optional[List[str]] = None) -> List[Player]:
+        """Build list of Player objects from players DataFrame. categories defaults to RANKING_CATEGORIES."""
         players = []
         for _, row in team_players.iterrows():
             players.append(Player(
                 player_name=str(row['Name']),
                 pro_team=str(row['Pro Team']),
                 positions=str(row['Positions']).split(', '),
-                stats=PlayerStats(
-                    pts=float(row['PTS']),
-                    reb=float(row['REB']),
-                    ast=float(row['AST']),
-                    stl=float(row['STL']),
-                    blk=float(row['BLK']),
-                    fgm=float(row['FGM']),
-                    fga=float(row['FGA']),
-                    ftm=float(row['FTM']),
-                    fta=float(row['FTA']),
-                    fg_percentage=float(row['FG%']),
-                    ft_percentage=float(row['FT%']),
-                    three_pm=float(row['3PM']),
-                    minutes=float(row['MIN']),
-                    gp=int(row['GP'])
-                ),
+                stats=self._build_player_stats(row, categories),
                 team_id=int(row['team_id']),
                 status=str(row.get('status', 'ONTEAM')),
                 player_id=self._player_id_from_row(row),
@@ -316,30 +324,15 @@ class ResponseBuilder:
             stats={col: float(avg_data[col]) for col in categories if col in avg_data},
         )
 
-    def build_all_players_response(self, players_df: pd.DataFrame) -> List[Player]:
-        """Build list of all players from players DataFrame"""
+    def build_all_players_response(self, players_df: pd.DataFrame, categories: Optional[List[str]] = None) -> List[Player]:
+        """Build list of all players from players DataFrame. categories defaults to RANKING_CATEGORIES."""
         players = []
         for _, row in players_df.iterrows():
             players.append(Player(
                 player_name=str(row['Name']),
                 pro_team=str(row['Pro Team']),
                 positions=str(row['Positions']).split(', '),
-                stats=PlayerStats(
-                    pts=float(row['PTS']),
-                    reb=float(row['REB']),
-                    ast=float(row['AST']),
-                    stl=float(row['STL']),
-                    blk=float(row['BLK']),
-                    fgm=float(row['FGM']),
-                    fga=float(row['FGA']),
-                    ftm=float(row['FTM']),
-                    fta=float(row['FTA']),
-                    fg_percentage=float(row['FG%']),
-                    ft_percentage=float(row['FT%']),
-                    three_pm=float(row['3PM']),
-                    minutes=float(row['MIN']),
-                    gp=int(row['GP'])
-                ),
+                stats=self._build_player_stats(row, categories),
                 team_id=int(row['team_id']),
                 status=str(row.get('status', 'ONTEAM')),
                 player_id=self._player_id_from_row(row),

--- a/backend/app/models/player.py
+++ b/backend/app/models/player.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import List, Optional
+from typing import Dict, List, Optional
 from datetime import date, timedelta
 from enum import Enum
 
@@ -73,6 +73,9 @@ class PlayerStats(BaseModel):
     three_pm: float
     minutes: float
     gp: int
+    # Generic per-category totals for this league's actual scoring categories
+    # (e.g. TO), keyed by category code. Superset of the fixed fields above.
+    stats: Optional[Dict[str, float]] = None
 
 class Player(BaseModel):
     player_name: str
@@ -101,3 +104,6 @@ class PaginatedPlayers(BaseModel):
     has_more: bool
     actual_start: Optional[date] = None
     actual_end: Optional[date] = None
+    # This league's actual scoring categories (see PlayerStats.stats),
+    # in display order.
+    categories: List[str] = []

--- a/backend/app/services/player_service.py
+++ b/backend/app/services/player_service.py
@@ -203,7 +203,8 @@ class PlayerService:
         end_idx = start_idx + limit
 
         page_df = players_df.iloc[start_idx:end_idx]
-        players = self.response_builder.build_all_players_response(page_df)
+        categories = await self.data_provider.get_ranking_categories()
+        players = self.response_builder.build_all_players_response(page_df, categories)
 
         return PaginatedPlayers(
             players=players,
@@ -213,4 +214,5 @@ class PlayerService:
             has_more=end_idx < total_count,
             actual_start=actual_start,
             actual_end=actual_end,
+            categories=categories,
         )

--- a/backend/app/services/team_service.py
+++ b/backend/app/services/team_service.py
@@ -46,6 +46,8 @@ class TeamService:
         if not is_team_exists(team_id, totals_df):
             raise ResourceNotFoundError(f"Team with ID {team_id} not found")
 
+        categories = await self.data_provider.get_ranking_categories()
+
         players_list = None
         slot_usage_map = {}
         actual_start = None
@@ -60,13 +62,12 @@ class TeamService:
                     time_period, players_df, self.data_provider.db_service, start, end
                 )
                 team_players_df = self._filter_team_players(players_df, team_id)
-                players_list = self.response_builder.build_players_list(team_players_df)
+                players_list = self.response_builder.build_players_list(team_players_df, categories)
         except Exception as e:
             self.logger.warning(f"Player data unavailable for team {team_id}: {e}")
 
         espn_url = f"https://fantasy.espn.com/basketball/team?leagueId={settings.league_id}&teamId={team_id}"
         team_slot_usage = slot_usage_map.get(team_id, {})
-        categories = await self.data_provider.get_ranking_categories()
 
         return self.response_builder.build_team_detail_response(
             team_id, totals_df, averages_df, rankings_df, players_list, espn_url,

--- a/backend/tests/builders/test_response_builder.py
+++ b/backend/tests/builders/test_response_builder.py
@@ -326,3 +326,28 @@ class TestTeamDetailGenericStats:
         )
         assert set(result.category_ranks.keys()) == {'PTS'}
         assert set(result.raw_averages.stats.keys()) == {'PTS'}
+
+
+class TestPlayerStatsGenericField:
+    def test_build_players_list_default_stats_matches_fixed_fields(
+        self, response_builder, response_builder_players_df
+    ):
+        result = response_builder.build_players_list(response_builder_players_df)
+        first = result[0]
+        assert first.stats.stats['PTS'] == first.stats.pts
+        assert first.stats.stats['FG%'] == first.stats.fg_percentage
+
+    def test_build_players_list_extra_category_included_when_present(
+        self, response_builder, response_builder_players_df
+    ):
+        df = response_builder_players_df.copy()
+        df['TO'] = [12.0, 8.0]
+        result = response_builder.build_players_list(df, categories=['PTS', 'TO'])
+        assert result[0].stats.stats == {'PTS': result[0].stats.pts, 'TO': 12.0}
+
+    def test_build_all_players_response_default_stats_matches_fixed_fields(
+        self, response_builder, response_builder_players_df
+    ):
+        result = response_builder.build_all_players_response(response_builder_players_df)
+        first = result[0]
+        assert first.stats.stats['PTS'] == first.stats.pts

--- a/backend/tests/services/test_player_service.py
+++ b/backend/tests/services/test_player_service.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pandas as pd
 import pytest
+import pytest_asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 from app.exceptions import ResourceNotFoundError
@@ -49,6 +50,8 @@ def player_service():
     svc.data_provider.db_service.aggregate_player_games = AsyncMock(
         return_value=(pd.DataFrame(), None, None)
     )
+    from app.utils.constants import RANKING_CATEGORIES
+    svc.data_provider.get_ranking_categories = AsyncMock(return_value=list(RANKING_CATEGORIES))
     svc.response_builder = MagicMock()
     svc.logger = MagicMock()
     return svc
@@ -107,12 +110,14 @@ class TestGetAllPlayers:
         assert result.has_more is False
         assert result.actual_start is None
         assert result.actual_end is None
+        from app.utils.constants import RANKING_CATEGORIES
+        assert result.categories == list(RANKING_CATEGORIES)
 
     @pytest.mark.asyncio
     async def test_has_more_second_page(self, player_service, sample_window_players_df):
         player_service.data_provider.get_players_df = AsyncMock(return_value=sample_window_players_df)
         player_service.response_builder.build_all_players_response.side_effect = (
-            lambda df: [_sample_player(f"P{i}") for i in range(len(df))]
+            lambda df, categories=None: [_sample_player(f"P{i}") for i in range(len(df))]
         )
 
         result = await player_service.get_all_players(page=1, limit=2, time_period=StatTimePeriod.SEASON)
@@ -360,3 +365,97 @@ class TestGetSeasonAnchorDate:
 
         result = await player_service_module.get_season_anchor_date("2025-26", db)
         assert result == date(2026, 4, 12)
+
+
+@pytest.mark.real_dataprovider
+class TestDynamicCategoriesPlayers:
+    """Full pipeline: real DataProvider + DataTransformer + ResponseBuilder,
+    only the ESPN HTTP call stubbed, proving a turnovers-scoring league
+    surfaces TO on individual player rows via get_all_players()."""
+
+    @staticmethod
+    def _turnovers_league_standings_payload():
+        return {
+            "scoringPeriodId": 5,
+            "teams": [{"id": 1, "name": "Alpha", "valuesByStat": {
+                "0": 1000, "1": 20, "2": 50, "3": 200, "6": 400,
+                "13": 400, "14": 850, "15": 150, "16": 200, "17": 100,
+                "19": 47.1, "20": 75.0, "42": 82, "40": 2000, "11": 120,
+            }}],
+            "settings": {"scoringSettings": {"scoringItems": [
+                {"statId": sid} for sid in (19, 20, 17, 3, 6, 2, 1, 0, 11)
+            ]}},
+        }
+
+    @staticmethod
+    def _players_payload():
+        return {"players": [{
+            "id": 501, "onTeamId": 1, "status": "ONTEAM",
+            "player": {
+                "id": 501, "fullName": "TO Guy", "proTeamId": 1, "injured": False,
+                "eligibleSlots": [0],
+                "stats": [{
+                    "scoringPeriodId": 0, "statSplitTypeId": 0, "seasonId": 2026,
+                    "stats": {
+                        "0": 500, "1": 10, "2": 25, "3": 100, "6": 200,
+                        "13": 200, "14": 425, "15": 75, "16": 100, "17": 50,
+                        "19": 47.1, "20": 75.0, "42": 41, "40": 1000, "11": 60,
+                    },
+                }],
+            },
+        }]}
+
+    @pytest_asyncio.fixture
+    async def real_player_service(self, monkeypatch):
+        from datetime import date as date_cls
+        from unittest.mock import AsyncMock as AM
+        from app.services.data_provider import DataProvider
+
+        monkeypatch.setattr(
+            player_service_module, "get_season_anchor_date", AM(return_value=date_cls(2026, 7, 10))
+        )
+
+        from app.services.cache_manager import CacheManager
+
+        DataProvider._instance = None
+        DataProvider._initialized = False
+        # CacheManager is its own singleton, independent of DataProvider's —
+        # resetting DataProvider alone leaves a stale players_0 cache entry
+        # (5-minute TTL) that could otherwise leak in from any other test.
+        CacheManager._instance = None
+        service = PlayerService()
+        service.data_provider = DataProvider()
+        service.data_provider.db_service = MagicMock()
+        service.data_provider.db_service.aggregate_player_games = AsyncMock(
+            return_value=(pd.DataFrame(), None, None)
+        )
+
+        standings_resp = MagicMock()
+        standings_resp.status_code = 200
+        standings_resp.headers = {"ETag": "e1"}
+        standings_resp.json.return_value = self._turnovers_league_standings_payload()
+        standings_resp.raise_for_status = MagicMock()
+
+        players_resp = MagicMock()
+        players_resp.status_code = 200
+        players_resp.headers = {}
+        players_resp.json.return_value = self._players_payload()
+        players_resp.raise_for_status = MagicMock()
+
+        async def routed_get(url, **kwargs):
+            return players_resp if 'kona_player_info' in url else standings_resp
+        service.data_provider._client.get = AsyncMock(side_effect=routed_get)
+
+        yield service
+        DataProvider._instance = None
+        DataProvider._initialized = False
+        CacheManager._instance = None
+
+    @pytest.mark.asyncio
+    async def test_player_row_includes_turnovers_stat(self, real_player_service):
+        result = await real_player_service.get_all_players(page=1, limit=10)
+
+        player = next(p for p in result.players if p.player_name == "TO Guy")
+        assert player.stats.stats is not None
+        assert player.stats.stats['TO'] == 60.0
+        assert player.stats.stats['PTS'] == player.stats.pts

--- a/backend/tests/services/test_team_service.py
+++ b/backend/tests/services/test_team_service.py
@@ -120,7 +120,7 @@ class TestTeamService:
         )
 
         captured = {}
-        def _capture_players_list(df):
+        def _capture_players_list(df, categories=None):
             captured['df'] = df
             return []
         team_service.response_builder.build_players_list.side_effect = _capture_players_list


### PR DESCRIPTION
## Summary
Stacked on #211. Extends the generic-stats work (#206/#208) down to the player level, as a prerequisite for making Player Rankings category-flexible. Its z-scores are computed over individual player box scores, not team totals — `PlayerStats` had no generic field and no way to carry a category like TO at all, so this had to come before any frontend Player Rankings work.

- `models/player.py` — `PlayerStats` gets the same `stats: Dict[str, float]` field as `RankingStats`/`AverageStats`. `PaginatedPlayers` gets a `categories: List[str]` field (mirrors `LeagueRankings.categories`) so consumers know the league's actual category set without inferring it from player rows.
- `response_builder.py` — new `_build_player_stats()` helper shared by `build_players_list` and `build_all_players_response`, both now take an optional `categories` param (default `RANKING_CATEGORIES`).
- `team_service.py` / `player_service.py` — resolve categories via `data_provider.get_ranking_categories()` and pass them through.

The underlying player-row parsing already carried every ESPN stat (`ESPN_COLUMN_MAP`, extended with TO in #206) — this PR only exposes it through the response models, no data-pipeline change needed.

## Test plan
- [x] 5 new/updated unit tests
- [x] New end-to-end test through the **real (unmocked)** `DataProvider → DataTransformer → ResponseBuilder` pipeline for a turnovers-scoring league via `PlayerService.get_all_players()` — including a `CacheManager` singleton-reset fix for test isolation (an unrelated pre-existing gap this test surfaced)
- [x] Manually verified via **FastAPI `TestClient`** hitting the real `/api/players/` route
- [x] Full backend suite: **592 passed**, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR3E5SAZSkNfMygaeuvt9f)_