### PR TITLE
feat: store per-category extras as JSONB (dual-write + Standings Race)

### DIFF
--- a/backend/app/models/league.py
+++ b/backend/app/models/league.py
@@ -56,6 +56,10 @@ class TeamTimeSeriesPoint(BaseModel):
     rk_blk: Optional[float] = None
     rk_pts: Optional[float] = None
     rk_total: Optional[float] = None
+    # Generic category -> rank mapping, present only when this league scores
+    # categories with no rk_* column (see category_storage). Null otherwise, so
+    # a fixed-category league's payload is unchanged.
+    ranks: Optional[Dict[str, float]] = None
     gp: Optional[int] = None
     fg_pct: Optional[float] = None
     ft_pct: Optional[float] = None

--- a/backend/app/services/data_provider.py
+++ b/backend/app/services/data_provider.py
@@ -3,7 +3,7 @@ import logging
 import httpx
 import json
 from datetime import datetime, timedelta
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 import pandas as pd
 from app.services.cache_manager import CacheManager
 from app.services.data_transformer import DataTransformer
@@ -11,6 +11,8 @@ from app.services.db_service import DBService
 from app.config import settings
 from app.exceptions import DataSourceError
 from app.utils.constants import RANKING_CATEGORIES
+from app.utils import category_storage
+from app.utils.category_storage import RANKINGS_FIXED_CATEGORIES, TOTAL_KEY
 
 class DataProvider:
     """Centralized data provider with caching for all ESPN data operations"""
@@ -350,25 +352,54 @@ class DataProvider:
 
         return totals_df, averages_df, rankings_df
     
+    def _extra_rank_payloads(self, df: pd.DataFrame, categories: list, reverse_categories: set) -> Optional[dict]:
+        """{team_id: {category: rank, ..., TOTAL: all-category total}} for the
+        categories with no rk_* column, or None when the league scores only the
+        fixed ones — which is what keeps the JSONB column NULL and free."""
+        extra_cats = [c for c in categories if c not in RANKINGS_FIXED_CATEGORIES and c in df.columns]
+        if not extra_cats:
+            return None
+
+        cols = ['team_id', 'team_name'] + [c for c in categories if c in df.columns] + ['GP']
+        full = self.data_transformer.averages_to_rankings_df(
+            df[[c for c in cols if c in df.columns]], reverse_categories
+        )
+        return {
+            int(row['team_id']): {
+                **{cat: category_storage.json_safe(row[cat]) for cat in extra_cats},
+                TOTAL_KEY: category_storage.json_safe(row['TOTAL_POINTS']),
+            }
+            for _, row in full.iterrows()
+        }
+
     async def _sync_db_if_needed(self, scoring_period_id: int, totals_df: pd.DataFrame) -> None:
         completed_period = scoring_period_id - 1
         async with self._db_sync_lock:
             if self._last_synced_period >= completed_period:
                 return
             try:
-                averages_df = self.data_transformer.totals_to_averages_df(totals_df)
-                # The rankings tables have one column per category fixed at the
-                # historical 8, so rank only those — otherwise an extra resolved
-                # category (e.g. TO) would be summed into TOTAL_POINTS and stored
-                # as rk_total while its own rank column has nowhere to go.
+                categories = await self.get_ranking_categories()
+                reverse_categories = await self.get_reverse_categories()
+
+                averages_df = self.data_transformer.totals_to_averages_df(totals_df, categories)
+                # The rk_* columns are fixed at the historical 8, so rank only
+                # those for them: rk_total keeps meaning "total over the fixed
+                # categories" for every row ever written. Extra categories are
+                # ranked separately below and stored as JSONB.
                 avg_cols_to_keep = ['team_id', 'team_name'] + [c for c in RANKING_CATEGORIES if c in averages_df.columns] + ['GP']
                 averages_for_ranking = averages_df[[c for c in avg_cols_to_keep if c in averages_df.columns]]
-                rankings_avg_df = self.data_transformer.averages_to_rankings_df(averages_for_ranking)
+                rankings_avg_df = self.data_transformer.averages_to_rankings_df(averages_for_ranking, reverse_categories)
 
                 totals_for_ranking = totals_df.drop(['FGM', 'FGA', 'FTM', 'FTA'], axis=1).copy()
                 cols_to_keep = ['team_id', 'team_name'] + [c for c in RANKING_CATEGORIES if c in totals_for_ranking.columns] + ['GP']
                 totals_for_ranking = totals_for_ranking[[c for c in cols_to_keep if c in totals_for_ranking.columns]]
