### PR TITLE
feat: date-range and ESPN-down reads resolve the league's categories

### DIFF
--- a/backend/app/services/data_provider.py
+++ b/backend/app/services/data_provider.py
@@ -124,17 +124,6 @@ class DataProvider:
         if not rows:
             raise DataSourceError("ESPN unavailable and no DB fallback data found for this league/season")
         df = pd.DataFrame(rows)
-        df = df.rename(columns={
-            'fg_pct': 'FG%', 'ft_pct': 'FT%', 'three_pm': '3PM',
-            'reb': 'REB', 'ast': 'AST', 'stl': 'STL', 'blk': 'BLK',
-            'pts': 'PTS', 'gp': 'GP', 'fgm': 'FGM', 'fga': 'FGA',
-            'ftm': 'FTM', 'fta': 'FTA',
-        })
-        df = df.drop(columns=['date'], errors='ignore')
-        # asyncpg returns Decimal for NUMERIC columns; cast to float here so every
-        # totals DataFrame (ESPN or DB fallback) is uniformly float downstream.
-        numeric_cols = [c for c in RANKING_CATEGORIES + ['GP'] if c in df.columns]
-        df[numeric_cols] = df[numeric_cols].astype(float)
         self.cache_manager.totals_cache['data'] = df
         self.cache_manager.totals_cache['data_date'] = snap_date
         self.cache_manager.totals_cache['etag'] = None
@@ -308,13 +297,28 @@ class DataProvider:
             return {}
         return self.data_transformer.parse_slot_usage(raw)
 
+    async def _settings_payload(self) -> Optional[Dict]:
+        """The raw standings payload, which carries the league's scoring settings.
+
+        Warms the cache if a caller hasn't already fetched totals this request:
+        the DB-backed date-range paths never do, and reading an unwarmed cache
+        silently resolved the historical fixed categories for them. Returns None
+        rather than raising when ESPN is unavailable — callers fall back to the
+        fixed default, which is the same shape the DB rows are in anyway."""
+        raw = self.cache_manager.totals_cache.get('raw')
+        if raw:
+            return raw
+        try:
+            await self.get_totals_df()
+        except Exception as e:
+            self.logger.warning(f"Could not load league settings, using default categories: {e}")
+            return None
+        return self.cache_manager.totals_cache.get('raw')
+
     async def get_ranking_categories(self) -> list:
         """Get this league's actual scoring categories, resolved from ESPN's
-        settings (falls back to the historical fixed default if unavailable).
-        Reads the raw standings payload from cache rather than fetching —
-        callers are expected to have already called get_totals_df() in the
-        same request, so this never issues its own ESPN request."""
-        raw = self.cache_manager.totals_cache.get('raw')
+        settings (falls back to the historical fixed default if unavailable)."""
+        raw = await self._settings_payload()
         if not raw:
             return list(RANKING_CATEGORIES)
         return self.data_transformer.resolve_ranking_categories(raw)
@@ -323,9 +327,8 @@ class DataProvider:
         """Get this league's reverse-scored categories (lower raw value = better,
         e.g. turnovers), resolved from ESPN's settings via each scoringItem's
         isReverseItem flag. Falls back to an empty set (no known reverse
-        categories) if settings are unavailable — same caching contract as
-        get_ranking_categories."""
-        raw = self.cache_manager.totals_cache.get('raw')
+        categories) if settings are unavailable."""
+        raw = await self._settings_payload()
         if not raw:
             return set()
         return self.data_transformer.resolve_reverse_categories(raw)

--- a/backend/app/services/data_provider.py
+++ b/backend/app/services/data_provider.py
@@ -207,7 +207,12 @@ class DataProvider:
                 if totals_data is not None:
                     fantasy_team_map = dict(zip(totals_data['team_id'], totals_data['team_name']))
 
-                players_df = self.data_transformer.raw_all_players_to_df(api_data, stat_split_type_id, fantasy_team_map)
+                # get_totals_df above already warmed the standings payload the
+                # categories are resolved from, so this costs no extra request.
+                categories = await self.get_ranking_categories()
+                players_df = self.data_transformer.raw_all_players_to_df(
+                    api_data, stat_split_type_id, fantasy_team_map, categories
+                )
 
                 cache['etag'] = response.headers.get('ETag')
                 cache['timestamp'] = datetime.now()

--- a/backend/app/services/data_transformer.py
+++ b/backend/app/services/data_transformer.py
@@ -3,12 +3,12 @@ import logging
 from typing import Dict
 from app.utils.constants import (
     ESPN_COLUMN_MAP, ALL_CATEGORIES, INTEGER_COLUMNS, PRO_TEAM_MAP, POSITION_MAP,
-    RANKING_CATEGORIES
+    RANKING_CATEGORIES, RATIO_CATEGORIES
 )
 from app.services.stats_calculator import StatsCalculator
 from app.config import settings
 from app.utils.roster_slots import SLOT_CAPS
-from app.utils.espn_stat_map import STAT_ID_TO_CATEGORY, NON_RANKING_STAT_KEYS
+from app.utils.espn_stat_map import STAT_ID_TO_CATEGORY, NON_RANKING_STAT_KEYS, UNSUPPORTED_CATEGORIES
 
 
 SLOT_MAP = {0: 'PG', 1: 'SG', 2: 'SF', 3: 'PF', 4: 'C', 5: 'G', 6: 'F', 11: 'UTIL'}
@@ -38,7 +38,19 @@ class DataTransformer:
             for item in scoring_items:
                 stat_id = item.get('statId')
                 category = STAT_ID_TO_CATEGORY.get(stat_id)
-                if category and category not in NON_RANKING_STAT_KEYS and category not in categories:
+                if category is None:
+                    self.logger.warning(
+                        f"League scores unknown ESPN statId {stat_id}; it will be missing from "
+                        "rankings. Add it to STAT_ID_TO_CATEGORY."
+                    )
+                    continue
+                if category in UNSUPPORTED_CATEGORIES:
+                    self.logger.warning(
+                        f"League scores {category}, which this app cannot compute; it will be "
+                        "missing from rankings."
+                    )
+                    continue
+                if category not in NON_RANKING_STAT_KEYS and category not in categories:
                     categories.append(category)
 
             return categories if categories else list(RANKING_CATEGORIES)
@@ -355,7 +367,12 @@ class DataTransformer:
 
         # Select only required columns (always the fixed default set, plus any
         # extra resolved categories beyond it)
-        extra_cols = [c for c in (categories or []) if c not in ALL_CATEGORIES]
+        # A derived category is useless without the quantities it is built from:
+        # the date-range path rebuilds it over the window rather than trusting a
+        # cumulative rate, so its sources have to survive column selection too.
+        resolved = list(categories or [])
+        sources = [src for c in resolved for src in RATIO_CATEGORIES.get(c, ())]
+        extra_cols = [c for c in dict.fromkeys(resolved + sources) if c not in ALL_CATEGORIES]
         available_cols = ['team_id', 'team_name'] + [col for col in ALL_CATEGORIES + extra_cols if col in df.columns]
         df = df[available_cols]
         

--- a/backend/app/services/data_transformer.py
+++ b/backend/app/services/data_transformer.py
@@ -21,6 +21,31 @@ class DataTransformer:
         self.logger = logging.getLogger(__name__)
         self.stats_calculator = StatsCalculator()
 
