### PR TITLE
feat: Player Rankings computes z-scores over the league's actual categories

### DIFF
--- a/frontend/src/pages/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router'
 import { useGetAllPlayersQuery, useGetNbaPlayerQuery, useGetNbaPlayerStatsQuery } from '../store/api/fantasyApi'
-import type { CustomDateRange, PlayerStats, TimePeriod } from '../types/api'
+import type { CustomDateRange, PlayerStatKey, TimePeriod } from '../types/api'
 import TimePeriodSelector from '../components/TimePeriodSelector'
 import { CoverageNotice } from '../components/DateRangePicker'
 import LoadingSpinner from '../components/LoadingSpinner'
@@ -19,7 +19,7 @@ function backLabel(from: string | undefined): string {
   return '← Back'
 }
 
-const STAT_ROWS: { key: keyof PlayerStats; label: string; isPct?: boolean }[] = [
+const STAT_ROWS: { key: PlayerStatKey; label: string; isPct?: boolean }[] = [
   { key: 'gp', label: 'GP' },
   { key: 'minutes', label: 'MIN' },
   { key: 'pts', label: 'PTS' },

--- a/frontend/src/pages/PlayerRankings.tsx
+++ b/frontend/src/pages/PlayerRankings.tsx
@@ -15,7 +15,8 @@ import {
   computePlayerRankings,
   getRawValue,
   partitionByDataAvailability,
-  CATEGORIES,
+  DEFAULT_CATEGORIES,
+  PERCENTAGE_CATEGORIES,
   CATEGORY_LABELS,
   type RankingCategory,
   type RankedPlayer,
@@ -24,7 +25,7 @@ import {
 
 type SortCol = 'totalZ' | 'gp' | 'mpg' | RankingCategory | `${RankingCategory}_raw`
 
-const DEFAULT_WEIGHTS = Object.fromEntries(CATEGORIES.map(c => [c, 1])) as Record<RankingCategory, number>
+const DEFAULT_WEIGHTS = Object.fromEntries(DEFAULT_CATEGORIES.map(c => [c, 1])) as Record<RankingCategory, number>
 
 const ALL_POSITIONS = ['PG', 'SG', 'SF', 'PF', 'C']
 
@@ -49,6 +50,9 @@ export default function PlayerRankings() {
     () => partitionByDataAvailability(allPlayers),
     [allPlayers]
   )
+  // This league's actual scoring categories, from the API response — falls
+  // back to the historical default 8 until the first response lands.
+  const categories = playersData?.categories?.length ? playersData.categories : DEFAULT_CATEGORIES
 
   const [calcMode, setCalcMode] = usePersistedState<'totals' | 'per_game'>('playerRankings.calcMode', 'per_game')
   const [displayMode, setDisplayMode] = usePersistedState<'totals' | 'per_game'>('playerRankings.displayMode', 'per_game')
@@ -56,6 +60,17 @@ export default function PlayerRankings() {
   const [minMin, setMinMin] = usePersistedState('playerRankings.minMin', 0)
   const [position, setPosition] = usePersistedState<string | null>('playerRankings.position', null)
   const [weights, setWeights] = usePersistedState<Record<RankingCategory, number>>('playerRankings.weights', { ...DEFAULT_WEIGHTS })
+  // A persisted weights object from a previous session (or the default 8)
+  // may be missing an entry for a category this league scores (e.g. TO) —
+  // default any missing category to weight 1 rather than treating it as punted.
+  const effectiveWeights = useMemo(() => {
+    const merged = { ...weights }
+    let changed = false
+    for (const cat of categories) {
+      if (!(cat in merged)) { merged[cat] = 1; changed = true }
+    }
+    return changed ? merged : weights
+  }, [weights, categories])
   const [displayLimit, setDisplayLimit] = useState<number | null>(null)
   const [sliderResetKey, setSliderResetKey] = useState(0)
   const [sortCol, setSortCol] = useState<SortCol>('totalZ')
@@ -85,11 +100,11 @@ export default function PlayerRankings() {
     setSliderResetKey(k => k + 1)
   }
 
-  const isPunted = (cat: RankingCategory) => weights[cat] === 0
+  const isPunted = (cat: RankingCategory) => effectiveWeights[cat] === 0
 
   const recompute = () => {
-    const config: RankingsConfig = { calcMode, minGp, minMin, position, weights }
-    const next = computePlayerRankings(players, config)
+    const config: RankingsConfig = { calcMode, minGp, minMin, position, weights: effectiveWeights }
+    const next = computePlayerRankings(players, config, categories)
     // Low-priority: if another slider tick (or anything urgent) comes in
     // while this 500-row re-render is in flight, React interrupts/discards
     // it instead of finishing it first — keeps the slider itself responsive.
@@ -149,7 +164,7 @@ export default function PlayerRankings() {
 
   const rawDisplay = (ranked: RankedPlayer, cat: RankingCategory) => {
     const val = getRawValue(ranked.player, cat, displayMode)
-    return cat === 'fg_pct' || cat === 'ft_pct' ? fmtPct(val) : fmt(val, 1)
+    return PERCENTAGE_CATEGORIES.has(cat) ? fmtPct(val) : fmt(val, 1)
   }
 
   if (isLoading) return <LoadingSpinner />
@@ -247,7 +262,7 @@ export default function PlayerRankings() {
             </p>
           )}
 
-          <WeightSliders key={sliderResetKey} initialWeights={weights} onCommit={setWeights} />
+          <WeightSliders key={sliderResetKey} categories={categories} initialWeights={effectiveWeights} onCommit={setWeights} />
 
           <div className="flex items-center justify-between">
             <p className="text-xs text-gray-400 dark:text-gray-500">
@@ -295,11 +310,11 @@ export default function PlayerRankings() {
                   <th className="hidden sm:table-cell px-2 py-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 whitespace-nowrap">Pos</th>
                   <Th col="gp" label="GP" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} />
                   <Th col="mpg" label="MPG" sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} className="hidden sm:table-cell" />
-                  {CATEGORIES.map(cat => (
-                    <Th key={`raw-${cat}`} col={`${cat}_raw` as SortCol} label={CATEGORY_LABELS[cat]} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} punted={isPunted(cat)} />
+                  {categories.map(cat => (
+                    <Th key={`raw-${cat}`} col={`${cat}_raw` as SortCol} label={CATEGORY_LABELS[cat] ?? cat} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} punted={isPunted(cat)} />
                   ))}
-                  {CATEGORIES.map(cat => (
-                    <Th key={`z-${cat}`} col={cat} label={`${CATEGORY_LABELS[cat]}_z`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} punted={isPunted(cat)} />
+                  {categories.map(cat => (
+                    <Th key={`z-${cat}`} col={cat} label={`${CATEGORY_LABELS[cat] ?? cat}_z`} sortCol={sortCol} sortAsc={sortAsc} onSort={handleSort} punted={isPunted(cat)} />
                   ))}
                 </tr>
               </thead>
@@ -313,12 +328,12 @@ export default function PlayerRankings() {
                     <td className="hidden sm:table-cell px-2 py-2 text-gray-500 dark:text-gray-400 text-xs whitespace-nowrap">{ranked.player.positions.join(', ')}</td>
                     <td className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-right text-gray-700 dark:text-gray-300 text-xs sm:text-sm">{ranked.player.stats.gp}</td>
                     <td className="hidden sm:table-cell px-3 py-2 text-right text-gray-700 dark:text-gray-300">{ranked.player.stats.gp > 0 ? fmt(ranked.player.stats.minutes / ranked.player.stats.gp, 1) : '—'}</td>
-                    {CATEGORIES.map(cat => (
+                    {categories.map(cat => (
                       <td key={`raw-${cat}`} className="px-1.5 sm:px-3 py-1.5 sm:py-2 text-right text-gray-700 dark:text-gray-300 text-xs sm:text-sm">
                         {rawDisplay(ranked, cat)}
                       </td>
                     ))}
-                    {CATEGORIES.map(cat => (
+                    {categories.map(cat => (
                       <td key={`z-${cat}`} className={`px-1.5 sm:px-3 py-1.5 sm:py-2 text-right font-mono text-xs ${isPunted(cat) ? 'text-gray-300 dark:text-gray-600' : ranked.zScores[cat] >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}>
                         {fmt(ranked.zScores[cat])}
                       </td>
@@ -337,7 +352,8 @@ export default function PlayerRankings() {
 // Owns slider drag state locally so ticking a slider only re-renders this
 // small subtree, not the parent (and its 500-row table). Only pushes a
 // debounced "settled" value up via onCommit, once per drag/toggle.
-function WeightSliders({ initialWeights, onCommit }: {
+function WeightSliders({ categories, initialWeights, onCommit }: {
+  categories: RankingCategory[]
   initialWeights: Record<RankingCategory, number>
   onCommit: (weights: Record<RankingCategory, number>) => void
 }) {
@@ -374,9 +390,9 @@ function WeightSliders({ initialWeights, onCommit }: {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-3">
-      {CATEGORIES.map(cat => (
+      {categories.map(cat => (
         <div key={cat} className={`flex items-center gap-2 p-2 rounded-lg border ${isPunted(cat) ? 'border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20' : 'border-gray-200 dark:border-gray-600'}`}>
-          <span className="text-xs font-semibold text-gray-700 dark:text-gray-300 w-8">{CATEGORY_LABELS[cat]}</span>
+          <span className="text-xs font-semibold text-gray-700 dark:text-gray-300 w-8">{CATEGORY_LABELS[cat] ?? cat}</span>
           <input
             type="range" min={0} max={2} step={0.1}
             value={isPunted(cat) ? 0 : weights[cat]}

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -3,7 +3,7 @@ import { usePersistedState } from '../hooks/usePersistedState';
 import { useDebounce } from '../hooks/useDebounce';
 import { useGetAllPlayersQuery, useGetScheduleQuery, useGetTeamsListQuery } from '../store/api/fantasyApi';
 import { useGetMatchupsTodayQuery, useGetMatchupDatesQuery, useGetUpcomingDatesQuery, useGetCurrentSlateDateQuery } from '../store/api/fantasyApi';
-import type { PlayerFilters, Player, StatFilter, TimePeriod, ComparisonOperator, PlayerStats, CustomDateRange } from '../types/api';
+import type { PlayerFilters, Player, StatFilter, TimePeriod, ComparisonOperator, PlayerStatKey, CustomDateRange } from '../types/api';
 import type { PlayerMatchup } from '../types/api';
 import TimePeriodSelector from '../components/TimePeriodSelector';
 import { CoverageNotice } from '../components/DateRangePicker';
@@ -362,7 +362,7 @@ const FilterPanel = ({ filters, onChange, teams }: { filters: PlayerFilters; onC
             const v = e.target.value
             setStatFilter({
               ...statFilter,
-              stat: v === '' ? undefined : (v as keyof PlayerStats),
+              stat: v === '' ? undefined : (v as PlayerStatKey),
             })
           }}
         >
@@ -488,8 +488,8 @@ const PlayerTable = ({
         aVal = getTeamDisplay(a)
         bVal = getTeamDisplay(b)
       } else if (sortColumn in a.stats) {
-        const aStat = a.stats[sortColumn as keyof typeof a.stats]
-        const bStat = b.stats[sortColumn as keyof typeof b.stats]
+        const aStat = a.stats[sortColumn as PlayerStatKey]
+        const bStat = b.stats[sortColumn as PlayerStatKey]
         const isPercentage = sortColumn === 'fg_percentage' || sortColumn === 'ft_percentage'
 
         aVal = (showAverages && sortColumn !== 'gp' && !isPercentage)

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -3,7 +3,7 @@ import { useState, useMemo, useEffect } from 'react'
 import React from 'react'
 import { usePersistedState } from '../hooks/usePersistedState'
 import { useGetTeamDetailQuery, useGetLeagueSummaryQuery, useGetMatchupsTodayQuery } from '../store/api/fantasyApi'
-import type { TimePeriod, PlayerMatchup, CustomDateRange } from '../types/api'
+import type { TimePeriod, PlayerMatchup, CustomDateRange, PlayerStatKey } from '../types/api'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import { getErrorMessage } from '../utils/errorMessage'
@@ -175,8 +175,8 @@ const TeamDetail = () => {
           aVal = a.pro_team
           bVal = b.pro_team
         } else {
-          const aStat = a.stats[sortBy as keyof typeof a.stats] ?? -1
-          const bStat = b.stats[sortBy as keyof typeof b.stats] ?? -1
+          const aStat = a.stats[sortBy as PlayerStatKey] ?? -1
+          const bStat = b.stats[sortBy as PlayerStatKey] ?? -1
           const isPercentage = sortBy === 'fg_percentage' || sortBy === 'ft_percentage'
 
           aVal = (showAverages && sortBy !== 'gp' && !isPercentage)

--- a/frontend/src/pages/TradeSuggestions/components/PlayerStatsTable.tsx
+++ b/frontend/src/pages/TradeSuggestions/components/PlayerStatsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Player } from '../../../types/api';
+import type { Player, PlayerStatKey } from '../../../types/api';
 import { CollapsibleTable } from '../../../components/CollapsibleTable';
 import { formatStatValue } from '../utils/tradeHelpers';
 import type { PlayerGroup } from '../utils/tradeHelpers';
@@ -34,7 +34,7 @@ export const PlayerStatsTable: React.FC<PlayerStatsTableProps> = ({
   ];
 
   const formatPlayerStat = (player: Player, statKey: string, isPercentage: boolean = false, isGamesPlayed: boolean = false) => {
-    const value = player.stats?.[statKey as keyof typeof player.stats] || 0;
+    const value = player.stats?.[statKey as PlayerStatKey] || 0;
     const gamesPlayed = player.stats?.gp || 1;
     return formatStatValue(value, gamesPlayed, viewMode, isPercentage, isGamesPlayed);
   };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -141,7 +141,14 @@ export interface PlayerStats {
   three_pm: number;
   minutes: number;
   gp: number;
+  /** See RankingStats.stats */
+  stats?: Record<string, number>;
 }
+
+/** Fixed, numeric PlayerStats fields — excludes the generic `stats` dict,
+ * for call sites that index PlayerStats dynamically by key (sort columns,
+ * comparison tables) where only a plain number makes sense. */
+export type PlayerStatKey = Exclude<keyof PlayerStats, 'stats'>
 
 export interface Player {
   player_name: string;
@@ -169,6 +176,8 @@ export interface PaginatedPlayers {
   has_more: boolean;
   actual_start?: string;
   actual_end?: string;
+  /** This league's actual scoring categories (see PlayerStats.stats). */
+  categories?: string[];
 }
 
 export type ComparisonOperator = "eq" | "gt" | "lt" | "gte" | "lte";
@@ -181,7 +190,7 @@ export interface CustomDateRange {
 }
 
 export interface StatFilter {
-  stat: keyof PlayerStats;
+  stat: PlayerStatKey;
   operator: ComparisonOperator;
   value: number;
 }

--- a/frontend/src/utils/__tests__/playerRankings.test.ts
+++ b/frontend/src/utils/__tests__/playerRankings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computePlayerRankings, partitionByDataAvailability, CATEGORIES } from '../playerRankings'
+import { computePlayerRankings, partitionByDataAvailability, DEFAULT_CATEGORIES as CATEGORIES } from '../playerRankings'
 import type { Player } from '../../types/api'
 import type { RankingsConfig } from '../playerRankings'
 
@@ -113,10 +113,10 @@ describe('computePlayerRankings', () => {
       makePlayer({ name: 'A', pts: 40, ast: 1 }),
       makePlayer({ name: 'B', pts: 5, ast: 20 }),
     ]
-    const puntPts = { ...defaultWeights, pts: 0 }
+    const puntPts = { ...defaultWeights, PTS: 0 }
     const result = computePlayerRankings(players, { ...defaultConfig, weights: puntPts })
     expect(result[0].player.player_name).toBe('B')
-    expect(result[0].zScores.pts).toBeDefined()
+    expect(result[0].zScores.PTS).toBeDefined()
   })
 
   it('per_game mode divides counting stats by GP', () => {
@@ -200,5 +200,45 @@ describe('partitionByDataAvailability', () => {
     const { available, excluded } = partitionByDataAvailability([])
     expect(available).toEqual([])
     expect(excluded).toEqual([])
+  })
+})
+
+describe('computePlayerRankings — dynamic categories', () => {
+  function makePlayerWithTO(name: string, to: number, pts: number): Player {
+    return {
+      player_name: name,
+      pro_team: 'LAL',
+      positions: ['PG'],
+      stats: {
+        pts, reb: 5, ast: 5, stl: 1, blk: 0.5, three_pm: 2,
+        fg_percentage: 0.47, ft_percentage: 0.85,
+        fgm: 8, fga: 17, ftm: 4, fta: 5,
+        minutes: 30, gp: 70,
+        stats: { 'FG%': 0.47, 'FT%': 0.85, '3PM': 2, AST: 5, REB: 5, STL: 1, BLK: 0.5, PTS: pts, TO: to },
+      },
+      team_id: 1,
+      status: 'ONTEAM',
+    }
+  }
+
+  it('ranks over an arbitrary extra category (TO) when passed explicitly', () => {
+    const categories = [...CATEGORIES, 'TO']
+    const players = [
+      makePlayerWithTO('LowTO', 20, 100),
+      makePlayerWithTO('HighTO', 200, 100),
+    ]
+    const weights = Object.fromEntries(categories.map(c => [c, c === 'TO' ? 1 : 0])) as Record<string, number>
+    const result = computePlayerRankings(players, { ...defaultConfig, weights }, categories)
+    // Only TO has weight -> whichever has the higher raw TO value scores
+    // higher here (this util doesn't know TO is "lower is better" — that's
+    // handled server-side via ESPN's isReverseItem, same as team rankings).
+    expect(result[0].player.player_name).toBe('HighTO')
+    expect(result[0].zScores.TO).toBeGreaterThan(result[1].zScores.TO)
+  })
+
+  it('falls back to the fixed field when stats.stats is missing a category', () => {
+    const legacyPlayer = makePlayer({ name: 'Legacy', pts: 30 })
+    const result = computePlayerRankings([legacyPlayer], defaultConfig)
+    expect(result[0].zScores.PTS).toBeDefined()
   })
 })

--- a/frontend/src/utils/draftReport.ts
+++ b/frontend/src/utils/draftReport.ts
@@ -3,7 +3,7 @@ import {
   computePlayerRankings,
   scoreAgainstPool,
   partitionByDataAvailability,
-  CATEGORIES,
+  DEFAULT_CATEGORIES,
   type RankingCategory,
 } from './playerRankings'
 
@@ -46,7 +46,7 @@ export interface TeamDiff {
 export const MIN_GP_FOR_RANK = 15
 export const LOW_GP_MIN = 1
 const STEAL_MIN_GP = 50
-const WEIGHTS = Object.fromEntries(CATEGORIES.map(c => [c, 1])) as Record<RankingCategory, number>
+const WEIGHTS = Object.fromEntries(DEFAULT_CATEGORIES.map(c => [c, 1])) as Record<RankingCategory, number>
 
 function badgeFor(diff: number): DraftBadge {
   if (diff >= 25) return 'Steal'

--- a/frontend/src/utils/playerRankings.ts
+++ b/frontend/src/utils/playerRankings.ts
@@ -1,21 +1,47 @@
-import type { Player } from '../types/api'
+import type { Player, PlayerStats } from '../types/api'
 
-export type RankingCategory = 'fg_pct' | 'ft_pct' | 'three_pm' | 'reb' | 'ast' | 'stl' | 'blk' | 'pts'
+// A category code as used across the app (e.g. "FG%", "PTS", "TO") — this
+// league's actual scoring categories, not a fixed set. Falls back to
+// DEFAULT_CATEGORIES (the historical 8) wherever a definitive list from the
+// API isn't available yet (e.g. before the first response lands).
+export type RankingCategory = string
 
-export const CATEGORIES: RankingCategory[] = ['fg_pct', 'ft_pct', 'three_pm', 'reb', 'ast', 'stl', 'blk', 'pts']
+export const DEFAULT_CATEGORIES: RankingCategory[] = ['FG%', 'FT%', '3PM', 'AST', 'REB', 'STL', 'BLK', 'PTS']
 
-export const CATEGORY_LABELS: Record<RankingCategory, string> = {
-  fg_pct: 'FG%',
-  ft_pct: 'FT%',
-  three_pm: '3PM',
-  reb: 'REB',
-  ast: 'AST',
-  stl: 'STL',
-  blk: 'BLK',
-  pts: 'PTS',
+export const PERCENTAGE_CATEGORIES = new Set(['FG%', 'FT%'])
+
+// Percentage categories need a paired "attempts" quantity to compute a
+// makes-weighted z-score (see pctImpactArray) — FG%/FT% are the only two
+// ESPN scores this way, so this pairing is inherent to the stat, not a
+// hardcoded category set.
+const ATTEMPT_KEY: Record<string, 'fga' | 'fta'> = { 'FG%': 'fga', 'FT%': 'fta' }
+
+// Category codes that still have a dedicated PlayerStats field, used as a
+// fallback when a player's generic `stats.stats` dict doesn't carry a given
+// category (e.g. an older cached response, or a test fixture that only sets
+// the fixed fields).
+const FIXED_FIELD_KEY: Partial<Record<string, keyof PlayerStats>> = {
+  'FG%': 'fg_percentage',
+  'FT%': 'ft_percentage',
+  '3PM': 'three_pm',
+  AST: 'ast',
+  REB: 'reb',
+  STL: 'stl',
+  BLK: 'blk',
+  PTS: 'pts',
 }
 
-const COUNTING_CATS = new Set<RankingCategory>(['three_pm', 'reb', 'ast', 'stl', 'blk', 'pts'])
+export const CATEGORY_LABELS: Record<string, string> = {
+  'FG%': 'FG%',
+  'FT%': 'FT%',
+  '3PM': '3PM',
+  AST: 'AST',
+  REB: 'REB',
+  STL: 'STL',
+  BLK: 'BLK',
+  PTS: 'PTS',
+  TO: 'TO',
+}
 
 export interface RankingsConfig {
   calcMode: 'totals' | 'per_game'
@@ -31,28 +57,26 @@ export interface RankedPlayer {
   totalZ: number
 }
 
-function getCatValue(player: Player, cat: RankingCategory, calcMode: 'totals' | 'per_game'): number {
-  const s = player.stats
-  const gp = Math.max(s.gp, 1)
-  const raw: Record<RankingCategory, number> = {
-    fg_pct: s.fg_percentage,
-    ft_pct: s.ft_percentage,
-    three_pm: s.three_pm,
-    reb: s.reb,
-    ast: s.ast,
-    stl: s.stl,
-    blk: s.blk,
-    pts: s.pts,
-  }
-  return calcMode === 'per_game' && COUNTING_CATS.has(cat) ? raw[cat] / gp : raw[cat]
+function rawCatValue(player: Player, cat: RankingCategory): number {
+  const fromGeneric = player.stats.stats?.[cat]
+  if (fromGeneric !== undefined) return fromGeneric
+  const fixedKey = FIXED_FIELD_KEY[cat]
+  return fixedKey ? (player.stats[fixedKey] as number) : 0
 }
 
-function pctImpactArray(pool: Player[], pctKey: 'fg_percentage' | 'ft_percentage', attemptKey: 'fga' | 'fta', calcMode: 'totals' | 'per_game'): number[] {
-  const poolMean = pool.reduce((s, p) => s + p.stats[pctKey], 0) / pool.length
+function getCatValue(player: Player, cat: RankingCategory, calcMode: 'totals' | 'per_game'): number {
+  const gp = Math.max(player.stats.gp, 1)
+  const raw = rawCatValue(player, cat)
+  return calcMode === 'per_game' && !PERCENTAGE_CATEGORIES.has(cat) ? raw / gp : raw
+}
+
+function pctImpactArray(pool: Player[], cat: RankingCategory, calcMode: 'totals' | 'per_game'): number[] {
+  const attemptKey = ATTEMPT_KEY[cat] ?? 'fga'
+  const poolMean = pool.reduce((s, p) => s + rawCatValue(p, cat), 0) / pool.length
   return pool.map(p => {
     const gp = Math.max(p.stats.gp, 1)
     const attempts = calcMode === 'per_game' ? p.stats[attemptKey] / gp : p.stats[attemptKey]
-    return (p.stats[pctKey] - poolMean) * attempts
+    return (rawCatValue(p, cat) - poolMean) * attempts
   })
 }
 
@@ -68,16 +92,15 @@ function zScoreArray(values: number[]): number[] {
   return values.map(v => (stdev === 0 ? 0 : (v - mean) / stdev))
 }
 
-function totalZArray(pool: Player[], calcMode: 'totals' | 'per_game', weights: Record<RankingCategory, number>): number[] {
-  const catZs = CATEGORIES.map(cat => {
-    if (cat === 'fg_pct') return zScoreArray(pctImpactArray(pool, 'fg_percentage', 'fga', calcMode))
-    if (cat === 'ft_pct') return zScoreArray(pctImpactArray(pool, 'ft_percentage', 'fta', calcMode))
-    return zScoreArray(pool.map(p => getCatValue(p, cat, calcMode)))
-  })
-  return pool.map((_, i) => CATEGORIES.reduce((sum, cat, ci) => sum + catZs[ci][i] * weights[cat], 0) / CATEGORIES.length)
+function categoryZArrays(pool: Player[], categories: RankingCategory[], calcMode: 'totals' | 'per_game'): number[][] {
+  return categories.map(cat =>
+    PERCENTAGE_CATEGORIES.has(cat)
+      ? zScoreArray(pctImpactArray(pool, cat, calcMode))
+      : zScoreArray(pool.map(p => getCatValue(p, cat, calcMode)))
+  )
 }
 
-export function computePlayerRankings(players: Player[], config: RankingsConfig): RankedPlayer[] {
+export function computePlayerRankings(players: Player[], config: RankingsConfig, categories: RankingCategory[] = DEFAULT_CATEGORIES): RankedPlayer[] {
   const { calcMode, minGp, minMin, position, weights } = config
 
   const filtered = players.filter(p =>
@@ -90,7 +113,8 @@ export function computePlayerRankings(players: Player[], config: RankingsConfig)
 
   let referencePool: Player[]
   if (filtered.length >= 300) {
-    const pass1Z = totalZArray(filtered, calcMode, weights)
+    const pass1CatZs = categoryZArrays(filtered, categories, calcMode)
+    const pass1Z = filtered.map((_, i) => categories.reduce((sum, cat, ci) => sum + pass1CatZs[ci][i] * weights[cat], 0) / categories.length)
     referencePool = filtered
       .map((p, i) => ({ p, z: pass1Z[i] }))
       .sort((a, b) => b.z - a.z)
@@ -100,18 +124,14 @@ export function computePlayerRankings(players: Player[], config: RankingsConfig)
     referencePool = filtered
   }
 
-  const catZs = CATEGORIES.map(cat => {
-    if (cat === 'fg_pct') return zScoreArray(pctImpactArray(referencePool, 'fg_percentage', 'fga', calcMode))
-    if (cat === 'ft_pct') return zScoreArray(pctImpactArray(referencePool, 'ft_percentage', 'fta', calcMode))
-    return zScoreArray(referencePool.map(p => getCatValue(p, cat, calcMode)))
-  })
+  const catZs = categoryZArrays(referencePool, categories, calcMode)
 
   return referencePool
     .map((p, i) => {
       const zScores = Object.fromEntries(
-        CATEGORIES.map((cat, ci) => [cat, catZs[ci][i]])
+        categories.map((cat, ci) => [cat, catZs[ci][i]])
       ) as Record<RankingCategory, number>
-      const totalZ = CATEGORIES.reduce((sum, cat) => sum + zScores[cat] * weights[cat], 0) / CATEGORIES.length
+      const totalZ = categories.reduce((sum, cat) => sum + zScores[cat] * weights[cat], 0) / categories.length
       return { player: p, zScores, totalZ }
     })
     .sort((a, b) => b.totalZ - a.totalZ)
@@ -124,23 +144,22 @@ export function getRawValue(player: Player, cat: RankingCategory, displayMode: '
 // Scores a player outside a ranking's referencePool (e.g. below the minGp
 // cutoff) against that same pool's mean/stdev, so the number is directly
 // comparable to the totalZ values computePlayerRankings produced for it.
-export function scoreAgainstPool(player: Player, referencePool: Player[], calcMode: 'totals' | 'per_game', weights: Record<RankingCategory, number>): number {
-  const catZs = CATEGORIES.map(cat => {
-    if (cat === 'fg_pct' || cat === 'ft_pct') {
-      const pctKey = cat === 'fg_pct' ? 'fg_percentage' : 'ft_percentage'
-      const attemptKey = cat === 'fg_pct' ? 'fga' : 'fta'
-      const poolMean = referencePool.reduce((s, p) => s + p.stats[pctKey], 0) / referencePool.length
-      const { mean, stdev } = meanStdev(pctImpactArray(referencePool, pctKey, attemptKey, calcMode))
+export function scoreAgainstPool(player: Player, referencePool: Player[], calcMode: 'totals' | 'per_game', weights: Record<RankingCategory, number>, categories: RankingCategory[] = DEFAULT_CATEGORIES): number {
+  const catZs = categories.map(cat => {
+    if (PERCENTAGE_CATEGORIES.has(cat)) {
+      const poolMean = referencePool.reduce((s, p) => s + rawCatValue(p, cat), 0) / referencePool.length
+      const { mean, stdev } = meanStdev(pctImpactArray(referencePool, cat, calcMode))
+      const attemptKey = ATTEMPT_KEY[cat] ?? 'fga'
       const gp = Math.max(player.stats.gp, 1)
       const attempts = calcMode === 'per_game' ? player.stats[attemptKey] / gp : player.stats[attemptKey]
-      const playerImpact = (player.stats[pctKey] - poolMean) * attempts
+      const playerImpact = (rawCatValue(player, cat) - poolMean) * attempts
       return stdev === 0 ? 0 : (playerImpact - mean) / stdev
     }
     const { mean, stdev } = meanStdev(referencePool.map(p => getCatValue(p, cat, calcMode)))
     const playerValue = getCatValue(player, cat, calcMode)
     return stdev === 0 ? 0 : (playerValue - mean) / stdev
   })
-  return CATEGORIES.reduce((sum, cat, ci) => sum + catZs[ci] * weights[cat], 0) / CATEGORIES.length
+  return categories.reduce((sum, cat, ci) => sum + catZs[ci] * weights[cat], 0) / categories.length
 }
 
 export interface DataAvailabilityPartition {


### PR DESCRIPTION
## Summary
Stacked on #212. Completes the Player Rankings piece: the z-score engine now takes a `categories` list (defaulting to `DEFAULT_CATEGORIES`, the historical 8) instead of a hardcoded module-level constant. Category codes now match the rest of the app (`'FG%'`, `'PTS'`, `'TO'`, ...) instead of the old private snake_case keys, reading from `PlayerStats`' new generic `stats` dict (#212) with a fallback to the fixed fields where a category isn't present there (older cached response, plain test fixture).

- `playerRankings.ts` — full z-score engine (`computePlayerRankings`, `scoreAgainstPool`, `getRawValue`) now takes a `categories` param.
- `PlayerRankings.tsx` — category list comes from the live API response (`playersData.categories`), with `DEFAULT_CATEGORIES` as a pre-load fallback. A persisted weights object missing an entry for a newly-scored category (e.g. TO) defaults that entry to 1 rather than silently treating it as punted. All render loops (columns, weight sliders) iterate the live category list.
- `draftReport.ts` — only needed a rename; draft reports stay on the fixed default set, out of scope here.
- `types/api.ts` — added `stats?`/`categories?` matching the backend; added a `PlayerStatKey` type (`Exclude<keyof PlayerStats, 'stats'>`) and used it wherever `PlayerStats` is indexed dynamically by key (`Players.tsx`, `TeamDetail.tsx`, `PlayerProfile.tsx`, `TradeSuggestions/PlayerStatsTable.tsx`) — adding a non-numeric `stats` field to the interface broke `keyof PlayerStats` in all of those.

## Test plan
- [x] 2 new tests: ranks over an arbitrary extra category end-to-end; falls back to the fixed field when `stats.stats` doesn't carry a category
- [x] Full frontend suite: **189 passed** (2 new), 0 failures
- [x] `tsc -b` clean
- [x] Manually verified with a **real browser** (Playwright/Chromium) against a real running backend (mocked ESPN, turnovers-scoring league) and Vite dev server: renders a TO column, TO weight slider, and TO_z score correctly, zero console/page errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR3E5SAZSkNfMygaeuvt9f)_