-                rankings_totals_df = self.data_transformer.averages_to_rankings_df(totals_for_ranking)
+                rankings_totals_df = self.data_transformer.averages_to_rankings_df(totals_for_ranking, reverse_categories)
+
+                avg_extras = self._extra_rank_payloads(averages_df, categories, reverse_categories)
+                totals_extras = self._extra_rank_payloads(
+                    totals_df.drop(['FGM', 'FGA', 'FTM', 'FTA'], axis=1, errors='ignore'),
+                    categories, reverse_categories,
+                )
 
                 league_id, season_id = settings.league_id, settings.season_id
                 max_avg, max_tot, max_snap = await asyncio.gather(
@@ -379,9 +410,9 @@ class DataProvider:
 
                 tasks = []
                 if max_avg < completed_period:
-                    tasks.append(self.db_service.upsert_rankings_averages(completed_period, rankings_avg_df, league_id, season_id))
+                    tasks.append(self.db_service.upsert_rankings_averages(completed_period, rankings_avg_df, league_id, season_id, avg_extras))
                 if max_tot < completed_period:
-                    tasks.append(self.db_service.upsert_rankings_totals(completed_period, rankings_totals_df, league_id, season_id))
+                    tasks.append(self.db_service.upsert_rankings_totals(completed_period, rankings_totals_df, league_id, season_id, totals_extras))
                 if max_snap < completed_period:
                     tasks.append(self.db_service.upsert_daily_snapshot(completed_period, totals_df, league_id, season_id))
 

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from datetime import date, timedelta
@@ -5,6 +6,8 @@ from typing import Optional
 import asyncpg
 import pandas as pd
 from app.config import settings
+from app.utils import category_storage
+from app.utils.category_storage import SNAPSHOT_FIXED_CATEGORIES, TOTAL_KEY
 from app.models.injury_models import InjuryRecord
 from model_stats_inference.research import config as rconfig
 
@@ -38,8 +41,21 @@ def fs_records_to_frame(records) -> pd.DataFrame:
     return df
 
 
+async def _init_connection(conn: asyncpg.Connection) -> None:
+    """asyncpg hands back jsonb as str without this, so every read site would
+    have to json.loads by hand."""
+    await conn.set_type_codec(
+        'jsonb', encoder=json.dumps, decoder=json.loads, schema='pg_catalog'
+    )
+
+
 class DBService:
     _instance = None
+    # None until probed once. Lets this code run against a database where
+    # add_dynamic_category_columns.sql has not been applied yet: without the
+    # probe every upsert would raise UndefinedColumnError into a log line and
+    # snapshots would quietly stop being written.
+    _dynamic_columns: Optional[bool] = None
 
     def __new__(cls):
         if cls._instance is None:
@@ -56,11 +72,33 @@ class DBService:
                     settings.database_url,
                     min_size=1,
                     max_size=5,
+                    init=_init_connection,
                 )
             except Exception as e:
                 logger.error(f"Failed to create DB connection pool: {e}")
                 return None
         return self._pool
+
+    async def _supports_dynamic_categories(self, conn) -> bool:
+        if DBService._dynamic_columns is None:
+            try:
+                DBService._dynamic_columns = bool(await conn.fetchval(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'team_daily_snapshot' AND column_name = 'stats'
+                    )
+                    """
+                ))
+                if not DBService._dynamic_columns:
+                    logger.warning(
+                        "team_daily_snapshot.stats missing - per-category extras will not be "
+                        "stored. Apply migrations/add_dynamic_category_columns.sql."
+                    )
+            except Exception as e:
+                logger.error(f"Failed to probe for dynamic category columns: {e}")
+                DBService._dynamic_columns = False
+        return DBService._dynamic_columns
 
     async def get_db_max_scoring_period(self, table: str, league_id: int, season_id: int) -> int:
         pool = await self._get_pool()
@@ -79,21 +117,27 @@ class DBService:
             return 0
 
     async def upsert_rankings_averages(
-        self, scoring_period_id: int, rankings_df: pd.DataFrame, league_id: int, season_id: int
+        self, scoring_period_id: int, rankings_df: pd.DataFrame, league_id: int, season_id: int,
+        extras_by_team: Optional[dict] = None,
     ) -> None:
+        """extras_by_team: {team_id: {category: rank}} for categories with no
+        rk_* column, plus TOTAL. None (the default) writes NULL, which is what a
+        league on the fixed categories stores."""
         pool = await self._get_pool()
         if pool is None:
             return
         snap_date = settings.season_start + timedelta(days=scoring_period_id - 1)
         try:
             async with pool.acquire() as conn:
+                dynamic = await self._supports_dynamic_categories(conn)
                 await conn.executemany(
-                    """
+                    f"""
                     INSERT INTO team_rankings_averages
                         (league_id, season_id, scoring_period_id, date, team_id, team_name,
                          rk_fg_pct, rk_ft_pct, rk_three_pm, rk_reb,
-                         rk_ast, rk_stl, rk_blk, rk_pts, rk_total)
-                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                         rk_ast, rk_stl, rk_blk, rk_pts, rk_total
+                         {', ranks' if dynamic else ''})
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15{',$16::jsonb' if dynamic else ''})
                     ON CONFLICT (league_id, season_id, scoring_period_id, team_id) DO UPDATE SET
                         team_name   = EXCLUDED.team_name,
                         rk_fg_pct   = EXCLUDED.rk_fg_pct,
@@ -105,6 +149,7 @@ class DBService:
                         rk_blk      = EXCLUDED.rk_blk,
                         rk_pts      = EXCLUDED.rk_pts,
                         rk_total    = EXCLUDED.rk_total
+                        {', ranks = EXCLUDED.ranks' if dynamic else ''}
                     """,
                     [
                         (
@@ -113,7 +158,9 @@ class DBService:
                             float(row['FG%']), float(row['FT%']), float(row['3PM']),
                             float(row['REB']), float(row['AST']), float(row['STL']),
                             float(row['BLK']), float(row['PTS']), float(row['TOTAL_POINTS']),
-                        )
+                        ) + ((
+                            category_storage.dumps((extras_by_team or {}).get(int(row['team_id']))),
+                        ) if dynamic else ())
                         for _, row in rankings_df.iterrows()
                     ],
                 )