+    @staticmethod
+    def stat_columns_to_keep(categories: list[str] = None) -> list[str]:
+        """Stat columns worth materializing for a league scoring `categories`.
+
+        ESPN's stat lines carry every stat it tracks -- per-game rates, streaks,
+        double-doubles, missed shots -- and STAT_ID_TO_CATEGORY can now name all
+        of them. Naming a stat is not a reason to keep it: the ones worth
+        carrying are the fixed set every response is built from, plus whatever
+        this league actually scores, plus the raw quantities a scored ratio is
+        rebuilt from. Everything else is width nothing reads.
+
+        MIN is kept explicitly -- it is not a ranking category, but player
+        responses report it directly.
+        """
+        resolved = list(categories or [])
+        sources = [src for c in resolved for src in RATIO_CATEGORIES.get(c, ())]
+        return list(dict.fromkeys(ALL_CATEGORIES + ['MIN'] + resolved + sources))
+
+    def _keep_stat_columns(self, df: pd.DataFrame, categories: list[str] = None) -> pd.DataFrame:
+        """Drop stat columns outside `stat_columns_to_keep`, leaving non-stat
+        columns (player/team identity, ratings, status) untouched."""
+        keep = set(self.stat_columns_to_keep(categories))
+        known_stats = set(ESPN_COLUMN_MAP.values())
+        return df[[c for c in df.columns if c not in known_stats or c in keep]]
+
     def resolve_ranking_categories(self, espn_data: Dict) -> list[str]:
         """Determine this league's actual scoring categories from ESPN's
         settings.scoringSettings.scoringItems (present when the standings
@@ -101,13 +126,16 @@ class DataTransformer:
             self.logger.warning(f"Error parsing slot usage data: {e}")
         return result
 
-    def raw_all_players_to_df(self, espn_data: Dict, stat_split_type_id: int = 0, fantasy_team_map: Dict[int, str] = None) -> pd.DataFrame:
+    def raw_all_players_to_df(self, espn_data: Dict, stat_split_type_id: int = 0, fantasy_team_map: Dict[int, str] = None,
+                              categories: list[str] = None) -> pd.DataFrame:
         """
         Convert ESPN kona_player_info API data to DataFrame (all 500 players including FA/waivers)
         Args:
             espn_data: Raw ESPN API response with 'players' array
             stat_split_type_id: ESPN stat split type (0=season, 1=last7, 2=last15, 3=last30)
             fantasy_team_map: Optional dict mapping fantasy team_id -> team_name
+            categories: league's active scoring categories; stat columns outside
+                        the fixed set and these are dropped (see stat_columns_to_keep)
         Returns:
             Clean DataFrame with proper columns and types, including status and injured fields
         """
@@ -179,18 +207,20 @@ class DataTransformer:
             # Keep player_id nulls intact (fillna(0) would create bogus /player/0 links).
             fill_cols = [c for c in df.columns if c != 'player_id']
             df[fill_cols] = df[fill_cols].fillna(0)
-            return self._organize_player_columns(df)
+            return self._organize_player_columns(self._keep_stat_columns(df, categories))
 
         except Exception as e:
             self.logger.error(f"Error transforming ESPN players data to DataFrame: {e}")
             raise Exception("Error transforming ESPN players data to DataFrame")
 
-    def raw_players_to_df(self, espn_players_data: Dict, stat_split_type_id: int = 0) -> pd.DataFrame:
+    def raw_players_to_df(self, espn_players_data: Dict, stat_split_type_id: int = 0,
+                          categories: list[str] = None) -> pd.DataFrame:
         """
         Convert raw ESPN API players data to DataFrame
         Args:
             espn_players_data: Raw ESPN API response
             stat_split_type_id: ESPN stat split type (0=season, 1=last7, 2=last15, 3=last30)
+            categories: league's active scoring categories (see stat_columns_to_keep)
         Returns:
             Clean DataFrame with proper columns and types
         """
@@ -212,7 +242,7 @@ class DataTransformer:
             df = pd.DataFrame(all_players)
             fill_cols = [c for c in df.columns if c != 'player_id']
             df[fill_cols] = df[fill_cols].fillna(0)
-            return self._organize_player_columns(df)
+            return self._organize_player_columns(self._keep_stat_columns(df, categories))
             
         except Exception as e:
             self.logger.error(f"Error transforming ESPN players data to DataFrame: {e}")
@@ -370,10 +400,8 @@ class DataTransformer:
         # A derived category is useless without the quantities it is built from:
         # the date-range path rebuilds it over the window rather than trusting a
         # cumulative rate, so its sources have to survive column selection too.
-        resolved = list(categories or [])
-        sources = [src for c in resolved for src in RATIO_CATEGORIES.get(c, ())]
-        extra_cols = [c for c in dict.fromkeys(resolved + sources) if c not in ALL_CATEGORIES]
-        available_cols = ['team_id', 'team_name'] + [col for col in ALL_CATEGORIES + extra_cols if col in df.columns]
+        wanted = [c for c in self.stat_columns_to_keep(categories) if c != 'MIN']
+        available_cols = ['team_id', 'team_name'] + [col for col in wanted if col in df.columns]
         df = df[available_cols]
         
         # Convert integer columns

--- a/backend/app/services/db_service.py
+++ b/backend/app/services/db_service.py
@@ -24,6 +24,41 @@ _RANKINGS_COL_MAP = {
     'PTS': 'rk_pts',
 }
 
+_SNAPSHOT_COL_MAP = {
+    'GP': 'gp',
+    'FGM': 'fgm',
+    'FGA': 'fga',
+    'FG%': 'fg_pct',
+    'FTM': 'ftm',
+    'FTA': 'fta',
+    'FT%': 'ft_pct',
+    '3PM': 'three_pm',
+    'REB': 'reb',
+    'AST': 'ast',
+    'STL': 'stl',
+    'BLK': 'blk',
+    'PTS': 'pts',
+}
+
+
+def _snapshot_row_to_categories(row: dict) -> dict:
+    """A snapshot row as `team_id`/`team_name` plus one key per category code.
+
+    The same wide shape the live-ESPN path builds from ESPN's own payload, so
+    everything downstream of here works off category codes alone and never has
+    to know which of them happen to have a dedicated column.
+
+    NUMERIC columns arrive as Decimal; cast so a frame built from these rows is
+    uniformly float rather than object dtype.
+    """
+    fixed = {cat: row.get(col) for cat, col in _SNAPSHOT_COL_MAP.items()}
+    merged = category_storage.merge_categories(fixed, row.get('stats'))
+    return {
+        'team_id': row['team_id'],
+        'team_name': row['team_name'],
+        **{cat: float(value) for cat, value in merged.items()},
+    }
+
 
 def fs_records_to_frame(records) -> pd.DataFrame:
     """asyncpg rows -> pipeline frame (uppercase columns, Timestamp GAME_DATE).
@@ -291,7 +326,8 @@ class DBService:
 
     async def get_latest_snapshot(self, league_id: int, season_id: int):
         """
-        Returns (date, rows) where rows is a list of dicts with team totals.
+        Returns (date, rows) where rows is a list of dicts with team totals keyed
+        by category code -- see _snapshot_row_to_categories.
         Returns (None, []) if DB unavailable or empty.
         """
         pool = await self._get_pool()
@@ -307,10 +343,12 @@ class DBService:
                 max_period = max_row['max_period']
                 if max_period == 0:
                     return None, []
+                dynamic = await self._supports_dynamic_categories(conn)
                 rows = await conn.fetch(
-                    """
+                    f"""
                     SELECT team_id, team_name, gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
                            three_pm, reb, ast, stl, blk, pts, date
+                           {', stats' if dynamic else ''}
                     FROM team_daily_snapshot
                     WHERE league_id = $1 AND season_id = $2 AND scoring_period_id = $3
                     """,
@@ -319,7 +357,7 @@ class DBService:
                 if not rows:
                     return None, []
                 snap_date = rows[0]['date']
-                return snap_date, [dict(r) for r in rows]
+                return snap_date, [_snapshot_row_to_categories(dict(r)) for r in rows]
         except Exception as e:
             logger.error(f"Failed to fetch latest snapshot: {e}")
             return None, []
@@ -474,6 +512,9 @@ class DBService:
         - actual_start_date: closest date >= start_date in DB (None if no data at or after start)
         - rows_start is empty list if no snapshot >= start_date exists (treat as zeros)
         - Returns (None, None, [], []) if no end snapshot found
+
+        Rows are keyed by category code, not column name, and carry whatever
+        categories the league scores -- see _snapshot_row_to_categories.
         """
         pool = await self._get_pool()
         if pool is None:
@@ -496,29 +537,26 @@ class DBService:
                 )
                 actual_start_date = start_row['d'] if start_row else None
 
