### PR TITLE
feat: Standings Race plots the league's actual categories

### DIFF
--- a/frontend/src/pages/StandingsRace.tsx
+++ b/frontend/src/pages/StandingsRace.tsx
@@ -16,6 +16,7 @@ import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import { getErrorMessage } from '../utils/errorMessage'
 import type { OverTimeSource, TeamTimeSeriesPoint } from '../types/api'
+import { TOTAL_METRIC, metricOptionsFor, rankValue } from './standingsRaceMetrics'
 
 const TEAM_COLORS = [
   '#2563eb', '#dc2626', '#16a34a', '#d97706', '#7c3aed',
@@ -30,19 +31,6 @@ type ViewMode = 'points' | 'rank'
 const SOURCES: { value: OverTimeSource; label: string }[] = [
   { value: 'rankings_totals', label: 'Rankings by Total' },
   { value: 'rankings_avg', label: 'Rankings by Avg' },
-]
-
-type MetricOption = { value: string; label: string }
-const METRICS: MetricOption[] = [
-  { value: 'rk_total', label: 'Total' },
-  { value: 'rk_pts', label: 'PTS' },
-  { value: 'rk_reb', label: 'REB' },
-  { value: 'rk_ast', label: 'AST' },
-  { value: 'rk_stl', label: 'STL' },
-  { value: 'rk_blk', label: 'BLK' },
-  { value: 'rk_three_pm', label: '3PM' },
-  { value: 'rk_fg_pct', label: 'FG%' },
-  { value: 'rk_ft_pct', label: 'FT%' },
 ]
 
 // Matches the app's Tailwind sans stack closely enough to measure label widths.
@@ -169,7 +157,7 @@ function EndLabels({
 const StandingsRace = () => {
   const [source, setSource] = useState<OverTimeSource>('rankings_totals')
   const [view, setView] = useState<ViewMode>('points')
-  const [metric, setMetric] = useState<string>('rk_total')
+  const [metric, setMetric] = useState<string>(TOTAL_METRIC)
   const [highlighted, setHighlighted] = useState<Set<number>>(new Set())
   const [brushEnd, setBrushEnd] = useState<number | null>(null)
 
@@ -199,6 +187,13 @@ const StandingsRace = () => {
 
   const teamIdByName = useMemo(() => new Map(teams.map(t => [t.team_name, t.team_id])), [teams])
 
+  const metricOptions = useMemo(() => metricOptionsFor(data?.data), [data])
+
+  // A selected category can vanish between payloads (source switch, a league
+  // that stops scoring it). Derived rather than corrected in an effect, so no
+  // render ever charts a metric the data doesn't carry.
+  const activeMetric = metricOptions.some(m => m.value === metric) ? metric : TOTAL_METRIC
+
   const gpByDateTeam = useMemo(() => {
     const m = new Map<string, number | undefined>()
     data?.data.forEach(p => m.set(`${p.date}|${p.team_id}`, p.gp))
@@ -211,8 +206,7 @@ const StandingsRace = () => {
     data.data.forEach((p: TeamTimeSeriesPoint) => {
       if (!byDate.has(p.date)) byDate.set(p.date, { date: p.date })
       const entry = byDate.get(p.date)!
-      const val = p[metric as keyof TeamTimeSeriesPoint]
-      entry[p.team_name] = val !== undefined && val !== null ? Number(val) : NaN
+      entry[p.team_name] = rankValue(p, activeMetric)
     })
     let rows = Array.from(byDate.values()).sort((a, b) => String(a.date).localeCompare(String(b.date)))
 
@@ -231,16 +225,16 @@ const StandingsRace = () => {
       })
     }
     return rows
-  }, [data, metric, view, teams])
+  }, [data, activeMetric, view, teams])
 
   const handleViewChange = (next: ViewMode) => {
     setView(next)
-    if (next === 'rank') setMetric('rk_total')
+    if (next === 'rank') setMetric(TOTAL_METRIC)
   }
 
   const handleMetricChange = (next: string) => {
     setMetric(next)
-    if (next !== 'rk_total' && view === 'rank') setView('points')
+    if (next !== TOTAL_METRIC && view === 'rank') setView('points')
   }
 
   const toggleHighlight = (teamId: number) => {
@@ -320,12 +314,12 @@ const StandingsRace = () => {
             </div>
 
             <select
-              value={metric}
+              value={activeMetric}
               onChange={e => handleMetricChange(e.target.value)}
               className="border border-gray-300 dark:border-gray-600 rounded-md px-3 py-1.5 text-xs text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 w-full sm:w-auto"
             >
-              {METRICS.map(m => (
-                <option key={m.value} value={m.value} disabled={view === 'rank' && m.value !== 'rk_total'}>
+              {metricOptions.map(m => (
+                <option key={m.value} value={m.value} disabled={view === 'rank' && m.value !== TOTAL_METRIC}>
                   {m.label}
                 </option>
               ))}

--- a/frontend/src/pages/__tests__/StandingsRace.test.tsx
+++ b/frontend/src/pages/__tests__/StandingsRace.test.tsx
@@ -1,0 +1,114 @@
+import { screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TeamTimeSeriesPoint } from '../../types/api';
+import { renderWithProviders } from '../../test/helpers';
+import StandingsRace from '../StandingsRace';
+import { rankValue } from '../standingsRaceMetrics';
+
+function point(overrides: Partial<TeamTimeSeriesPoint> = {}): TeamTimeSeriesPoint {
+  return {
+    date: '2026-01-31',
+    team_id: 1,
+    team_name: 'Alpha Squad',
+    rk_fg_pct: 2,
+    rk_ft_pct: 2,
+    rk_three_pm: 2,
+    rk_reb: 2,
+    rk_ast: 2,
+    rk_stl: 2,
+    rk_blk: 2,
+    rk_pts: 2,
+    rk_total: 16,
+    gp: 40,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return (input as Request).url;
+}
+
+function stubApi(points: TeamTimeSeriesPoint[]) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes('over-time') || url.includes('rankings')) {
+        return jsonResponse({ data: points });
+      }
+      return new Response('not found', { status: 404 });
+    }),
+  );
+}
+
+const metricNames = () =>
+  Array.from(screen.getByRole('combobox').querySelectorAll('option')).map(o => o.textContent);
+
+describe('StandingsRace metric options', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('offers the fixed categories when the league scores nothing extra', async () => {
+    stubApi([
+      point(),
+      point({ team_id: 2, team_name: 'Beta Ballers', rk_total: 12 }),
+    ]);
+    renderWithProviders(<StandingsRace />);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    const names = metricNames();
+    expect(names).toContain('PTS');
+    expect(names).toContain('FG%');
+    expect(names).not.toContain('TO');
+  });
+
+  it('offers a category that only exists in the ranks payload', async () => {
+    stubApi([
+      point({ ranks: { 'FG%': 2, 'FT%': 2, '3PM': 2, REB: 2, AST: 2, STL: 2, BLK: 2, PTS: 2, TO: 1 } }),
+      point({
+        team_id: 2,
+        team_name: 'Beta Ballers',
+        rk_total: 12,
+        ranks: { 'FG%': 1, 'FT%': 1, '3PM': 1, REB: 1, AST: 1, STL: 1, BLK: 1, PTS: 1, TO: 2 },
+      }),
+    ]);
+    renderWithProviders(<StandingsRace />);
+
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    await waitFor(() => expect(metricNames()).toContain('TO'));
+    // the familiar categories keep their order, the extra one is appended
+    expect(metricNames()).toEqual(['Total', 'PTS', 'REB', 'AST', 'STL', 'BLK', '3PM', 'FG%', 'FT%', 'TO']);
+  });
+});
+
+describe('rankValue', () => {
+  it('reads a category from ranks when it has no rk_* field', () => {
+    expect(rankValue(point({ ranks: { TO: 3 } }), 'TO')).toBe(3);
+  });
+
+  it('prefers ranks over the rk_* field for a category that has both', () => {
+    expect(rankValue(point({ rk_pts: 2, ranks: { PTS: 7 } }), 'PTS')).toBe(7);
+  });
+
+  it('falls back to the rk_* field when the payload carries no ranks', () => {
+    expect(rankValue(point({ rk_pts: 2 }), 'PTS')).toBe(2);
+  });
+
+  it('takes the total from rk_total, which the backend already overrode', () => {
+    expect(rankValue(point({ rk_total: 16, ranks: { TOTAL: 99 } }), 'rk_total')).toBe(16);
+  });
+
+  it('is NaN for a category the point does not carry', () => {
+    expect(rankValue(point({ rk_pts: undefined }), 'PTS')).toBeNaN();
+  });
+});

--- a/frontend/src/pages/standingsRaceMetrics.ts
+++ b/frontend/src/pages/standingsRaceMetrics.ts
@@ -1,0 +1,54 @@
+import type { TeamTimeSeriesPoint } from '../types/api'
+
+export type MetricOption = { value: string; label: string }
+
+export const TOTAL_METRIC = 'rk_total'
+
+// Categories that have a dedicated rk_* field, mirroring the backend's
+// _RANKINGS_COL_MAP. Anything the league scores beyond these arrives in `ranks`.
+const RK_FIELD_BY_CATEGORY: Record<string, keyof TeamTimeSeriesPoint> = {
+  PTS: 'rk_pts',
+  REB: 'rk_reb',
+  AST: 'rk_ast',
+  STL: 'rk_stl',
+  BLK: 'rk_blk',
+  '3PM': 'rk_three_pm',
+  'FG%': 'rk_fg_pct',
+  'FT%': 'rk_ft_pct',
+}
+
+const FIXED_CATEGORY_ORDER = ['PTS', 'REB', 'AST', 'STL', 'BLK', '3PM', 'FG%', 'FT%']
+
+// A category's rank comes from `ranks` when the league scores something without
+// a field of its own, and from the rk_* field otherwise. rk_total is never read
+// from `ranks`: the backend has already overridden it with the all-category
+// total when there is one, since rk_total alone means "total over the fixed
+// categories" and would under-count a league scoring more.
+export const rankValue = (point: TeamTimeSeriesPoint, metric: string): number => {
+  if (metric === TOTAL_METRIC) return point.rk_total ?? NaN
+  const fromRanks = point.ranks?.[metric]
+  if (fromRanks !== undefined && fromRanks !== null) return Number(fromRanks)
+  const field = RK_FIELD_BY_CATEGORY[metric]
+  const value = field ? point[field] : undefined
+  return value === undefined || value === null ? NaN : Number(value)
+}
+
+// The league's actual categories, not a fixed list: `ranks` carries every
+// category once the league scores anything without an rk_* field. Familiar
+// ordering first, then whatever else the payload adds.
+export const metricOptionsFor = (points: TeamTimeSeriesPoint[] | undefined): MetricOption[] => {
+  const fromRanks = new Set<string>()
+  points?.forEach(p => {
+    if (p.ranks) Object.keys(p.ranks).forEach(c => fromRanks.add(c))
+  })
+  const categories = fromRanks.size > 0
+    ? [
+        ...FIXED_CATEGORY_ORDER.filter(c => fromRanks.has(c)),
+        ...Array.from(fromRanks).filter(c => !FIXED_CATEGORY_ORDER.includes(c)),
+      ]
+    : FIXED_CATEGORY_ORDER
+  return [
+    { value: TOTAL_METRIC, label: 'Total' },
+    ...categories.map(c => ({ value: c, label: c })),
+  ]
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -238,6 +238,9 @@ export interface TeamTimeSeriesPoint {
   rk_blk?: number;
   rk_pts?: number;
   rk_total?: number;
+  /** Category -> rank, present only when the league scores categories with no
+   *  rk_* field of their own. Null for a fixed-category league. */
+  ranks?: Record<string, number> | null;
   gp?: number;
   fg_pct?: number;
   ft_pct?: number;


### PR DESCRIPTION
Step 3 of `docs/dynamic-categories-db-migration-plan.md`, and the other half of #216. Stacked on it — **merge #216 first**, then this retargets to `dev` automatically.

## What this fixes

The backend has returned a `ranks` mapping on every Standings Race point since #215, and nothing read it. The metric dropdown was a hardcoded list of nine `rk_*` field names, so a league scoring anything beyond the fixed eight had no way to chart it — the invisible-gap shape this whole review started from: correct data that nothing displays.

Metric options are now derived from the payload. The familiar categories keep their current order and anything extra is appended, so the dropdown a fixed-category league sees is unchanged.

## How a value is resolved

`rankValue` prefers `ranks[category]` and falls back to the `rk_*` field, which means a fixed-category league — where `ranks` is null on every row — behaves exactly as before.

`rk_total` stays the source for Total. The backend already overrides it with the all-category total when there is one (`_rankings_row_to_point`), so reading `TOTAL` out of `ranks` here would double-handle it.

The active metric is derived per render rather than corrected in a `useEffect`. Switching to a source that lacks the selected category falls back to Total without a cascading render, and no render ever charts a metric the data doesn't carry.

The helpers live in `standingsRaceMetrics.ts` rather than being exported from the page component, which keeps fast-refresh working and makes them directly testable.

## Testing

StandingsRace had no tests. Added 7:

- the dropdown offers only the fixed categories when `ranks` is absent, and offers `TO` when it isn't, in the expected order
- `ranks` wins over the `rk_*` field for a category carrying both
- the `rk_*` field is used when the payload has no `ranks`
- Total reads `rk_total`, not `ranks.TOTAL`
- a category the point doesn't carry is `NaN`, not `0` (which would plot as a real datapoint)

`npx vitest run` — 198 passed, 3 skipped (was 191). `npx tsc --noEmit` clean. `npm run lint` — my files clean; the 14 remaining problems are pre-existing on `dev`.

## Mobile

No layout change: the metric control is an existing `<select>` already `w-full sm:w-auto`, and this only changes how many `<option>`s it holds. Nothing else on the page moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