@@ -125,21 +172,27 @@ class DBService:
             logger.error(f"Failed to upsert team_rankings_averages: {e}")
 
     async def upsert_rankings_totals(
-        self, scoring_period_id: int, rankings_totals_df: pd.DataFrame, league_id: int, season_id: int
+        self, scoring_period_id: int, rankings_totals_df: pd.DataFrame, league_id: int, season_id: int,
+        extras_by_team: Optional[dict] = None,
     ) -> None:
+        """extras_by_team: {team_id: {category: rank}} for categories with no
+        rk_* column, plus TOTAL. None (the default) writes NULL, which is what a
+        league on the fixed categories stores."""
         pool = await self._get_pool()
         if pool is None:
             return
         snap_date = settings.season_start + timedelta(days=scoring_period_id - 1)
         try:
             async with pool.acquire() as conn:
+                dynamic = await self._supports_dynamic_categories(conn)
                 await conn.executemany(
-                    """
+                    f"""
                     INSERT INTO team_rankings_totals
                         (league_id, season_id, scoring_period_id, date, team_id, team_name,
                          rk_fg_pct, rk_ft_pct, rk_three_pm, rk_reb,
-                         rk_ast, rk_stl, rk_blk, rk_pts, rk_total)
-                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                         rk_ast, rk_stl, rk_blk, rk_pts, rk_total
+                         {', ranks' if dynamic else ''})
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15{',$16::jsonb' if dynamic else ''})
                     ON CONFLICT (league_id, season_id, scoring_period_id, team_id) DO UPDATE SET
                         team_name   = EXCLUDED.team_name,
                         rk_fg_pct   = EXCLUDED.rk_fg_pct,
@@ -151,6 +204,7 @@ class DBService:
                         rk_blk      = EXCLUDED.rk_blk,
                         rk_pts      = EXCLUDED.rk_pts,
                         rk_total    = EXCLUDED.rk_total
+                        {', ranks = EXCLUDED.ranks' if dynamic else ''}
                     """,
                     [
                         (
@@ -159,7 +213,9 @@ class DBService:
                             float(row['FG%']), float(row['FT%']), float(row['3PM']),
                             float(row['REB']), float(row['AST']), float(row['STL']),
                             float(row['BLK']), float(row['PTS']), float(row['TOTAL_POINTS']),
-                        )
+                        ) + ((
+                            category_storage.dumps((extras_by_team or {}).get(int(row['team_id']))),
+                        ) if dynamic else ())
                         for _, row in rankings_totals_df.iterrows()
                     ],
                 )
@@ -179,6 +235,7 @@ class DBService:
         snap_date = settings.season_start + timedelta(days=scoring_period_id - 1)
         try:
             async with pool.acquire() as conn:
+                dynamic = await self._supports_dynamic_categories(conn)
                 rows = []
                 for _, row in totals_df.iterrows():
                     fgm = int(row['FGM'])
@@ -193,14 +250,19 @@ class DBService:
                         ftm, fta, round(ftm / fta, 4) if fta > 0 else 0.0,
                         int(row['3PM']), int(row['REB']), int(row['AST']),
                         int(row['STL']), int(row['BLK']), int(row['PTS']),
-                    ))
+                    ) + ((
+                        category_storage.dumps(
+                            category_storage.extra_categories(row, SNAPSHOT_FIXED_CATEGORIES)
+                        ),
+                    ) if dynamic else ()))
                 await conn.executemany(
-                    """
+                    f"""
                     INSERT INTO team_daily_snapshot
                         (league_id, season_id, scoring_period_id, date, team_id, team_name,
                          gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
-                         three_pm, reb, ast, stl, blk, pts)
-                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
+                         three_pm, reb, ast, stl, blk, pts
+                         {', stats' if dynamic else ''})
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19{',$20::jsonb' if dynamic else ''})
                     ON CONFLICT (league_id, season_id, scoring_period_id, team_id) DO UPDATE SET
                         team_name = EXCLUDED.team_name,
                         gp        = EXCLUDED.gp,
@@ -216,6 +278,7 @@ class DBService:
                         stl       = EXCLUDED.stl,
                         blk       = EXCLUDED.blk,
                         pts       = EXCLUDED.pts
+                        {', stats = EXCLUDED.stats' if dynamic else ''}
                     """,
                     rows,
                 )
@@ -269,12 +332,14 @@ class DBService:
             return []
         try:
             async with pool.acquire() as conn:
+                dynamic = await self._supports_dynamic_categories(conn)
                 if team_ids:
                     rows = await conn.fetch(
                         f"""
                         SELECT r.date, r.team_id, r.team_name,
                                r.rk_fg_pct, r.rk_ft_pct, r.rk_three_pm, r.rk_reb,
                                r.rk_ast, r.rk_stl, r.rk_blk, r.rk_pts, r.rk_total,
+                               {'r.ranks,' if dynamic else ''}
                                s.gp
                         FROM {table} r
                         LEFT JOIN team_daily_snapshot s
@@ -291,6 +356,7 @@ class DBService:
                         SELECT r.date, r.team_id, r.team_name,
                                r.rk_fg_pct, r.rk_ft_pct, r.rk_three_pm, r.rk_reb,
                                r.rk_ast, r.rk_stl, r.rk_blk, r.rk_pts, r.rk_total,
+                               {'r.ranks,' if dynamic else ''}
                                s.gp
                         FROM {table} r
                         LEFT JOIN team_daily_snapshot s
@@ -301,10 +367,30 @@ class DBService:
                         """,
                         league_id, season_id,
                     )