-                rows_end = await conn.fetch(
-                    """
+                dynamic = await self._supports_dynamic_categories(conn)
+                query = f"""
                     SELECT team_id, team_name, gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
                            three_pm, reb, ast, stl, blk, pts
+                           {', stats' if dynamic else ''}
                     FROM team_daily_snapshot
                     WHERE league_id = $1 AND season_id = $2 AND date = $3
-                    """,
-                    league_id, season_id, actual_end_date
-                )
+                """
+                rows_end = await conn.fetch(query, league_id, season_id, actual_end_date)
 
                 rows_start = []
                 if actual_start_date is not None:
-                    rows_start = await conn.fetch(
-                        """
-                        SELECT team_id, team_name, gp, fgm, fga, fg_pct, ftm, fta, ft_pct,
-                               three_pm, reb, ast, stl, blk, pts
-                        FROM team_daily_snapshot
-                        WHERE league_id = $1 AND season_id = $2 AND date = $3
-                        """,
-                        league_id, season_id, actual_start_date
-                    )
+                    rows_start = await conn.fetch(query, league_id, season_id, actual_start_date)
 
-                return actual_end_date, actual_start_date, [dict(r) for r in rows_end], [dict(r) for r in rows_start]
+                return (
+                    actual_end_date,
+                    actual_start_date,
+                    [_snapshot_row_to_categories(dict(r)) for r in rows_end],
+                    [_snapshot_row_to_categories(dict(r)) for r in rows_start],
+                )
         except Exception as e:
             logger.error(f"Failed to fetch snapshots for date range: {e}")
             return None, None, [], []

--- a/backend/app/services/league_service.py
+++ b/backend/app/services/league_service.py
@@ -95,7 +95,6 @@ class LeagueService:
 
     async def _get_heatmap_for_range(self, start_date: date, end_date: date) -> HeatmapData:
         from app.services.ranking_service import RankingService
-        from app.services.data_transformer import DataTransformer
 
         actual_end_date, actual_start_date, rows_end, rows_start = \
             await self.data_provider.db_service.get_snapshots_for_date_range(
@@ -110,34 +109,28 @@ class LeagueService:
         start_df = pd.DataFrame(rows_start) if rows_start else None
         delta_df = ranking_service._compute_delta(end_df, start_df)
 
-        _, averages_rankings_df = ranking_service._build_averages_rankings_df(delta_df)
-        rankings_df = averages_rankings_df.sort_values(by='TOTAL_POINTS', ascending=False)
+        categories = await self.data_provider.get_ranking_categories()
+        reverse_categories = await self.data_provider.get_reverse_categories()
 
-        transformer = DataTransformer()
-        averages_df = pd.DataFrame()
-        averages_df['team_id'] = delta_df['team_id']
-        averages_df['team_name'] = delta_df['team_name']
-        averages_df['GP'] = delta_df['gp']
-        averages_df['FGM'] = delta_df['fgm']
-        averages_df['FGA'] = delta_df['fga']
-        averages_df['FTM'] = delta_df['ftm']
-        averages_df['FTA'] = delta_df['fta']
-        averages_df['FG%'] = delta_df['fg_pct']
-        averages_df['FT%'] = delta_df['ft_pct']
-        averages_df['3PM'] = delta_df['three_pm']
-        averages_df['REB'] = delta_df['reb']
-        averages_df['AST'] = delta_df['ast']
-        averages_df['STL'] = delta_df['stl']
-        averages_df['BLK'] = delta_df['blk']
-        averages_df['PTS'] = delta_df['pts']
-        averages_df = transformer.totals_to_averages_df(averages_df)
+        averages_df, averages_rankings_df = ranking_service._build_averages_rankings_df(
+            delta_df, categories, reverse_categories
+        )
+        rankings_df = averages_rankings_df.sort_values(by='TOTAL_POINTS', ascending=False)
 
         sorted_averages_df = averages_df.set_index('team_id').loc[rankings_df['team_id']].reset_index()
 
+        # Same narrowing as the live path: a resolved category can be missing
+        # from rows written before it was added to the league, and the labels,
+        # values, normalized matrix and ranks all have to describe the same
+        # columns.
+        categories = [c for c in categories
+                      if c in sorted_averages_df.columns and c in rankings_df.columns]
         teams_data = self._extract_teams_data(sorted_averages_df)
-        categories_data = self._extract_categories_data(sorted_averages_df)
-        normalized_data = self.stats_calculator.normalize_for_heatmap(sorted_averages_df)
-        ranks_data = self._extract_ranks_data(rankings_df, sorted_averages_df)
+        categories_data = self._extract_categories_data(sorted_averages_df, categories)
+        normalized_data = self.stats_calculator.normalize_for_heatmap(
+            sorted_averages_df, categories, reverse_categories
+        )
+        ranks_data = self._extract_ranks_data(rankings_df, sorted_averages_df, categories)
 
         return self.response_builder.build_heatmap_response(
             teams=teams_data,
@@ -148,6 +141,7 @@ class LeagueService:
             date_range_end=end_date,
             actual_start_date=actual_start_date,
             actual_end_date=actual_end_date,
+            category_labels=categories + ['GP'],
         )
     
     async def get_league_shots_data(self) -> LeagueShotsData:

--- a/backend/app/services/ranking_service.py
+++ b/backend/app/services/ranking_service.py
@@ -6,7 +6,7 @@ from app.models import LeagueRankings
 from app.exceptions import InvalidParameterError, ResourceNotFoundError
 from app.services.data_provider import DataProvider
 from app.builders.response_builder import ResponseBuilder
-from app.utils.constants import RANKING_CATEGORIES, PER_GAME_CATEGORIES
+from app.utils.constants import RANKING_CATEGORIES, PER_GAME_CATEGORIES, DERIVED_CATEGORIES, RATIO_CATEGORIES
 from app.config import settings
 
 class RankingService:
@@ -61,10 +61,17 @@ class RankingService:
         end_df = pd.DataFrame(rows_end)
         start_df = pd.DataFrame(rows_start) if rows_start else None
 
+        categories = await self.data_provider.get_ranking_categories()
+        reverse_categories = await self.data_provider.get_reverse_categories()
+
         delta_df = self._compute_delta(end_df, start_df)
 
-        averages_df, averages_rankings_df = self._build_averages_rankings_df(delta_df)
-        totals_raw_df, totals_rankings_df = self._build_totals_rankings_df_from_delta(delta_df)
+        averages_df, averages_rankings_df = self._build_averages_rankings_df(
+            delta_df, categories, reverse_categories
+        )
+        totals_raw_df, totals_rankings_df = self._build_totals_rankings_df_from_delta(
+            delta_df, categories, reverse_categories
+        )
 
         if sort_by is not None and not self._is_valid_sort_column(sort_by, averages_rankings_df):
             raise InvalidParameterError(f"Invalid sort column: {sort_by}")
@@ -82,70 +89,73 @@ class RankingService:
             date_range_end=end_date,
             actual_start_date=actual_start_date,
             actual_end_date=actual_end_date,
+            categories=categories,
         )
 
     def _compute_delta(self, end_df: pd.DataFrame, start_df: Optional[pd.DataFrame]) -> pd.DataFrame:
-        """Compute per-team delta between end and start snapshots."""
-        counting_cols = ['gp', 'fgm', 'fga', 'ftm', 'fta', 'three_pm', 'reb', 'ast', 'stl', 'blk', 'pts']
+        """Compute per-team delta between end and start snapshots.
+
+        Both frames are keyed by category code and carry whatever categories the
+        league scores, so the counting columns are read off the frame rather than
+        listed here. A ratio category cannot be differenced -- the delta of two
+        cumulative percentages is meaningless -- so it is rebuilt from its
+        made/attempted sources after they have been differenced."""
+        id_cols = ['team_id', 'team_name']
+        counting_cols = [c for c in end_df.columns
+                         if c not in id_cols and c not in DERIVED_CATEGORIES]
 
         if start_df is None or start_df.empty:
-            delta = end_df[['team_id', 'team_name'] + counting_cols].copy()
+            delta = end_df[id_cols + counting_cols].copy()
         else:
-            merged = end_df.merge(start_df[['team_id'] + counting_cols], on='team_id', suffixes=('_end', '_start'))
+            shared = [c for c in counting_cols if c in start_df.columns]
+            merged = end_df.merge(start_df[['team_id'] + shared], on='team_id', suffixes=('_end', '_start'))
             delta = pd.DataFrame()
             delta['team_id'] = merged['team_id']
             delta['team_name'] = end_df.set_index('team_id').loc[merged['team_id'].values, 'team_name'].values
             for col in counting_cols:
-                delta[col] = merged[f'{col}_end'] - merged[f'{col}_start']
+                if col in shared:
+                    delta[col] = merged[f'{col}_end'] - merged[f'{col}_start']
+                else:
+                    delta[col] = merged[col]
 
-        delta['fg_pct'] = (delta['fgm'] / delta['fga'].replace(0, float('nan'))).fillna(0)
-        delta['ft_pct'] = (delta['ftm'] / delta['fta'].replace(0, float('nan'))).fillna(0)
+        for category, (numerator, denominator) in RATIO_CATEGORIES.items():
+            if category not in end_df.columns:
+                continue
+            if numerator in delta.columns and denominator in delta.columns:
+                delta[category] = (delta[numerator] / delta[denominator].replace(0, float('nan'))).fillna(0)
         return delta
 
-    def _build_averages_rankings_df(self, delta_df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    def _delta_categories_df(self, delta_df: pd.DataFrame, categories: list[str]) -> pd.DataFrame:
+        """delta_df narrowed to the league's scoring categories plus team info.
+
+        Drops the made/attempted feeders and anything else the delta carries that
+        is not itself scored, so nothing unscored reaches calculate_rankings and
+        gets ranked as if it were a category."""
+        cols = ['team_id', 'team_name', 'GP'] + [c for c in categories if c in delta_df.columns]
+        return delta_df[[c for c in cols if c in delta_df.columns]].copy()
+
+    def _build_averages_rankings_df(self, delta_df: pd.DataFrame,
+                                     categories: Optional[list[str]] = None,
+                                     reverse_categories: Optional[set] = None) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Build (raw averages, rankings) DataFrames from delta (divide counting stats by GP)."""
         from app.services.data_transformer import DataTransformer
         transformer = DataTransformer()
 
-        df = pd.DataFrame()
-        df['team_id'] = delta_df['team_id']
-        df['team_name'] = delta_df['team_name']
-        df['GP'] = delta_df['gp']
-        df['FGM'] = delta_df['fgm']
-        df['FGA'] = delta_df['fga']
-        df['FTM'] = delta_df['ftm']
-        df['FTA'] = delta_df['fta']
-        df['FG%'] = delta_df['fg_pct']
-        df['FT%'] = delta_df['ft_pct']
-        df['3PM'] = delta_df['three_pm']
-        df['REB'] = delta_df['reb']
-        df['AST'] = delta_df['ast']
-        df['STL'] = delta_df['stl']
-        df['BLK'] = delta_df['blk']
-        df['PTS'] = delta_df['pts']
+        categories = categories or RANKING_CATEGORIES
+        df = self._delta_categories_df(delta_df, categories)
+        averages_df = transformer.totals_to_averages_df(df, categories)
+        return averages_df, transformer.averages_to_rankings_df(averages_df, reverse_categories)
 
-        averages_df = transformer.totals_to_averages_df(df)
-        return averages_df, transformer.averages_to_rankings_df(averages_df)
-
-    def _build_totals_rankings_df_from_delta(self, delta_df: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    def _build_totals_rankings_df_from_delta(self, delta_df: pd.DataFrame,
+                                              categories: Optional[list[str]] = None,
+                                              reverse_categories: Optional[set] = None) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Build (raw totals, rankings) DataFrames directly from delta counting stats."""
         from app.services.data_transformer import DataTransformer
         transformer = DataTransformer()
 
-        df = pd.DataFrame()
-        df['team_id'] = delta_df['team_id']
-        df['team_name'] = delta_df['team_name']
-        df['GP'] = delta_df['gp']
-        df['FG%'] = delta_df['fg_pct']
-        df['FT%'] = delta_df['ft_pct']
-        df['3PM'] = delta_df['three_pm']
-        df['REB'] = delta_df['reb']
-        df['AST'] = delta_df['ast']
-        df['STL'] = delta_df['stl']
-        df['BLK'] = delta_df['blk']
-        df['PTS'] = delta_df['pts']
-
-        return df, transformer.averages_to_rankings_df(df)
+        categories = categories or RANKING_CATEGORIES
+        df = self._delta_categories_df(delta_df, categories)
+        return df, transformer.averages_to_rankings_df(df, reverse_categories)
 
     def _build_totals_rankings_df(self, totals_df: pd.DataFrame,
                                    categories: Optional[list[str]] = None,

--- a/backend/app/services/stats_calculator.py
+++ b/backend/app/services/stats_calculator.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from typing import Dict, List, Optional
-from app.utils.constants import RANKING_CATEGORIES, PERCENTAGE_CATEGORIES
+from app.utils.constants import RANKING_CATEGORIES, DERIVED_CATEGORIES
+from app.utils.espn_stat_map import NON_RANKING_STAT_KEYS
 
 
 class StatsCalculator:
@@ -174,8 +175,9 @@ class StatsCalculator:
         Args:
             totals_df: DataFrame with total stats
             categories: category codes to average (defaults to RANKING_CATEGORIES).
-                        Percentage categories (FG%, FT%) are left as-is; every
-                        other category present is divided by GP.
+                        Derived categories (FG%, PPG, A/TO, ...) are already
+                        rates and are left as-is; every other category present
+                        is divided by GP.
         Returns:
             DataFrame with per-game averages
         """
@@ -184,11 +186,13 @@ class StatsCalculator:
 
         per_game_categories = [
             c for c in (categories or RANKING_CATEGORIES)
-            if c not in PERCENTAGE_CATEGORIES
+            if c not in DERIVED_CATEGORIES
         ]
 
-        # Create copy without raw counting stats (keep percentages)
-        averages = totals_df.drop(['FGM', 'FGA', 'FTM', 'FTA'], axis=1, errors='ignore').copy()
+        # Drop the raw quantities that only exist to build derived categories.
+        # GP is exempt: it is the divisor below and callers read it downstream.
+        feeder_cols = [c for c in NON_RANKING_STAT_KEYS if c != 'GP']
+        averages = totals_df.drop(feeder_cols, axis=1, errors='ignore').copy()
         per_game_categories = [c for c in per_game_categories if c in averages.columns]
         # Calculate per-game averages for counting stats
         averages[per_game_categories] = averages[per_game_categories].div(averages['GP'], axis=0).fillna(0)

--- a/backend/app/utils/constants.py
+++ b/backend/app/utils/constants.py
@@ -1,23 +1,11 @@
 # ESPN API Constants and Mappings
+from app.utils.espn_stat_map import STAT_ID_TO_CATEGORY
 
-# ESPN API column mapping
-ESPN_COLUMN_MAP = {
-    '0': 'PTS',
-    '1': 'BLK',
-    '2': 'STL',
-    '3': 'AST',
-    '6': 'REB',
-    '13': 'FGM',
-    '14': 'FGA',
-    '15': 'FTM',
-    '16': 'FTA',
-    '17': '3PM',
-    '19': 'FG%',
-    '20': 'FT%',
-    '42': 'GP',
-    '40': 'MIN',
-    '11': 'TO',
-}
+# ESPN stat lines (valuesByStat, player stats) key stats by the same numeric id
+# as the scoring settings, as strings. Derived from the one id map rather than
+# restated, so a category cannot be resolvable from league settings but
+# unparseable from the stat line that carries its value.
+ESPN_COLUMN_MAP = {str(stat_id): category for stat_id, category in STAT_ID_TO_CATEGORY.items()}
 
 PRO_TEAM_MAP: dict[int, str] = {
     0: 'FA',
@@ -67,5 +55,32 @@ PER_GAME_CATEGORIES = ['3PM', 'AST', 'REB', 'STL', 'BLK', 'PTS']
 # Integer columns for type conversion
 INTEGER_COLUMNS = ['FGM', 'FGA', 'FTM', 'FTA', '3PM', 'AST', 'REB', 'STL', 'BLK', 'PTS', 'GP']
 
-# Categories that are percentages rather than per-game counting stats
-PERCENTAGE_CATEGORIES = frozenset({'FG%', 'FT%'})
+# Categories that are a quotient of two other stats, and the (numerator,
+# denominator) pair each is built from. A quotient cannot be summed, divided by
+# games played, or differenced between two cumulative snapshots -- doing any of
+# those to a rate gives a number that means nothing -- so it is always rebuilt
+# from its sources over whatever window is being computed.
+#
+# Per-game categories (PPG, RPG, ...) are quotients too, over GP, and are listed
+# here for exactly that reason: a league scoring PPG must not have it divided by
+# GP a second time.
+RATIO_CATEGORIES: dict[str, tuple[str, str]] = {
+    'FG%': ('FGM', 'FGA'),
+    'FT%': ('FTM', 'FTA'),
+    '3P%': ('3PM', '3PA'),
+    'A/TO': ('AST', 'TO'),
+    'FTR': ('FTA', 'FGA'),
+    'PPM': ('PTS', 'MIN'),
+    'PPG': ('PTS', 'GP'),
+    'RPG': ('REB', 'GP'),
+    'APG': ('AST', 'GP'),
+    'BPG': ('BLK', 'GP'),
+    'SPG': ('STL', 'GP'),
+    'TOPG': ('TO', 'GP'),
+    '3PG': ('3PM', 'GP'),
+    'MPG': ('MIN', 'GP'),
+}
+
+# Categories that are derived rather than counted, and so are never divided by
+# games played. Named PERCENTAGE_CATEGORIES when FG% and FT% were the only two.
+DERIVED_CATEGORIES = frozenset(RATIO_CATEGORIES)

--- a/backend/app/utils/espn_stat_map.py
+++ b/backend/app/utils/espn_stat_map.py
@@ -1,35 +1,79 @@
 """Maps ESPN's numeric fantasy basketball statId -> our category code.
 
-ESPN identifies every stat category by a small numeric id (see
-https://github.com/cwendt94/espn-api conventions, and
-app.utils.constants.ESPN_COLUMN_MAP for the subset we already parse from
-player/team stat lines). This is the same id space, extended with a few
-common categories leagues sometimes score on but this app hasn't needed
-yet (e.g. turnovers).
+ESPN identifies every stat category by a small numeric id. The full id space is
+mapped here, not just the categories this app has needed, so a league scoring
+anything ESPN offers resolves without a code change. Ids are taken from the
+espn-api library's basketball STATS_MAP, the same source this file has always
+cited (https://github.com/cwendt94/espn-api). Id 45 is a placeholder there with
+no stat behind it and is deliberately absent.
 
-Categories NOT eligible to be "ranking" categories (raw counting stats
-that feed a percentage, or non-competitive stats like games/minutes
-played) are listed in NON_RANKING_STAT_KEYS and filtered out by
-resolve_ranking_categories regardless of whether ESPN's league settings
-include them.
+Mapping an id is only half of supporting a category. Three further facts decide
+whether a resolved category can actually be computed:
+
+- NON_RANKING_STAT_KEYS -- raw quantities that feed a derived category (FGA,
+  3PA) or describe participation (GP, MIN). Never scored on their own, but kept
+  in the frame because derived categories are rebuilt from them.
+- constants.RATIO_CATEGORIES -- categories that are a quotient of two others.
+  They cannot be summed, averaged per game, or differenced between cumulative
+  snapshots, so every consumer has to rebuild them from their sources.
+- UNSUPPORTED_CATEGORIES -- mapped, and ESPN may well score them, but this app
+  has no way to compute them from what it stores. Resolving one logs a warning
+  rather than silently dropping it.
 """
-
 STAT_ID_TO_CATEGORY: dict[int, str] = {
     0: 'PTS',
     1: 'BLK',
     2: 'STL',
     3: 'AST',
+    4: 'OREB',
+    5: 'DREB',
     6: 'REB',
+    7: 'EJ',
+    8: 'FF',
+    9: 'PF',
+    10: 'TF',
     11: 'TO',
+    12: 'DQ',
     13: 'FGM',
     14: 'FGA',
     15: 'FTM',
     16: 'FTA',
     17: '3PM',
+    18: '3PA',
     19: 'FG%',
     20: 'FT%',
-    42: 'GP',
+    21: '3P%',
+    22: 'AFG%',
+    23: 'FGMI',
+    24: 'FTMI',
+    25: '3PMI',
+    26: 'APG',
+    27: 'BPG',
+    28: 'MPG',
+    29: 'PPG',
+    30: 'RPG',
+    31: 'SPG',
+    32: 'TOPG',
+    33: '3PG',
+    34: 'PPM',
+    35: 'A/TO',
+    36: 'STR',
+    37: 'DD',
+    38: 'TD',
+    39: 'QD',
     40: 'MIN',
+    41: 'GS',
+    42: 'GP',
+    43: 'TW',
+    44: 'FTR',
 }
 
-NON_RANKING_STAT_KEYS: frozenset[str] = frozenset({'FGM', 'FGA', 'FTM', 'FTA', 'GP', 'MIN'})
+NON_RANKING_STAT_KEYS: frozenset[str] = frozenset({
+    'FGM', 'FGA', 'FTM', 'FTA', '3PA', 'GP', 'MIN',
+})
+
+# Mapped but not computable from what this app stores. AFG% is a weighted
+# formula rather than a quotient of two stored quantities, and STR (streak) is
+# not a stat at all.
+UNSUPPORTED_CATEGORIES: frozenset[str] = frozenset({'AFG%', 'STR'})
+

--- a/backend/tests/services/test_data_provider.py
+++ b/backend/tests/services/test_data_provider.py
@@ -296,26 +296,22 @@ async def test_fallback_from_db_raises_when_no_rows(provider):
 
 
 @pytest.mark.asyncio
-async def test_fallback_from_db_casts_decimal_columns_to_float(provider):
-    """asyncpg returns Decimal for NUMERIC columns; the DB-fallback totals
-    DataFrame must be uniformly float (like the ESPN path) so downstream
-    consumers (e.g. the heatmap) don't crash mixing Decimal and float."""
-    from decimal import Decimal
-
+async def test_fallback_from_db_carries_categories_beyond_the_fixed_columns(provider):
+    """get_latest_snapshot hands back category-code rows, so a league scoring
+    more than the fixed 8 gets those categories in the fallback frame too."""
     rows = [{
-        "team_id": 1, "team_name": "T", "date": "2025-01-01",
-        "fg_pct": Decimal("46.7"), "ft_pct": Decimal("74.9"),
-        "three_pm": Decimal("15"), "reb": Decimal("43"), "ast": Decimal("28"),
-        "stl": Decimal("9"), "blk": Decimal("4"), "pts": Decimal("112"),
-        "gp": Decimal("10"), "fgm": Decimal("40"), "fga": Decimal("85"),
-        "ftm": Decimal("20"), "fta": Decimal("27"),
+        "team_id": 1, "team_name": "T",
+        "FG%": 46.7, "FT%": 74.9, "3PM": 15.0, "REB": 43.0, "AST": 28.0,
+        "STL": 9.0, "BLK": 4.0, "PTS": 112.0, "GP": 10.0,
+        "FGM": 40.0, "FGA": 85.0, "FTM": 20.0, "FTA": 27.0, "TO": 18.0,
     }]
     provider.db_service.get_latest_snapshot = AsyncMock(return_value=("2025-01-01", rows))
 
     df = await provider._fallback_from_db()
 
-    for col in ["FG%", "FT%", "3PM", "REB", "AST", "STL", "BLK", "PTS", "GP"]:
-        assert df[col].dtype == float, f"{col} should be cast to float, got {df[col].dtype}"
+    assert df["TO"].iloc[0] == 18.0
+    for col in ["FG%", "FT%", "3PM", "REB", "AST", "STL", "BLK", "PTS", "GP", "TO"]:
+        assert df[col].dtype == float, f"{col} should be float, got {df[col].dtype}"
 
 
 @pytest.mark.asyncio
@@ -383,15 +379,42 @@ async def test_get_ranking_categories_delegates_to_transformer(provider):
 
 
 @pytest.mark.asyncio
-async def test_get_ranking_categories_falls_back_when_no_raw_cached(provider):
+async def test_get_ranking_categories_falls_back_when_settings_unreachable(provider):
+    """No cached payload and ESPN down: fall back to the fixed categories rather
+    than propagating the failure, since a date-range request can still be served
+    from the DB."""
     from app.utils.constants import RANKING_CATEGORIES
 
-    provider.cache_manager.totals_cache = {"etag": None, "data": pd.DataFrame({"team_id": [1]})}
+    provider.cache_manager.totals_cache = {"etag": None, "data": None}
+    provider._client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+    provider.db_service.get_latest_snapshot = AsyncMock(return_value=(None, []))
 
     categories = await provider.get_ranking_categories()
 
     assert categories == list(RANKING_CATEGORIES)
-    provider._client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_ranking_categories_loads_settings_when_cache_is_cold(provider):
+    """The DB-backed date-range paths never fetch totals, so resolving from a
+    cache nobody warmed silently returned the fixed 8 for a league scoring more."""
+    payload = _api_teams_payload()
+    payload["settings"] = {"scoringSettings": {"scoringItems": [
+        {"statId": sid} for sid in (19, 20, 17, 3, 6, 2, 1, 0, 11)
+    ]}}
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"ETag": "e1"}
+    resp.json.return_value = payload
+    resp.raise_for_status = MagicMock()
+
+    provider.cache_manager.totals_cache = {"etag": None, "data": None}
+    provider._client.get = AsyncMock(return_value=resp)
+
+    await provider.get_ranking_categories()
+
+    provider._client.get.assert_awaited()
+    provider.data_transformer.resolve_ranking_categories.assert_called_with(payload)
 
 
 @pytest.mark.real_dataprovider

--- a/backend/tests/services/test_data_transformer.py
+++ b/backend/tests/services/test_data_transformer.py
@@ -367,3 +367,47 @@ class TestResolveReverseCategories:
 
     def test_malformed_settings_returns_empty_set(self, transformer):
         assert transformer.resolve_reverse_categories({"settings": "not-a-dict"}) == set()
+
+
+class TestStatColumnsToKeep:
+    """ESPN's stat lines carry every stat it tracks and the id map can now name
+    all of them, so what gets materialized has to be chosen deliberately."""
+
+    def test_keeps_the_fixed_set_for_a_default_league(self, transformer):
+        keep = transformer.stat_columns_to_keep()
+
+        assert 'PTS' in keep and 'FG%' in keep and 'GP' in keep
+
+    def test_keeps_min_even_though_it_is_not_a_ranking_category(self, transformer):
+        """Player responses report minutes directly (response_builder reads
+        row['MIN']), so dropping it as 'not a category' breaks them."""
+        assert 'MIN' in transformer.stat_columns_to_keep()
+
+    def test_drops_stats_the_league_does_not_score(self, transformer):
+        keep = transformer.stat_columns_to_keep()
+
+        for unscored in ('PPG', 'STR', 'DD', 'A/TO', 'OREB', 'AFG%'):
+            assert unscored not in keep
+
+    def test_keeps_a_scored_category_beyond_the_fixed_set(self, transformer):
+        keep = transformer.stat_columns_to_keep(['PTS', 'REB', 'TO'])
+
+        assert 'TO' in keep
+
+    def test_keeps_the_sources_a_scored_ratio_is_rebuilt_from(self, transformer):
+        """3P% over a date range is (3PM delta)/(3PA delta), so 3PA has to
+        survive even though nothing scores it on its own."""
+        keep = transformer.stat_columns_to_keep(['3P%'])
+
+        assert '3PA' in keep and '3PM' in keep
+
+    def test_leaves_non_stat_columns_untouched(self, transformer):
+        import pandas as pd
+        df = pd.DataFrame([{
+            'Name': 'A', 'player_id': 1, 'status': 'ACTIVE',
+            'PTS': 10.0, 'MIN': 30.0, 'PPG': 9.9, 'STR': 'W2',
+        }])
+
+        out = transformer._keep_stat_columns(df)
+
+        assert list(out.columns) == ['Name', 'player_id', 'status', 'PTS', 'MIN']

--- a/backend/tests/services/test_db_service.py
+++ b/backend/tests/services/test_db_service.py
@@ -450,6 +450,57 @@ class TestRankingsRowToPoint:
         assert out['rk_total'] == 23.0
 
 
+class TestSnapshotRowToCategories:
+    """The date-range and ESPN-down read paths: a snapshot row becomes one
+    mapping keyed by category code, whichever side each value came from."""
+
+    @staticmethod
+    def _row(**overrides):
+        from decimal import Decimal
+        row = {
+            'team_id': 1, 'team_name': 'Alpha', 'date': None,
+            'gp': 10, 'fgm': 40, 'fga': 85, 'fg_pct': Decimal('0.4706'),
+            'ftm': 20, 'fta': 27, 'ft_pct': Decimal('0.7407'),
+            'three_pm': 15, 'reb': 43, 'ast': 28, 'stl': 9, 'blk': 4, 'pts': 112,
+            'stats': None,
+        }
+        row.update(overrides)
+        return row
+
+    def test_fixed_columns_become_category_codes(self):
+        from app.services.db_service import _snapshot_row_to_categories
+        out = _snapshot_row_to_categories(self._row())
+
+        assert out['PTS'] == 112.0
+        assert out['3PM'] == 15.0
+        assert out['team_name'] == 'Alpha'
+        assert 'pts' not in out
+        assert 'date' not in out
+
+    def test_numeric_columns_are_float_not_decimal(self):
+        """asyncpg returns Decimal for NUMERIC; a frame of these rows has to be
+        float throughout or downstream arithmetic mixes the two and blows up."""
+        from app.services.db_service import _snapshot_row_to_categories
+        out = _snapshot_row_to_categories(self._row())
+
+        assert isinstance(out['FG%'], float)
+        assert isinstance(out['PTS'], float)
+
+    def test_extras_appear_alongside_the_fixed_categories(self):
+        from app.services.db_service import _snapshot_row_to_categories
+        out = _snapshot_row_to_categories(self._row(stats={'TO': 18.0, '3PA': 40.0}))
+
+        assert out['TO'] == 18.0
+        assert out['3PA'] == 40.0
+        assert out['PTS'] == 112.0
+
+    def test_tolerates_a_json_string_when_no_codec_is_registered(self):
+        from app.services.db_service import _snapshot_row_to_categories
+        out = _snapshot_row_to_categories(self._row(stats='{"TO": 18.0}'))
+
+        assert out['TO'] == 18.0
+
+
 @pytest.mark.asyncio
 async def test_upsert_omits_extras_column_when_migration_not_applied(db_service, monkeypatch):
     """Without add_dynamic_category_columns.sql the write must still succeed:

--- a/backend/tests/services/test_league_service.py
+++ b/backend/tests/services/test_league_service.py
@@ -274,6 +274,9 @@ class TestDynamicCategoriesLeagueSummary:
         service = LeagueService()
         service.data_provider = DataProvider()
         service.data_provider.db_service = AsyncMock()
+        # The cache is a singleton that outlives the DataProvider reset above,
+        # so a payload another test warmed would answer this league's settings.
+        service.data_provider.cache_manager.invalidate_cache()
 
         resp = MagicMock()
         resp.status_code = 200
@@ -336,6 +339,9 @@ class TestReverseScoredCategories:
         service = LeagueService()
         service.data_provider = DataProvider()
         service.data_provider.db_service = AsyncMock()
+        # The cache is a singleton that outlives the DataProvider reset above,
+        # so a payload another test warmed would answer this league's settings.
+        service.data_provider.cache_manager.invalidate_cache()
 
         resp = MagicMock()
         resp.status_code = 200
@@ -400,6 +406,9 @@ class TestDynamicCategoriesHeatmap:
         service = LeagueService()
         service.data_provider = DataProvider()
         service.data_provider.db_service = AsyncMock()
+        # The cache is a singleton that outlives the DataProvider reset above,
+        # so a payload another test warmed would answer this league's settings.
+        service.data_provider.cache_manager.invalidate_cache()
 
         resp = MagicMock()
         resp.status_code = 200
@@ -450,3 +459,91 @@ class TestDynamicCategoriesHeatmap:
             assert len(row) == len(heatmap.categories)
         for row in heatmap.ranks_data:
             assert len(row) == len(heatmap.categories)
+
+
+@pytest.mark.real_dataprovider
+class TestDynamicCategoriesRangeHeatmap:
+    """The date-range heatmap reads DB snapshots rather than ESPN totals, so it
+    is the one path where a category can exist in league settings but only in
+    the JSONB extras of a stored row."""
+
+    @staticmethod
+    def _snapshot(team_id, name, pts, to, gp):
+        return {
+            "team_id": team_id, "team_name": name,
+            "GP": float(gp), "FGM": 400.0, "FGA": 850.0, "FG%": 400 / 850,
+            "FTM": 100.0, "FTA": 125.0, "FT%": 0.8,
+            "3PM": 100.0, "REB": 400.0, "AST": 200.0, "STL": 50.0,
+            "BLK": 20.0, "PTS": float(pts), "TO": float(to),
+        }
+
+    @pytest_asyncio.fixture
+    async def real_league_service(self):
+        from app.services.data_provider import DataProvider
+        from datetime import date as _date
+
+        DataProvider._instance = None
+        DataProvider._initialized = False
+        service = LeagueService()
+        service.data_provider = DataProvider()
+        service.data_provider.db_service = AsyncMock()
+        # The cache is a singleton that outlives the DataProvider reset above,
+        # so a payload another test warmed would answer this league's settings.
+        service.data_provider.cache_manager.invalidate_cache()
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"ETag": "e1"}
+        resp.json.return_value = {
+            "scoringPeriodId": 5,
+            "teams": [{"id": 1, "name": "Alpha", "valuesByStat": {
+                "0": 1000, "1": 20, "2": 50, "3": 200, "6": 400,
+                "13": 400, "14": 850, "15": 150, "16": 200, "17": 100,
+                "19": 47.1, "20": 75.0, "42": 82, "40": 2000, "11": 120,
+            }}],
+            "settings": {"scoringSettings": {"scoringItems": [
+                {"statId": sid} for sid in (19, 20, 17, 3, 6, 2, 1, 0)
+            ] + [{"statId": 11, "isReverseItem": True}]}},
+        }
+        resp.raise_for_status = MagicMock()
+        service.data_provider._client.get = AsyncMock(return_value=resp)
+        service.data_provider.db_service.get_snapshots_for_date_range = AsyncMock(
+            return_value=(
+                _date(2026, 1, 31), _date(2026, 1, 1),
+                [self._snapshot(1, "Alpha", 1000, 120, 40),
+                 self._snapshot(2, "Beta", 900, 60, 40)],
+                [self._snapshot(1, "Alpha", 400, 60, 20),
+                 self._snapshot(2, "Beta", 300, 20, 20)],
+            )
+        )
+
+        yield service
+        DataProvider._instance = None
+        DataProvider._initialized = False
+
+    @pytest.mark.asyncio
+    async def test_range_heatmap_includes_turnovers_and_stays_aligned(self, real_league_service):
+        from datetime import date as _date
+        heatmap = await real_league_service.get_heatmap_data(
+            start_date=_date(2026, 1, 1), end_date=_date(2026, 1, 31)
+        )
+
+        assert 'TO' in heatmap.categories
+        for row in heatmap.data:
+            assert len(row) == len(heatmap.categories)
+        for row in heatmap.ranks_data:
+            assert len(row) == len(heatmap.categories)
+
+    @pytest.mark.asyncio
+    async def test_range_heatmap_colors_fewest_turnovers_as_best(self, real_league_service):
+        """Alpha commits 60 over the window, Beta 40, so Beta reads as the good
+        end of the TO scale -- the reverse-scoring the range path never applied."""
+        from datetime import date as _date
+        heatmap = await real_league_service.get_heatmap_data(
+            start_date=_date(2026, 1, 1), end_date=_date(2026, 1, 31)
+        )
+
+        to_index = heatmap.categories.index('TO')
+        order = [t.team_name for t in heatmap.teams]
+        assert (heatmap.normalized_data[order.index('Beta')][to_index]
+                > heatmap.normalized_data[order.index('Alpha')][to_index])

--- a/backend/tests/services/test_ranking_service.py
+++ b/backend/tests/services/test_ranking_service.py
@@ -290,6 +290,9 @@ class TestDynamicCategoriesEndToEnd:
         service = RankingService()
         service.data_provider = DataProvider()
         service.data_provider.db_service = AsyncMock()
+        # The cache is a singleton that outlives the DataProvider reset above,
+        # so a payload another test warmed would answer this league's settings.
+        service.data_provider.cache_manager.invalidate_cache()
 
         resp = MagicMock()
         resp.status_code = 200
@@ -352,6 +355,9 @@ class TestReverseScoredRankings:
         service = RankingService()
         service.data_provider = DataProvider()
         service.data_provider.db_service = AsyncMock()
+        # The cache is a singleton that outlives the DataProvider reset above,
+        # so a payload another test warmed would answer this league's settings.
+        service.data_provider.cache_manager.invalidate_cache()
 
         resp = MagicMock()
         resp.status_code = 200
@@ -380,3 +386,128 @@ class TestReverseScoredRankings:
         alpha = next(r for r in result.totals_rankings if r.team.team_name == 'Alpha')
         assert beta.category_ranks['TO'] == 2
         assert alpha.category_ranks['TO'] == 1
+
+
+@pytest.mark.real_dataprovider
+class TestDynamicCategoriesDateRange:
+    """Full pipeline for the DB-backed date-range path: real DataProvider,
+    DataTransformer and StatsCalculator, only the ESPN HTTP call and the
+    snapshot rows stubbed, for a turnovers-scoring league."""
+
+    @staticmethod
+    def _turnovers_league_payload():
+        return {
+            "scoringPeriodId": 5,
+            "teams": [
+                {"id": 1, "name": "Alpha", "valuesByStat": {
+                    "0": 1000, "1": 20, "2": 50, "3": 200, "6": 400,
+                    "13": 400, "14": 850, "15": 150, "16": 200, "17": 100,
+                    "19": 47.1, "20": 75.0, "42": 82, "40": 2000, "11": 120,
+                }},
+            ],
+            "settings": {"scoringSettings": {"scoringItems": [
+                {"statId": sid} for sid in (19, 20, 17, 3, 6, 2, 1, 0)
+            ] + [{"statId": 11, "isReverseItem": True}]}},
+        }
+
+    @staticmethod
+    def _snapshot(team_id, name, pts, to, gp, fgm, fga):
+        return {
+            "team_id": team_id, "team_name": name,
+            "GP": float(gp), "FGM": float(fgm), "FGA": float(fga),
+            "FG%": fgm / fga, "FTM": 100.0, "FTA": 125.0, "FT%": 0.8,
+            "3PM": 100.0, "REB": 400.0, "AST": 200.0, "STL": 50.0,
+            "BLK": 20.0, "PTS": float(pts), "TO": float(to),
+        }
+
+    @pytest_asyncio.fixture
+    async def real_ranking_service(self):
+        from app.services.data_provider import DataProvider
+
+        DataProvider._instance = None
+        DataProvider._initialized = False
+        service = RankingService()
+        service.data_provider = DataProvider()
+        service.data_provider.db_service = AsyncMock()
+        # The cache is a singleton that outlives the DataProvider reset above,
+        # so a payload another test warmed would answer this league's settings.
+        service.data_provider.cache_manager.invalidate_cache()
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"ETag": "e1"}
+        resp.json.return_value = self._turnovers_league_payload()
+        resp.raise_for_status = MagicMock()
+        service.data_provider._client.get = AsyncMock(return_value=resp)
+
+        yield service
+        DataProvider._instance = None
+        DataProvider._initialized = False
+
+    def _stub_range(self, service, rows_end, rows_start):
+        from datetime import date as _date
+        service.data_provider.db_service.get_snapshots_for_date_range = AsyncMock(
+            return_value=(_date(2026, 1, 31), _date(2026, 1, 1), rows_end, rows_start)
+        )
+
+    @pytest.mark.asyncio
+    async def test_range_rankings_include_turnovers(self, real_ranking_service):
+        from datetime import date as _date
+        self._stub_range(
+            real_ranking_service,
+            [self._snapshot(1, "Alpha", 1000, 120, 40, 400, 850),
+             self._snapshot(2, "Beta", 900, 60, 40, 380, 800)],
+            [self._snapshot(1, "Alpha", 400, 60, 20, 160, 340),
+             self._snapshot(2, "Beta", 300, 20, 20, 150, 320)],
+        )
+
+        result = await real_ranking_service.get_league_rankings(
+            start_date=_date(2026, 1, 1), end_date=_date(2026, 1, 31)
+        )
+
+        assert 'TO' in result.categories
+
+    @pytest.mark.asyncio
+    async def test_turnovers_are_differenced_and_reverse_ranked(self, real_ranking_service):
+        """Alpha commits 60 turnovers over the window and Beta 40, so Beta --
+        the lower raw value -- must score higher in TO, not lower."""
+        from datetime import date as _date
+        self._stub_range(
+            real_ranking_service,
+            [self._snapshot(1, "Alpha", 1000, 120, 40, 400, 850),
+             self._snapshot(2, "Beta", 900, 60, 40, 380, 800)],
+            [self._snapshot(1, "Alpha", 400, 60, 20, 160, 340),
+             self._snapshot(2, "Beta", 300, 20, 20, 150, 320)],
+        )
+
+        result = await real_ranking_service.get_league_rankings(
+            start_date=_date(2026, 1, 1), end_date=_date(2026, 1, 31)
+        )
+
+        to_rank = {row.team.team_name: row.category_ranks['TO']
+                   for row in result.averages_rankings}
+        assert to_rank['Beta'] > to_rank['Alpha']
+
+    @pytest.mark.asyncio
+    async def test_percentage_is_rebuilt_over_the_window_not_differenced(self, real_ranking_service):
+        """FG% over the window is (FGM end-start)/(FGA end-start), not the
+        difference of two cumulative percentages."""
+        from datetime import date as _date
+        rows_end = [self._snapshot(1, "Alpha", 1000, 120, 40, 400, 850),
+                    self._snapshot(2, "Beta", 900, 60, 40, 380, 800)]
+        rows_start = [self._snapshot(1, "Alpha", 400, 60, 20, 160, 340),
+                      self._snapshot(2, "Beta", 300, 20, 20, 150, 320)]
+        delta = real_ranking_service._compute_delta(
+            pd.DataFrame(rows_end), pd.DataFrame(rows_start)
+        )
+
+        alpha = delta.set_index('team_id').loc[1]
+        assert alpha['FG%'] == pytest.approx((400 - 160) / (850 - 340))
+        assert alpha['TO'] == 60.0
+
+    @pytest.mark.asyncio
+    async def test_missing_start_snapshot_treats_window_as_everything_so_far(self, real_ranking_service):
+        rows_end = [self._snapshot(1, "Alpha", 1000, 120, 40, 400, 850)]
+        delta = real_ranking_service._compute_delta(pd.DataFrame(rows_end), None)
+
+        assert delta.set_index('team_id').loc[1]['TO'] == 120.0

--- a/docs/dynamic-categories-db-migration-plan.md
+++ b/docs/dynamic-categories-db-migration-plan.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Not started. This is a plan document only — no code or schema changes yet.
+Steps 1–3 done for the non-estimator readers. Step 4 (backfill) is only needed
+once a category is actually added to the league; step 5 remains optional and
+probably not worth doing. The estimator is untouched — see out of scope below.
 Written after the "dynamic categories" PR stack (#203–#214), which made the
 **live-ESPN** path (current rankings, league summary, team detail, heatmap,
 player rankings) read the league's actual scoring categories instead of a
@@ -137,11 +139,17 @@ document-shaped app. This is not that.
    non-null and falling back to the fixed columns. The fallback means there is
    no ordering constraint between these, and no reader is ever broken by a row
    written before step 2:
-   - `get_latest_snapshot` (DB fallback when ESPN is down)
+   - `get_latest_snapshot` (DB fallback when ESPN is down) — **done**
    - `get_snapshots_for_date_range` (`_get_rankings_for_range`,
-     `_get_heatmap_for_range`)
-   - `get_rankings_over_time` (Standings Race)
+     `_get_heatmap_for_range`) — **done**
+   - `get_rankings_over_time` (Standings Race) — **done**
    - `fantsy_estimator/` (see below — larger, separate effort)
+
+   The two snapshot readers return rows keyed by category code rather than by
+   column name (`_snapshot_row_to_categories`), so nothing downstream of the DB
+   layer knows which categories happen to have a dedicated column. That is what
+   let the hardcoded `['gp','fgm',...]` lists in `ranking_service` and
+   `league_service` go away rather than grow a second branch.
    Each gets the same "real end-to-end test against a turnovers-scoring
    league" bar used throughout the #203–#214 stack.
 4. **Backfill.** Two independent cases:
@@ -202,6 +210,30 @@ changes once the DB layer hands them the shape it does today.
   width (~10 bytes for `0.469` vs a flat 8) and slower arithmetic — irrelevant
   here, since all math happens in pandas, not SQL. Noted so a later benchmark
   against the old wide table doesn't read as a regression.
+
+## Category coverage (added with step 3)
+
+`STAT_ID_TO_CATEGORY` now maps ESPN's full statId space rather than the subset
+this app had needed, so resolving a new category is data, not a code change.
+Mapping an id is only part of supporting it, so three further facts are declared
+alongside:
+
+- `NON_RANKING_STAT_KEYS` — raw quantities that only exist to build a derived
+  category (FGA, 3PA) or describe participation (GP, MIN).
+- `RATIO_CATEGORIES` — every category that is a quotient, with the pair it
+  divides. Percentages (FG%, 3P%), true ratios (A/TO, FTR, PPM) and the per-game
+  rates (PPG, RPG, ...) are all the same thing: values that must be rebuilt over
+  whatever window is being computed instead of summed, averaged by GP, or
+  differenced between cumulative snapshots. `_compute_delta` and
+  `calculate_per_game_averages` both read this rather than naming FG%/FT%.
+- `UNSUPPORTED_CATEGORIES` — AFG% (a weighted formula, not a quotient of two
+  stored quantities) and STR. Resolving one logs a warning, as does an unmapped
+  statId, so a category this app cannot compute is visible instead of silently
+  absent from rankings.
+
+`ESPN_COLUMN_MAP` is derived from the same id map instead of restating it, so a
+category cannot be resolvable from league settings but unparseable from the stat
+line carrying its value.
 
 ## What's explicitly out of scope here
 


### PR DESCRIPTION
Step 2 (and 3) of `docs/dynamic-categories-db-migration-plan.md`: migrate the remaining snapshot readers off the fixed 8 categories.

## What this fixes

`get_snapshots_for_date_range` and `get_latest_snapshot` selected one column per category, so the date-range rankings, the date-range heatmap, and the ESPN-down fallback were stuck on the historical 8 no matter what the league scores — while the live pages beside them resolved the real set.

Both now return rows keyed by **category code**, merging the JSONB extras with the fixed columns via `_snapshot_row_to_categories`. Nothing downstream of the DB layer knows which categories happen to have a dedicated column, which is what let the hardcoded `['gp','fgm',…,'pts']` lists in `ranking_service` and `league_service` go away rather than grow a second branch. The 15-line duplicated DataFrame build in `_get_heatmap_for_range` is gone; it mirrors the live path now.

## Two live bugs fixed on the way

1. **Reverse-scored categories ranked backwards on the date-range path.** Neither date-range builder passed `reverse_categories` — the same defect #210 fixed for the live path.
2. **Cold date-range requests ignored league settings entirely.** `get_ranking_categories` / `get_reverse_categories` only read a cache that `get_totals_df()` warms, and the date-range paths never call it. A cold `/rankings?start_date=…` resolved the fixed 8 and an empty reverse set regardless of what the league scores. They now warm the cache themselves and fall back to the defaults only when ESPN is genuinely unreachable.

## Category coverage is now data, not code

Answering "do we have a map of every ESPN category, so future support needs no change?" — we did not. Now:

- `STAT_ID_TO_CATEGORY` maps ESPN's full statId space (0–44), from espn-api's `constant.py`, the source this file already cited. Id 45 is a placeholder there and is deliberately absent.
- `RATIO_CATEGORIES` declares every quotient category with the pair it divides. Percentages (FG%, 3P%), true ratios (A/TO, FTR, PPM) **and the per-game rates** (PPG, RPG, …) are the same thing — values that must be rebuilt over the window rather than summed, divided by GP, or differenced between cumulative snapshots. `_compute_delta` and `calculate_per_game_averages` both read this instead of naming FG%/FT%.
- `NON_RANKING_STAT_KEYS` gains 3PA and the other raw feeders.
- `UNSUPPORTED_CATEGORIES` names the honest limit: `AFG%` is a weighted formula rather than a quotient of two stored quantities, and `STR` is not a stat. Resolving one logs a warning, as does an unmapped statId — a category this app cannot compute is now visible instead of silently missing from rankings.
- `ESPN_COLUMN_MAP` is derived from the id map rather than restating it, so a category cannot be resolvable from league settings but unparseable from the stat line carrying its value.
- `_transform_standings_dataframe` keeps a resolved ratio category's sources, or the date-range path could not rebuild it over the window.

## Testing

The date-range paths had **no** test coverage at all — which is how the earlier `sort_values`-on-a-tuple bug survived on dev. They now have end-to-end tests against a turnovers-scoring league (real DataProvider / DataTransformer / StatsCalculator, only the ESPN HTTP call and the snapshot rows stubbed), covering: TO reaching the response, TO reverse-ranked, FG% rebuilt over the window rather than differenced, a missing start snapshot, and the range heatmap staying column-aligned.

- `uv run pytest -q` — 637 passed, 14 deselected (was 626)
- `npx tsc --noEmit` — clean
- `npx vitest run` — 191 passed, 3 skipped

Note: `cache_manager` is a singleton that outlives the `DataProvider` reset in these fixtures, so a payload from another test class was answering this league's settings. The affected fixtures now call `invalidate_cache()`.

## Not in this PR

Standings Race still plots `rk_*` by name and reads nothing from the `ranks` payload the backend already returns — that's the follow-up, and it should land together with this one.

The estimator is untouched; it needs its own migration and the coupled `(n_teams, 8)` / `(n_teams, 10)` constants unpicked, per the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