-                return [dict(r) for r in rows]
+                return [self._rankings_row_to_point(dict(r)) for r in rows]
         except Exception as e:
             logger.error(f"Failed to fetch rankings over time from {table}: {e}")
             return []
+
+    @staticmethod
+    def _rankings_row_to_point(row: dict) -> dict:
+        """Fold the JSONB extras into a generic `ranks` mapping alongside the
+        rk_* columns the response already carries.
+
+        `TOTAL` overrides rk_total when present: rk_total is the total over the
+        fixed categories only, so for a league scoring more than those it is the
+        wrong number to plot."""
+        stored = category_storage.loads(row.pop('ranks', None))
+        if not stored:
+            row['ranks'] = None
+            return row
+
+        total = stored.pop(TOTAL_KEY, None)
+        if total is not None:
+            row['rk_total'] = total
+        fixed = {cat: row.get(col) for cat, col in _RANKINGS_COL_MAP.items()}
+        row['ranks'] = category_storage.merge_categories(fixed, stored)
+        return row
 
     async def get_snapshot_over_time(
         self, team_ids: list[int] | None, league_id: int, season_id: int

--- a/backend/app/utils/category_storage.py
+++ b/backend/app/utils/category_storage.py
@@ -1,0 +1,104 @@
+"""Storage of per-category values that have no dedicated DB column.
+
+`team_daily_snapshot` and the two rankings tables carry one column per category
+for the historical fixed set. A league scoring anything beyond it (e.g. TO) has
+nowhere to put the value, so those extras live in a JSONB column alongside.
+
+Only the extras are ever stored there, never a mirror of the fixed columns: a
+value lives in exactly one place, so a column and a JSON key cannot drift apart,
+and a league on the fixed categories writes NULL and pays nothing.
+
+The cost of that choice is that reads must combine the two, which is what
+`merge_categories` is for. It is deliberately the only place that knows values
+come from two sources -- if the JSONB ever becomes the whole story, this is the
+one function that changes.
+"""
+import json
+import math
+from typing import Dict, Optional, Union
+
+from app.utils.constants import RANKING_CATEGORIES
+
+# Categories with a dedicated column, per table. Anything outside these is an
+# "extra" and goes to JSONB.
+SNAPSHOT_FIXED_CATEGORIES = frozenset({
+    'GP', 'FGM', 'FGA', 'FG%', 'FTM', 'FTA', 'FT%', '3PM',
+    'REB', 'AST', 'STL', 'BLK', 'PTS',
+})
+RANKINGS_FIXED_CATEGORIES = frozenset(RANKING_CATEGORIES)
+
+# Key holding the all-category total in a rankings `ranks` document. rk_total
+# cannot carry it: that column means "total over the fixed categories" for every
+# row ever written, and re-pointing it would silently change what older rows say.
+TOTAL_KEY = 'TOTAL'
+
+_NON_CATEGORY_COLUMNS = frozenset({
+    'team_id', 'team_name', 'league_id', 'season_id', 'scoring_period_id',
+    'date', 'id', 'created_at', 'RANK', 'TOTAL_POINTS',
+})
+
+
+def json_safe(value) -> Optional[float]:
+    """A numpy scalar or NaN turned into something `json.dumps` accepts.
+
+    NaN and infinities are not valid JSON and Postgres rejects the payload
+    outright, so they become NULL rather than a token nothing can read back.
+    """
+    if value is None:
+        return None
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(as_float) or math.isinf(as_float):
+        return None
+    return as_float
+
+
+def extra_categories(row, fixed: frozenset) -> Optional[Dict[str, float]]:
+    """Values in `row` for categories that have no dedicated column.
+
+    Returns None rather than {} when there are none, so the column stays NULL
+    instead of storing an empty document on every row of every fixed-category
+    league.
+    """
+    extras = {
+        key: json_safe(row[key])
+        for key in row.keys()
+        if key not in fixed and key not in _NON_CATEGORY_COLUMNS
+    }
+    extras = {k: v for k, v in extras.items() if v is not None}
+    return extras or None
+
+
+def dumps(payload: Optional[Dict]) -> Optional[str]:
+    """Serialize an extras document for a `$n::jsonb` parameter."""
+    return None if payload is None else json.dumps(payload)
+
+
+def loads(stored: Union[str, Dict, None]) -> Dict[str, float]:
+    """Read back a stored extras document.
+
+    Tolerates both shapes: asyncpg hands back `str` unless a jsonb codec is
+    registered on the connection, and not every pool in this codebase is
+    guaranteed to have one.
+    """
+    if not stored:
+        return {}
+    if isinstance(stored, str):
+        try:
+            return json.loads(stored)
+        except (ValueError, TypeError):
+            return {}
+    return dict(stored)
+
+
+def merge_categories(fixed_values: Dict[str, Optional[float]],
+                     stored: Union[str, Dict, None]) -> Dict[str, float]:
+    """One category -> value mapping from the fixed columns plus stored extras.
+
+    The single seam between "some categories are columns" and "some are JSON".
+    """
+    merged = {k: v for k, v in fixed_values.items() if v is not None}
+    merged.update(loads(stored))
+    return merged

--- a/backend/migrations/add_dynamic_category_columns.sql
+++ b/backend/migrations/add_dynamic_category_columns.sql
@@ -1,0 +1,29 @@
+-- Dynamic categories: storage for per-category values that have no column.
+--
+-- The snapshot/rankings tables carry one column per category for the historical
+-- fixed set (FG%, FT%, 3PM, REB, AST, STL, BLK, PTS, plus the raw counting stats
+-- on the snapshot). A league scoring anything beyond that -- turnovers being the
+-- obvious case -- has nowhere to put the value. These columns hold exactly those
+-- extras, and nothing else: a category that already has a column is never
+-- mirrored here, so a column and a JSON key can never disagree.
+--
+-- For a league on the historical 8 the columns stay NULL and cost nothing.
+--
+-- Nullable ADD COLUMN is metadata-only on PG 11+: no table rewrite, safe to run
+-- against a live table. Nothing reads these until the reader PRs land.
+
+ALTER TABLE team_daily_snapshot    ADD COLUMN IF NOT EXISTS stats JSONB;
+ALTER TABLE team_rankings_averages ADD COLUMN IF NOT EXISTS ranks JSONB;
+ALTER TABLE team_rankings_totals   ADD COLUMN IF NOT EXISTS ranks JSONB;
+
+COMMENT ON COLUMN team_daily_snapshot.stats IS
+    'Per-category values with no dedicated column (e.g. {"TO": 120}). NULL when the league scores only the fixed categories.';
+COMMENT ON COLUMN team_rankings_averages.ranks IS
+    'Per-category ranks with no dedicated column, plus "TOTAL" (the all-category total, which rk_total cannot represent). NULL when the league scores only the fixed categories.';
+COMMENT ON COLUMN team_rankings_totals.ranks IS
+    'Per-category ranks with no dedicated column, plus "TOTAL" (the all-category total, which rk_total cannot represent). NULL when the league scores only the fixed categories.';
+
+-- Deliberately no GIN index. Every read reaches these rows by the existing
+-- (league_id, season_id, team_id, date) btree and then reads the whole document;
+-- nothing ever searches inside it. A GIN index here would cost more than the
+-- columns it indexes.

--- a/backend/tests/services/test_data_provider.py
+++ b/backend/tests/services/test_data_provider.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import pytest
 import httpx
 from datetime import datetime
@@ -10,6 +11,7 @@ from app.services.data_provider import DataProvider
 
 pytestmark = pytest.mark.real_dataprovider
 from app.exceptions import DataSourceError
+from app.utils.constants import RANKING_CATEGORIES
 
 
 def _api_teams_payload():
@@ -390,3 +392,76 @@ async def test_get_ranking_categories_falls_back_when_no_raw_cached(provider):
 
     assert categories == list(RANKING_CATEGORIES)
     provider._client.get.assert_not_called()
+
+
+@pytest.mark.real_dataprovider
+class TestExtraRankPayloads:
+    """What actually reaches the JSONB column on the write path."""
+
+    @staticmethod
+    def _provider():
+        from app.services.data_provider import DataProvider
+        DataProvider._instance = None
+        DataProvider._initialized = False
+        provider = DataProvider()
+        provider.db_service = AsyncMock()
+        return provider
+
+    @staticmethod
+    def _averages(with_turnovers: bool):
+        row_a = {'team_id': 1, 'team_name': 'Alpha', 'FG%': 0.47, 'FT%': 0.75,
+                 '3PM': 12.0, 'AST': 25.0, 'REB': 44.0, 'STL': 8.0, 'BLK': 5.0,
+                 'PTS': 112.0, 'GP': 47}
+        row_b = {**row_a, 'team_id': 2, 'team_name': 'Beta', 'PTS': 118.0}
+        if with_turnovers:
+            row_a['TO'] = 16.0
+            row_b['TO'] = 11.0
+        return pd.DataFrame([row_a, row_b])
+
+    def test_none_when_league_scores_only_fixed_categories(self):
+        """No extras means the column stays NULL — the whole cost argument."""
+        provider = self._provider()
+        try:
+            payload = provider._extra_rank_payloads(
+                self._averages(with_turnovers=False), list(RANKING_CATEGORIES), set()
+            )
+            assert payload is None
+        finally:
+            from app.services.data_provider import DataProvider
+            DataProvider._instance = None
+            DataProvider._initialized = False
+
+    def test_extra_category_is_ranked_and_totalled(self):
+        provider = self._provider()
+        try:
+            payload = provider._extra_rank_payloads(
+                self._averages(with_turnovers=True),
+                list(RANKING_CATEGORIES) + ['TO'],
+                {'TO'},
+            )
+
+            assert set(payload) == {1, 2}
+            # TO is reverse-scored: Beta turns it over less, so it ranks higher.
+            assert payload[2]['TO'] > payload[1]['TO']
+            # TOTAL spans all 9 categories, which rk_total cannot represent.
+            assert payload[1]['TOTAL'] > 0
+            assert set(payload[1]) == {'TO', 'TOTAL'}
+        finally:
+            from app.services.data_provider import DataProvider
+            DataProvider._instance = None
+            DataProvider._initialized = False
+
+    def test_payload_is_json_serializable(self):
+        """numpy scalars off a DataFrame would otherwise blow up json.dumps."""
+        provider = self._provider()
+        try:
+            payload = provider._extra_rank_payloads(
+                self._averages(with_turnovers=True),
+                list(RANKING_CATEGORIES) + ['TO'],
+                set(),
+            )
+            json.dumps(payload[1])
+        finally:
+            from app.services.data_provider import DataProvider
+            DataProvider._instance = None
+            DataProvider._initialized = False

--- a/backend/tests/services/test_db_service.py
+++ b/backend/tests/services/test_db_service.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 from unittest.mock import AsyncMock
 
@@ -8,13 +9,26 @@ from app.services.db_service import DBService
 
 
 class FakeConn:
-    def __init__(self, fetchrow_result=None, fetch_result=None, raise_on_fetch=False):
+    def __init__(self, fetchrow_result=None, fetch_result=None, raise_on_fetch=False,
+                 dynamic_columns=False):
         self.fetchrow = AsyncMock(return_value=fetchrow_result)
         if raise_on_fetch:
             self.fetch = AsyncMock(side_effect=RuntimeError("boom"))
         else:
             self.fetch = AsyncMock(return_value=fetch_result or [])
         self.executemany = AsyncMock(return_value=None)
+        # Answers the information_schema probe for the dynamic-category columns.
+        self.fetchval = AsyncMock(return_value=dynamic_columns)
+
+
+@pytest.fixture(autouse=True)
+def _reset_dynamic_column_probe():
+    """The probe result is cached on the class, so it would otherwise leak
+    between tests in whichever order they happen to run."""
+    from app.services.db_service import DBService
+    DBService._dynamic_columns = None
+    yield
+    DBService._dynamic_columns = None
 
 
 class FakeAcquireCtx:
@@ -313,7 +327,9 @@ async def test_get_rankings_over_time_joins_gp(db_service, monkeypatch):
 
     result = await db_service.get_rankings_over_time("team_rankings_totals", None, 1234567890, 2026)
 
-    assert result == rows
+    # `ranks` is added by the read path and is None for a fixed-category league,
+    # leaving every other field exactly as the row came out of the DB.
+    assert result == [{**rows[0], "ranks": None}]
     query = conn.fetch.call_args[0][0]
     assert "LEFT JOIN team_daily_snapshot" in query
     assert "s.gp" in query
@@ -385,3 +401,118 @@ def test_fs_records_to_frame_handles_no_rows():
     from app.services.db_service import fs_records_to_frame
 
     assert fs_records_to_frame([]).empty
+
+
+class TestRankingsRowToPoint:
+    """The Standings Race read path: fold JSONB extras into the row without
+    changing what a fixed-category league gets back."""
+
+    @staticmethod
+    def _row(**overrides):
+        row = {
+            'date': None, 'team_id': 1, 'team_name': 'Alpha',
+            'rk_fg_pct': 2.0, 'rk_ft_pct': 3.0, 'rk_three_pm': 2.0, 'rk_reb': 1.0,
+            'rk_ast': 2.0, 'rk_stl': 3.0, 'rk_blk': 1.0, 'rk_pts': 2.0,
+            'rk_total': 16.0, 'ranks': None, 'gp': 47,
+        }
+        row.update(overrides)
+        return row
+
+    def test_no_extras_leaves_the_payload_unchanged(self):
+        from app.services.db_service import DBService
+        out = DBService._rankings_row_to_point(self._row())
+
+        assert out['ranks'] is None
+        assert out['rk_total'] == 16.0
+        assert out['rk_pts'] == 2.0
+
+    def test_extras_are_merged_with_the_fixed_columns(self):
+        from app.services.db_service import DBService
+        out = DBService._rankings_row_to_point(self._row(ranks={'TO': 7.0, 'TOTAL': 23.0}))
+
+        assert out['ranks']['TO'] == 7.0
+        assert out['ranks']['PTS'] == 2.0
+        assert 'TOTAL' not in out['ranks']
+
+    def test_stored_total_overrides_the_fixed_category_total(self):
+        """rk_total only ever means 'total over the fixed categories', so a
+        league scoring more than those must not plot it."""
+        from app.services.db_service import DBService
+        out = DBService._rankings_row_to_point(self._row(ranks={'TO': 7.0, 'TOTAL': 23.0}))
+
+        assert out['rk_total'] == 23.0
+
+    def test_tolerates_a_json_string_when_no_codec_is_registered(self):
+        from app.services.db_service import DBService
+        out = DBService._rankings_row_to_point(self._row(ranks='{"TO": 7.0, "TOTAL": 23.0}'))
+
+        assert out['ranks']['TO'] == 7.0
+        assert out['rk_total'] == 23.0
+
+
+@pytest.mark.asyncio
+async def test_upsert_omits_extras_column_when_migration_not_applied(db_service, monkeypatch):
+    """Without add_dynamic_category_columns.sql the write must still succeed:
+    inserting into a missing column would fail into a log line and silently
+    stop snapshots being written."""
+    conn = FakeConn(dynamic_columns=False)
+    monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=FakePool(conn)))
+    df = pd.DataFrame([{
+        "team_id": 1, "team_name": "A",
+        "FG%": 1.0, "FT%": 2.0, "3PM": 3.0, "REB": 4.0,
+        "AST": 5.0, "STL": 6.0, "BLK": 7.0, "PTS": 8.0,
+        "TOTAL_POINTS": 36.0,
+    }])
+
+    await db_service.upsert_rankings_averages(5, df, 1234567890, 2026, {1: {"TO": 9.0}})
+
+    query = conn.executemany.call_args[0][0]
+    assert "ranks" not in query
+    assert len(conn.executemany.call_args[0][1][0]) == 15
+
+
+@pytest.mark.asyncio
+async def test_upsert_writes_extras_column_when_migration_applied(db_service, monkeypatch):
+    conn = FakeConn(dynamic_columns=True)
+    monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=FakePool(conn)))
+    df = pd.DataFrame([{
+        "team_id": 1, "team_name": "A",
+        "FG%": 1.0, "FT%": 2.0, "3PM": 3.0, "REB": 4.0,
+        "AST": 5.0, "STL": 6.0, "BLK": 7.0, "PTS": 8.0,
+        "TOTAL_POINTS": 36.0,
+    }])
+
+    await db_service.upsert_rankings_averages(5, df, 1234567890, 2026, {1: {"TO": 9.0}})
+
+    query = conn.executemany.call_args[0][0]
+    params = conn.executemany.call_args[0][1][0]
+    assert "ranks" in query
+    assert len(params) == 16
+    assert json.loads(params[-1]) == {"TO": 9.0}
+
+
+@pytest.mark.asyncio
+async def test_upsert_writes_null_extras_for_a_fixed_category_league(db_service, monkeypatch):
+    """The cost argument: nothing is stored when there is nothing extra."""
+    conn = FakeConn(dynamic_columns=True)
+    monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=FakePool(conn)))
+    df = pd.DataFrame([{
+        "team_id": 1, "team_name": "A",
+        "FG%": 1.0, "FT%": 2.0, "3PM": 3.0, "REB": 4.0,
+        "AST": 5.0, "STL": 6.0, "BLK": 7.0, "PTS": 8.0,
+        "TOTAL_POINTS": 36.0,
+    }])
+
+    await db_service.upsert_rankings_averages(5, df, 1234567890, 2026, None)
+
+    assert conn.executemany.call_args[0][1][0][-1] is None
+
+
+@pytest.mark.asyncio
+async def test_over_time_omits_extras_column_when_migration_not_applied(db_service, monkeypatch):
+    conn = FakeConn(fetch_result=[], dynamic_columns=False)
+    monkeypatch.setattr(db_service, "_get_pool", AsyncMock(return_value=FakePool(conn)))
+
+    await db_service.get_rankings_over_time("team_rankings_totals", None, 1234567890, 2026)
+
+    assert "r.ranks" not in conn.fetch.call_args[0][0]

--- a/backend/tests/utils/test_category_storage.py
+++ b/backend/tests/utils/test_category_storage.py
@@ -1,0 +1,102 @@
+import json
+
+import pandas as pd
+import pytest
+
+from app.utils import category_storage
+from app.utils.category_storage import (
+    RANKINGS_FIXED_CATEGORIES, SNAPSHOT_FIXED_CATEGORIES, TOTAL_KEY,
+)
+
+
+class TestJsonSafe:
+    def test_numpy_scalars_become_plain_floats(self):
+        row = pd.Series({'PTS': 1120})
+        value = category_storage.json_safe(row['PTS'])
+        assert isinstance(value, float)
+        json.dumps(value)
+
+    @pytest.mark.parametrize("bad", [float('nan'), float('inf'), float('-inf')])
+    def test_non_finite_becomes_none(self, bad):
+        """NaN/inf are not valid JSON and Postgres rejects the whole payload."""
+        assert category_storage.json_safe(bad) is None
+
+    def test_none_stays_none(self):
+        assert category_storage.json_safe(None) is None
+
+
+class TestExtraCategories:
+    def test_none_when_league_scores_only_fixed_categories(self):
+        """The whole point of extras-only storage: the column stays NULL."""
+        row = pd.Series({'team_id': 1, 'team_name': 'A', 'PTS': 1120, 'REB': 400,
+                         'GP': 47, 'FGM': 380, 'FGA': 810, 'FG%': 0.469,
+                         'FTM': 150, 'FTA': 200, 'FT%': 0.75, '3PM': 100,
+                         'AST': 200, 'STL': 50, 'BLK': 20})
+        assert category_storage.extra_categories(row, SNAPSHOT_FIXED_CATEGORIES) is None
+
+    def test_captures_only_the_extras(self):
+        row = pd.Series({'team_id': 1, 'team_name': 'A', 'PTS': 1120, 'TO': 120})
+        assert category_storage.extra_categories(row, SNAPSHOT_FIXED_CATEGORIES) == {'TO': 120.0}
+
+    def test_ignores_identity_and_ranking_bookkeeping_columns(self):
+        row = pd.Series({'team_id': 1, 'team_name': 'A', 'RANK': 3,
+                         'TOTAL_POINTS': 61, 'PTS': 1120})
+        assert category_storage.extra_categories(row, RANKINGS_FIXED_CATEGORIES) is None
+
+    def test_nan_extra_is_dropped_rather_than_serialized(self):
+        row = pd.Series({'team_id': 1, 'TO': float('nan')})
+        assert category_storage.extra_categories(row, SNAPSHOT_FIXED_CATEGORIES) is None
+
+    def test_output_is_json_serializable(self):
+        row = pd.Series({'team_id': 1, 'TO': 120})
+        payload = category_storage.extra_categories(row, SNAPSHOT_FIXED_CATEGORIES)
+        assert json.loads(category_storage.dumps(payload)) == {'TO': 120.0}
+
+    def test_dumps_passes_none_through_as_sql_null(self):
+        assert category_storage.dumps(None) is None
+
+
+class TestLoads:
+    def test_accepts_dict_from_a_codec_registered_connection(self):
+        assert category_storage.loads({'TO': 120}) == {'TO': 120}
+
+    def test_accepts_str_from_a_connection_without_the_codec(self):
+        assert category_storage.loads('{"TO": 120}') == {'TO': 120}
+
+    @pytest.mark.parametrize("empty", [None, '', {}])
+    def test_empty_shapes_become_empty_dict(self, empty):
+        assert category_storage.loads(empty) == {}
+
+    def test_malformed_json_does_not_raise(self):
+        assert category_storage.loads('{not json') == {}
+
+
+class TestMergeCategories:
+    def test_combines_columns_and_extras(self):
+        merged = category_storage.merge_categories({'PTS': 8.0, 'REB': 3.0}, {'TO': 5.0})
+        assert merged == {'PTS': 8.0, 'REB': 3.0, 'TO': 5.0}
+
+    def test_drops_null_columns(self):
+        merged = category_storage.merge_categories({'PTS': 8.0, 'REB': None}, None)
+        assert merged == {'PTS': 8.0}
+
+    def test_extras_win_on_collision(self):
+        merged = category_storage.merge_categories({'PTS': 8.0}, {'PTS': 9.0})
+        assert merged == {'PTS': 9.0}
+
+
+class TestRoundTrip:
+    def test_write_then_read_reproduces_the_extra_category(self):
+        row = pd.Series({'team_id': 1, 'team_name': 'A', 'PTS': 1120, 'TO': 120})
+        stored = category_storage.dumps(
+            category_storage.extra_categories(row, SNAPSHOT_FIXED_CATEGORIES)
+        )
+        merged = category_storage.merge_categories({'PTS': 1120.0}, stored)
+        assert merged == {'PTS': 1120.0, 'TO': 120.0}
+
+    def test_total_key_is_not_a_category(self):
+        """TOTAL rides in the same document but is pulled out before merging."""
+        stored = {'TO': 7.0, TOTAL_KEY: 61.0}
+        total = stored.pop(TOTAL_KEY)
+        assert total == 61.0
+        assert category_storage.merge_categories({'PTS': 3.0}, stored) == {'PTS': 3.0, 'TO': 7.0}


### PR DESCRIPTION
Stacks on #214. Step 1 of the DB-backed dynamic-categories work.

## Why

The snapshot and rankings tables carry one column per category, so a league scoring anything beyond the historical 8 has nowhere to put the value. Everything reading them — date ranges, Standings Race, the estimator — is stuck on the fixed 8 regardless of what the live-ESPN path resolves.

## Approach: extras-only JSONB, not EAV

Only categories **without** a column are stored. A value lives in exactly one place, so a column and a JSON key cannot drift apart, and a league on the fixed categories writes `NULL` and pays nothing.

Measured read-only against the real DB before choosing:

| | rows/season | storage | Standings Race |
|---|---|---|---|
| today | 2,088 | 0.35 MB | 2,088 rows, 95.8 ms |
| EAV (original plan) | 27,144 | ~4.9 MB | 27,144 rows |
| full-mirror JSONB | 2,088 | +1.24 MB | +10.6 ms client decode |
| **extras-only (this PR)** | 2,088 | **+0 B today** | **+0 ms today** |

Storage was never the constraint — EAV's ~5 MB/season is ~1% of the tier. The 13× read amplification was. Server-side cost of the JSONB measured at −2.9% (noise); a query returning zero rows already takes 60 ms, so network RTT dominates everything.

Going to a full mirror later is a backfill `UPDATE`, not a schema change — this column is already the final shape.

## What's here

- `migrations/add_dynamic_category_columns.sql` — nullable `ADD COLUMN`, metadata-only on PG 11+. **Not applied yet**; apply manually per project convention.
- `app/utils/category_storage.py` — the single seam between "some categories are columns" and "some are JSON". `merge_categories` is the one function to change if the JSONB ever becomes the whole story.
- Dual-write in all three upserts; `get_rankings_over_time` (Standings Race) migrated as the proving reader.
- `rk_total` keeps meaning "total over the fixed categories" for every row ever written. The all-category total rides in the JSONB under `TOTAL` and overrides it on read only when present.

## Backwards compatibility

- Writes and reads are guarded by an `information_schema` probe, cached per process. Against a database without the migration this is **inert** — not an `UndefinedColumnError` swallowed into a log line while snapshots silently stop being written. Both sides of the guard are tested.
- `TeamTimeSeriesPoint.ranks` is `None` for a fixed-category league, so today's API payload is byte-identical. Frontend untouched.
- Merge order with the migration does not matter.

## Gotchas handled

- asyncpg returns `jsonb` as `str` without a codec — one is registered at pool init.
- `NaN`/`inf` are not valid JSON and Postgres rejects the payload outright — normalised to `NULL`.
- numpy scalars off a DataFrame make `json.dumps` raise `TypeError` — cast before serializing.
- No GIN index: every read reaches these rows by the existing btree and reads the whole document.

## Verification

- `uv run pytest -q` → **626 passed** (+33 new)
- `npx tsc --noEmit` clean, `npx vitest run` → 191 passed
- Generated SQL inspected in all four combinations (snapshot/rankings × migration applied/not): correct param counts, no trailing commas

The migration itself has **not** been executed against any database.